### PR TITLE
libathemecore, *serv: unify all three copies of create_challenge()

### DIFF
--- a/include/tools.h
+++ b/include/tools.h
@@ -116,6 +116,7 @@ typedef struct {
 
 /* misc string stuff */
 E char *random_string(int sz);
+E void create_challenge(sourceinfo_t *si, const char *name, int v, char *dest);
 E void tb2sp(char *line);
 E char *replace(char *s, int size, const char *old, const char *new);
 E const char *number_to_string(int num);

--- a/libathemecore/function.c
+++ b/libathemecore/function.c
@@ -43,6 +43,25 @@ char *random_string(int sz)
 	return buf;
 }
 
+void create_challenge(sourceinfo_t *si, const char *name, int v, char *dest)
+{
+	char buf[256];
+	int digest[4];
+	md5_state_t ctx;
+
+	snprintf(buf, sizeof buf, "%lu:%s:%s",
+			(unsigned long)(CURRTIME / 300) - v,
+			get_source_name(si),
+			name);
+	md5_init(&ctx);
+	md5_append(&ctx, (unsigned char *)buf, strlen(buf));
+	md5_finish(&ctx, (unsigned char *)digest);
+	/* note: this depends on byte order, but that's ok because
+	 * it's only going to work in the same atheme instance anyway
+	 */
+	snprintf(dest, 80, "%x:%x", digest[0], digest[1]);
+}
+
 #ifdef HAVE_GETTIMEOFDAY
 /* starts a timer */
 void s_time(struct timeval *sttime)

--- a/modules/chanserv/drop.c
+++ b/modules/chanserv/drop.c
@@ -35,25 +35,6 @@ void _moddeinit(module_unload_intent_t intent)
 	service_named_unbind_command("chanserv", &cs_fdrop);
 }
 
-static void create_challenge(sourceinfo_t *si, const char *name, int v, char *dest)
-{
-	char buf[256];
-	int digest[4];
-	md5_state_t ctx;
-
-	snprintf(buf, sizeof buf, "%lu:%s:%s",
-			(unsigned long)(CURRTIME / 300) - v,
-			get_source_name(si),
-			name);
-	md5_init(&ctx);
-	md5_append(&ctx, (unsigned char *)buf, strlen(buf));
-	md5_finish(&ctx, (unsigned char *)digest);
-	/* note: this depends on byte order, but that's ok because
-	 * it's only going to work in the same atheme instance anyway
-	 */
-	snprintf(dest, 80, "%x:%x", digest[0], digest[1]);
-}
-
 static void cs_cmd_drop(sourceinfo_t *si, int parc, char *parv[])
 {
 	mychan_t *mc;

--- a/modules/groupserv/drop.c
+++ b/modules/groupserv/drop.c
@@ -20,26 +20,6 @@ static void gs_cmd_drop(sourceinfo_t *si, int parc, char *parv[]);
 
 command_t gs_drop = { "DROP", N_("Drops a group registration."), AC_AUTHENTICATED, 2, gs_cmd_drop, { .path = "groupserv/drop" } };
 
-/* I don't like this here, but it works --jdhore */
-static void create_challenge(sourceinfo_t *si, const char *name, int v, char *dest)
-{
-	char buf[256];
-	int digest[4];
-	md5_state_t ctx;
-
-	snprintf(buf, sizeof buf, "%lu:%s:%s",
-			(unsigned long)(CURRTIME / 300) - v,
-			get_source_name(si),
-			name);
-	md5_init(&ctx);
-	md5_append(&ctx, (unsigned char *)buf, strlen(buf));
-	md5_finish(&ctx, (unsigned char *)digest);
-	/* note: this depends on byte order, but that's ok because
-	 * it's only going to work in the same atheme instance anyway
-	 */
-	snprintf(dest, 80, "%x:%x", digest[0], digest[1]);
-}
-
 static void gs_cmd_drop(sourceinfo_t *si, int parc, char *parv[])
 {
 	mygroup_t *mg;

--- a/modules/nickserv/drop.c
+++ b/modules/nickserv/drop.c
@@ -33,25 +33,6 @@ void _moddeinit(module_unload_intent_t intent)
 	service_named_unbind_command("nickserv", &ns_fdrop);
 }
 
-static void create_challenge(sourceinfo_t *si, const char *name, int v, char *dest)
-{
-	char buf[256];
-	int digest[4];
-	md5_state_t ctx;
-
-	snprintf(buf, sizeof buf, "%lu:%s:%s",
-			(unsigned long)(CURRTIME / 300) - v,
-			get_source_name(si),
-			name);
-	md5_init(&ctx);
-	md5_append(&ctx, (unsigned char *)buf, strlen(buf));
-	md5_finish(&ctx, (unsigned char *)digest);
-	/* note: this depends on byte order, but that's ok because
-	 * it's only going to work in the same atheme instance anyway
-	 */
-	snprintf(dest, 80, "%x:%x", digest[0], digest[1]);
-}
-
 static void ns_cmd_drop(sourceinfo_t *si, int parc, char *parv[])
 {
 	myuser_t *mu;


### PR DESCRIPTION
All three services now use copies of the same function for DROP confirmation, so it was moved to libathemecore.

I should've probably done this along with the NickServ DROP patch… oh well.
