### PR TITLE
patch for unreal's umode +r when using esvid

### DIFF
--- a/modules/protocol/unreal.c
+++ b/modules/protocol/unreal.c
@@ -604,7 +604,10 @@ static void unreal_on_login(user_t *u, myuser_t *account, const char *wantedhost
 		return;
 	}
 
-	sts(":%s SVS2MODE %s +rd %s", nicksvs.nick, u->nick, entity(account)->name);
+	if (should_reg_umode(u))
+		sts(":%s SVS2MODE %s +rd %s", nicksvs.nick, u->nick, entity(account)->name);
+	else
+		sts(":%s SVS2MODE %s +d %s", nicksvs.nick, u->nick, entity(account)->name);
 }
 
 /* protocol-specific stuff to do on logout */
@@ -1175,6 +1178,13 @@ static void m_nick(sourceinfo_t *si, int parc, char *parv[])
 			else
 				/* changed from registered nick, remove +r */
 				sts(":%s SVS2MODE %s -r+d 0", nicksvs.nick, parv[0]);
+		}
+		else if (realchange && !nicksvs.no_nick_ownership && use_esvid)
+		{
+			if (should_reg_umode(si->su))
+				sts(":%s SVS2MODE %s +r", nicksvs.nick, parv[0]);
+			else
+				sts(":%s SVS2MODE %s -r", nicksvs.nick, parv[0]);
 		}
 
 		handle_nickchange(si->su);


### PR DESCRIPTION
I've noticed strange behaviour of Atheme login and nick change handling when using UnrealIRCd 3.2 with ESVID support.

Based on nenolod's comment from unreal's bugtracker (http://bugs.unrealircd.org/view.php?id=4083)

> The baseline recommendation for legacy IRCd software which has had a registered usermode is to continue to support the registered usermode and send +r/-r when the account is authenticated _and_ on an owned nick.
> If the account is authenticated, but the nickname is not owned by that account, then only the accountname should be sent in WHOIS. This is the current behaviour of Atheme -- I do not know what Anope's behaviour is.

But it is not the current behaviour.

Whenever I identify myself from an unregistered nick (eg. as Guest213123 /ns identify myuser pass) I get +r. Moreover, whenever I change my nickname (to registered) I do not receive +r back. In both of those cases the actual atheme's behaviour differs from my expectations.

I don't know if I'm correct, so please review the patch I've attached.

Best regards!
