### PR TITLE
Rename faultcode_t, since it conflits on Solaris

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -130,7 +130,7 @@ enum faultcode_
 	fault_badauthcookie	= 15
 };
 
-typedef enum faultcode_ faultcode_t;
+typedef enum faultcode_ cmd_faultcode_t;
 
 #if defined(__GNUC__) || defined(__INTEL_COMPILER)
 #define PRINTFLIKE(fmtarg, firstvararg) \

--- a/include/services.h
+++ b/include/services.h
@@ -112,7 +112,7 @@ E void change_notify(const char *from, user_t *to, const char *message, ...) PRI
 E bool bad_password(sourceinfo_t *si, myuser_t *mu);
 
 E sourceinfo_t *sourceinfo_create(void);
-E void command_fail(sourceinfo_t *si, faultcode_t code, const char *fmt, ...) PRINTFLIKE(3, 4);
+E void command_fail(sourceinfo_t *si, cmd_faultcode_t code, const char *fmt, ...) PRINTFLIKE(3, 4);
 E void command_success_nodata(sourceinfo_t *si, const char *fmt, ...) PRINTFLIKE(2, 3);
 E void command_success_string(sourceinfo_t *si, const char *result, const char *fmt, ...) PRINTFLIKE(3, 4);
 E void command_success_table(sourceinfo_t *si, table_t *table);

--- a/include/sourceinfo.h
+++ b/include/sourceinfo.h
@@ -12,7 +12,7 @@
 struct sourceinfo_vtable
 {
 	const char *description;
-	void (*cmd_fail)(sourceinfo_t *si, faultcode_t code, const char *message);
+	void (*cmd_fail)(sourceinfo_t *si, cmd_faultcode_t code, const char *message);
 	void (*cmd_success_nodata)(sourceinfo_t *si, const char *message);
 	void (*cmd_success_string)(sourceinfo_t *si, const char *result, const char *message);
 	const char *(*get_source_name)(sourceinfo_t *si);

--- a/libathemecore/services.c
+++ b/libathemecore/services.c
@@ -830,7 +830,7 @@ sourceinfo_t *sourceinfo_create(void)
 	return out;
 }
 
-void command_fail(sourceinfo_t *si, faultcode_t code, const char *fmt, ...)
+void command_fail(sourceinfo_t *si, cmd_faultcode_t code, const char *fmt, ...)
 {
 	va_list args;
 	char buf[BUFSIZE];

--- a/modules/operserv/override.c
+++ b/modules/operserv/override.c
@@ -34,7 +34,7 @@ typedef struct {
 	sourceinfo_t *parent_si;
 } cooked_sourceinfo_t;
 
-static void override_command_fail(sourceinfo_t *si, faultcode_t code, const char *message)
+static void override_command_fail(sourceinfo_t *si, cmd_faultcode_t code, const char *message)
 {
 	cooked_sourceinfo_t *csi = (cooked_sourceinfo_t *) si;
 

--- a/modules/transport/xmlrpc/main.c
+++ b/modules/transport/xmlrpc/main.c
@@ -32,7 +32,7 @@ connection_t *current_cptr; /* XXX: Hack: src/xmlrpc.c requires us to do this */
 
 mowgli_list_t *httpd_path_handlers;
 
-static void xmlrpc_command_fail(sourceinfo_t *si, faultcode_t code, const char *message);
+static void xmlrpc_command_fail(sourceinfo_t *si, cmd_faultcode_t code, const char *message);
 static void xmlrpc_command_success_nodata(sourceinfo_t *si, const char *message);
 static void xmlrpc_command_success_string(sourceinfo_t *si, const char *result, const char *message);
 
@@ -147,7 +147,7 @@ void _moddeinit(module_unload_intent_t intent)
 	hook_del_config_ready(xmlrpc_config_ready);
 }
 
-static void xmlrpc_command_fail(sourceinfo_t *si, faultcode_t code, const char *message)
+static void xmlrpc_command_fail(sourceinfo_t *si, cmd_faultcode_t code, const char *message)
 {
 	connection_t *cptr;
 	struct httpddata *hd;


### PR DESCRIPTION
Solaris defines a faultcode_t type already, which causes some
compilation issues on Solaris.
