### PR TITLE
Add a few checks to groupserv/flags. Restrict +f from +Fing themselves. ...

### DIFF
--- a/modules/groupserv/flags.c
+++ b/modules/groupserv/flags.c
@@ -195,6 +195,24 @@ static void gs_cmd_flags(sourceinfo_t *si, int parc, char *parv[])
 		c++;
 	}
 
+	if (flags & GA_FOUNDER)
+		flags |= GA_FLAGS;
+
+	if (!(flags & GA_FOUNDER) && groupacs_find(mg, mu, GA_FOUNDER))
+	{
+		if (mygroup_count_flag(mg, GA_FOUNDER) == 1 )
+		{
+			command_fail(si, fault_noprivs, _("You may not remove the last founder."));
+			return;
+		}
+
+		if (!groupacs_sourceinfo_has_flag(mg, si, GA_FOUNDER))
+		{
+			command_fail(si, fault_noprivs, _("You may not remove a founder's +F access."));
+			return;
+		}
+	}
+
 	if (ga != NULL && flags != 0)
 		ga->flags = flags;
 	else if (ga != NULL)


### PR DESCRIPTION
...Prevent +f-F from removing founders. Prevent removing the last founder of a group. Make sure +Fs always have +f.
