### PR TITLE
Update ChanServ flags help file for when successor_acl is loaded

### DIFF
--- a/help/default/cservice/flags
+++ b/help/default/cservice/flags
@@ -91,7 +91,11 @@ Permissions:
     +F - Grants full founder access.
     +b - Enables automatic kickban.
 
+#if module chanserv/successor_acl
+The special permission +* adds all permissions except +b, +S, and +F.
+#else
 The special permission +* adds all permissions except +b and +F.
+#endif
 The special permission -* removes all permissions including +b and +F.
 
 Examples:


### PR DESCRIPTION
This makes the "Special permission +_" line conditional on whether ChanServ/successor_acl is loaded, and when it is, mentions that +S is not added by +_.
