### PR TITLE
Removed ability for ircops on an inspircd network to be completely immune from kicks from services

### DIFF
--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -63,7 +63,6 @@ struct cmode_ inspircd_mode_list[] = {
   { 'T', CMODE_NONOTICE },
   { 'u', CMODE_HIDING   },
   { 'Q', CMODE_PEACE    },
-  { 'Y', CMODE_IMMUNE	},
   { 'D', CMODE_DELAYJOIN },
   { '\0', 0 }
 };


### PR DESCRIPTION
As a general rule of thumb it is bad form for any oper anywhere to be immune to a channel operator deciding that the oper should not be a part of the channel the oper is joined to, use of an OJOIN command or not.
