### PR TITLE
Actually send the new vhost

### DIFF
--- a/modules/nickserv/vhost.c
+++ b/modules/nickserv/vhost.c
@@ -43,7 +43,7 @@ static void do_sethost(user_t *u, const char *host)
 	if (!strcmp(u->vhost, host))
 		return;
 
-	user_sethost(nicksvs.me->me, u, u->vhost);
+	user_sethost(nicksvs.me->me, u, host);
 }
 
 static void do_sethost_all(myuser_t *mu, char *host)


### PR DESCRIPTION
This bug was introduced in 35cf1b, which assumed that u->vhost had
already been updated with a stringref-ed version of the new host.  As
user_sethost() in libathemecore does this for us, just pass through the
new host to it, after checking that it's different from the current
vhost.
