### PR TITLE
HOP Generally has kick privs, so we should add them to the default temp...

### DIFF
--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -1173,7 +1173,7 @@ chanserv {
 	 */
 	templates {
 		vop = "+AV";
-		hop = "+AHhtv";
+		hop = "+AHhrtv";
 		aop = "+AOhiortv";
 		sop = "+AOafhiorstv";
 


### PR DESCRIPTION
...late
