### PR TITLE
Fix memoserv/sendall only sending the first word of the memo

### DIFF
--- a/modules/memoserv/sendall.c
+++ b/modules/memoserv/sendall.c
@@ -17,7 +17,7 @@ DECLARE_MODULE_V1
 static void ms_cmd_sendall(sourceinfo_t *si, int parc, char *parv[]);
 
 command_t ms_sendall = { "SENDALL", N_("Sends a memo to all accounts."),
-                         PRIV_ADMIN, 2, ms_cmd_sendall, { .path = "memoserv/sendall" } };
+                         PRIV_ADMIN, 1, ms_cmd_sendall, { .path = "memoserv/sendall" } };
 
 void _modinit(module_t *m)
 {


### PR DESCRIPTION
Fixed a bug where memoserv/sendall would only send the first word of the memo.  This bug was caused by copying one of the other MemoServ send modules, and not testing that the module actually worked.
