### PR TITLE
Update help

### DIFF
--- a/help/default/help
+++ b/help/default/help
@@ -4,7 +4,3 @@ HELP displays help information on all
 commands in services.
 
 Syntax: HELP <command> [parameters]
-
-Examples:
-    /msg &nick& HELP REGISTER
-    /msg &nick& HELP SET PASSWORD


### PR DESCRIPTION
No need to display examples and to confuse users who type /msg memoserv help help or services which don't have register or set password
