### PR TITLE
Fixed confusion between +F and +f with inspircd

### DIFF
--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -223,13 +223,12 @@ static inline void channel_metadata_sts(channel_t *c, const char *key, const cha
 
 static bool check_flood(const char *value, channel_t *c, mychan_t *mc, user_t *u, myuser_t *mu)
 {
-	/* +F doesn't support *, so don't bother checking for it -- w00t */
-	return check_jointhrottle(value, c, mc, u, mu);
+	return check_jointhrottle((*value == '*' ? value + 1 : value), c, mc, u, mu);
 }
 
 static bool check_nickflood(const char *value, channel_t *c, mychan_t *mc, user_t *u, myuser_t *mu)
 {
-	return *value == '*' ? check_jointhrottle(value + 1, c, mc, u, mu) : check_jointhrottle(value, c, mc, u, mu);
+	return check_jointhrottle(value, c, mc, u, mu);
 }
 
 static bool check_jointhrottle(const char *value, channel_t *c, mychan_t *mc, user_t *u, myuser_t *mu)


### PR DESCRIPTION
+F can not take a \* as first letter, +f can, so these were basically switched

```
[08:26] <ASHER> Hello i need please help about MLOCK i try set some modes in inspircd version 2.0.5 and i cant why?
[08:27] <ASHER> when i try set commands to chanserv like this
[08:27] <ASHER> ./msg ChanServ SET #network MLOCK +f *10:10
[08:27] <ASHER> and i get this ChanServ- Invalid value *10:10 for mode +f
```
