### PR TITLE
Moved hs_sethost_all()

### DIFF
--- a/modules/hostserv/group.c
+++ b/modules/hostserv/group.c
@@ -30,24 +30,6 @@ void _moddeinit(module_unload_intent_t intent)
 	service_named_unbind_command("hostserv", &hs_group);
 }
 
-static void hs_sethost_all(myuser_t *mu, const char *host)
-{
-	mowgli_node_t *n;
-	mynick_t *mn;
-	char buf[BUFSIZE];
-
-	MOWGLI_ITER_FOREACH(n, mu->nicks.head)
-	{
-		mn = n->data;
-		snprintf(buf, BUFSIZE, "%s:%s", "private:usercloak", mn->nick);
-		metadata_delete(mu, buf);
-	}
-	if (host != NULL)
-		metadata_add(mu, "private:usercloak", host);
-	else
-		metadata_delete(mu, "private:usercloak");
-}
-
 static void hs_cmd_group(sourceinfo_t *si, int parc, char *parv[])
 {
 	mynick_t *mn;

--- a/modules/hostserv/hostserv.h
+++ b/modules/hostserv/hostserv.h
@@ -63,4 +63,22 @@ static inline void do_sethost_all(myuser_t *mu, const char *host)
                 do_sethost(u, host);
         }
 }
+
+static inline void hs_sethost_all(myuser_t *mu, const char *host)
+{
+	mowgli_node_t *n;
+	mynick_t *mn;
+	char buf[BUFSIZE];
+
+	MOWGLI_ITER_FOREACH(n, mu->nicks.head)
+	{
+		mn = n->data;
+		snprintf(buf, BUFSIZE, "%s:%s", "private:usercloak", mn->nick);
+		metadata_delete(mu, buf);
+	}
+	if (host != NULL)
+		metadata_add(mu, "private:usercloak", host);
+	else
+		metadata_delete(mu, "private:usercloak");
+}
 #endif

--- a/modules/hostserv/offer.c
+++ b/modules/hostserv/offer.c
@@ -70,24 +70,6 @@ void _moddeinit(module_unload_intent_t intent)
 	service_named_unbind_command("hostserv", &hs_take);
 }
 
-static void hs_sethost_all(myuser_t *mu, const char *host)
-{
-	mowgli_node_t *n;
-	mynick_t *mn;
-	char buf[BUFSIZE];
-
-	MOWGLI_ITER_FOREACH(n, mu->nicks.head)
-	{
-		mn = n->data;
-		snprintf(buf, BUFSIZE, "%s:%s", "private:usercloak", mn->nick);
-		metadata_delete(mu, buf);
-	}
-	if (host != NULL)
-		metadata_add(mu, "private:usercloak", host);
-	else
-		metadata_delete(mu, "private:usercloak");
-}
-
 static void write_hsofferdb(database_handle_t *db)
 {
 	mowgli_node_t *n;

--- a/modules/hostserv/vhost.c
+++ b/modules/hostserv/vhost.c
@@ -34,24 +34,6 @@ void _moddeinit(module_unload_intent_t intent)
 	service_named_unbind_command("hostserv", &hs_listvhost);
 }
 
-static void hs_sethost_all(myuser_t *mu, const char *host)
-{
-	mowgli_node_t *n;
-	mynick_t *mn;
-	char buf[BUFSIZE];
-
-	MOWGLI_ITER_FOREACH(n, mu->nicks.head)
-	{
-		mn = n->data;
-		snprintf(buf, BUFSIZE, "%s:%s", "private:usercloak", mn->nick);
-		metadata_delete(mu, buf);
-	}
-	if (host != NULL)
-		metadata_add(mu, "private:usercloak", host);
-	else
-		metadata_delete(mu, "private:usercloak");
-}
-
 /* VHOST <nick> [host] */
 static void hs_cmd_vhost(sourceinfo_t *si, int parc, char *parv[])
 {


### PR DESCRIPTION
hs_sethost_all() was defined in three different files, and used in each with no modification what-so-ever.
Moved to a header already included by all three files.
