### PR TITLE
memoserv/delete: Only accept numeric indexes.

### DIFF
--- a/modules/memoserv/delete.c
+++ b/modules/memoserv/delete.c
@@ -41,6 +41,7 @@ static void ms_cmd_delete(sourceinfo_t *si, int parc, char *parv[])
 	unsigned int i = 0, delcount = 0, memonum = 0;
 	unsigned int deleteall = 0, deleteold = 0;
 	mymemo_t *memo;
+	char *errptr = NULL;
 	
 	/* We only take 1 arg, and we ignore all others */
 	char *arg1 = parv[0];
@@ -73,10 +74,10 @@ static void ms_cmd_delete(sourceinfo_t *si, int parc, char *parv[])
 	}
 	else
 	{
-		memonum = atoi(arg1);
+		memonum = strtoul(arg1, &errptr, 10);
 		
 		/* Make sure they didn't slip us an alphabetic index */
-		if (!memonum)
+		if (!memonum || (errptr && *errptr))
 		{
 			command_fail(si, fault_badparams, _("Invalid message index."));
 			return;


### PR DESCRIPTION
As reported by Chiyo on IRC.

> &lt;Chiyo&gt; i was trying to delete memo 10, but mistyped "1o" and it deleted memo 1.

---

Let's hope I didn't forget basic pointer usage yet.
