### PR TITLE
operserv/specs: Display one privilege per line (and show priv names)

### DIFF
--- a/modules/operserv/specs.c
+++ b/modules/operserv/specs.c
@@ -118,9 +118,8 @@ static void os_cmd_specs(sourceinfo_t *si, int parc, char *parv[])
 	operclass_t *cl = NULL;
 	const char *targettype = parv[0];
 	const char *target = parv[1];
-	char privbuf[BUFSIZE];
 	unsigned int i;
-	int j;
+	int j, n;
 
 	if (!has_any_privs(si))
 	{
@@ -185,20 +184,19 @@ static void os_cmd_specs(sourceinfo_t *si, int parc, char *parv[])
 	{
 		struct priv_category *cat = priv_categories[i];
 
-		*privbuf = '\0';
+		command_success_nodata(si, "\2%s\2:", _(cat->name));
 
-		for (j = 0; cat->privs[j].priv != NULL; j++)
+		for (j = n = 0; cat->privs[j].priv != NULL; j++)
 		{
 			if (targettype == NULL ? has_priv(si, cat->privs[j].priv) : (tu ? has_priv_user(tu, cat->privs[j].priv) : has_priv_operclass(cl, cat->privs[j].priv)))
 			{
-				if (*privbuf)
-					mowgli_strlcat(privbuf, ", ", sizeof privbuf);
-				mowgli_strlcat(privbuf, _(cat->privs[j].desc), sizeof privbuf);
+				command_success_nodata(si, "    %s (%s)", cat->privs[j].priv, _(cat->privs[j].desc));
+				++n;
 			}
 		}
 
-		if (*privbuf)
-			command_success_nodata(si, "\2%s\2: %s", _(cat->name), privbuf);
+		if (!n)
+			command_success_nodata(si, "    %s", _("(no privileges held)"));
 	}
 
 	command_success_nodata(si, _("End of privileges"));


### PR DESCRIPTION
Example output:

<pre>
&lt;grawity&gt; specs
-OperServ- Privileges for grawity:
-OperServ- Nicknames/Accounts:
-OperServ-     user:auspex (view concealed information about accounts)
-OperServ-     user:admin (drop accounts, freeze accounts, reset passwords)
-OperServ-     user:sendpass (send passwords)
-OperServ-     user:vhost (set vhosts)
-OperServ-     user:mark (mark accounts)
-OperServ-     user:hold (hold accounts)
-OperServ- Channels:
-OperServ-     chan:auspex (view concealed information about channels)
-OperServ-     chan:admin (drop channels, close channels, transfer ownership)
-OperServ-     chan:cmodes (mlock operator modes)
-OperServ-     chan:joinstaffonly (join staff channels)
-OperServ-     user:mark (mark accounts)
-OperServ-     user:hold (hold accounts)
-OperServ-     user:regnolimit (bypass channel registration limits)
-OperServ- General:
-OperServ-     general:auspex (view concealed information about servers)
-OperServ-     general:viewprivs (view privileges of other users)
-OperServ-     general:flood (exempt from flood control)
-OperServ-     general:admin (administer services)
-OperServ-     general:metadata (edit private and internal metadata)
-OperServ- OperServ:
-OperServ-     operserv:omode (set channel modes)
-OperServ-     operserv:akill (add and remove autokills)
-OperServ-     operserv:jupe (jupe servers)
-OperServ-     operserv:noop (NOOP access)
-OperServ-     operserv:global (send global notices)
-OperServ-     operserv:grant (edit oper privileges)
-OperServ- GroupServ:
-OperServ-     group:auspex (view concealed information about groups)
-OperServ-     group:admin (administer groups)
-OperServ-     user:regnolimit (bypass group registration limits)
-OperServ- End of privileges
</pre>


Any comments would be welcome.
