### PR TITLE
unreal - services are logged in as *

### DIFF
--- a/modules/protocol/unreal.c
+++ b/modules/protocol/unreal.c
@@ -340,7 +340,7 @@ static void unreal_introduce_nick(user_t *u)
 	const char *umode = user_get_umodestr(u);
 
 	if (!ircd->uses_uid)
-		sts("NICK %s 1 %lu %s %s %s * %sS * :%s", u->nick, (unsigned long)u->ts, u->user, u->host, me.name, umode, u->gecos);
+		sts("NICK %s 1 %lu %s %s %s 0 %sS * :%s", u->nick, (unsigned long)u->ts, u->user, u->host, me.name, umode, u->gecos);
 	else
 		sts(":%s UID %s 1 %lu %s %s %s * %sS * * * :%s", ME, u->nick, (unsigned long)u->ts, u->user, u->host, u->uid, umode, u->gecos);
 }


### PR DESCRIPTION
Hi

On UnrealIRCd 3.2 (without UID) all nicks introduced by atheme are logged in as *:

```
/whois ChanServ
* [ChanServ] (ChanServ@xxxx): Channel Services
* [ChanServ] is using modes +ioS 
(...)
* [ChanServ] is a Network Service
* [ChanServ] is logged in as *
```

Based on syzop's comment on unreal's [bugtracker](http://bugs.unrealircd.org/view.php?id=3966#c16841): 

> I was informed by an anope dev that it did break some of their versions. I've therefore just committed a change that makes the servicestamp default to '0' again (instead of '*'), just like it always was.

I've made a (very small) patch which fixes this, I believe, bug. Please review the code, because I don't have Unreal 3.4 (maybe it requires the change from \* to 0 too). 

Keep up the good work!
