### PR TITLE
Pass the entire myuser_t* to svslogin_sts()

### DIFF
--- a/include/phandler.h
+++ b/include/phandler.h
@@ -213,7 +213,7 @@ E void (*fnc_sts)(user_t *source, user_t *u, const char *newnick, int type);
 E void (*holdnick_sts)(user_t *source, int duration, const char *nick, myuser_t *account);
 /* change nick, user, host and/or services login name for a user
  * target may also be a not yet fully introduced UID (for SASL) */
-E void (*svslogin_sts)(char *target, char *nick, char *user, char *host, stringref login);
+E void (*svslogin_sts)(char *target, char *nick, char *user, char *host, myuser_t *account);
 /* send sasl message */
 E void (*sasl_sts) (char *target, char mode, char *data);
 /* find next channel ban (or other ban-like mode) matching user */
@@ -268,7 +268,7 @@ E void generic_jupe(const char *server, const char *reason);
 E void generic_sethost_sts(user_t *source, user_t *target, const char *host);
 E void generic_fnc_sts(user_t *source, user_t *u, const char *newnick, int type);
 E void generic_holdnick_sts(user_t *source, int duration, const char *nick, myuser_t *account);
-E void generic_svslogin_sts(char *target, char *nick, char *user, char *host, stringref login);
+E void generic_svslogin_sts(char *target, char *nick, char *user, char *host, myuser_t *account);
 E void generic_sasl_sts(char *target, char mode, char *data);
 E mowgli_node_t *generic_next_matching_ban(channel_t *c, user_t *u, int type, mowgli_node_t *first);
 E mowgli_node_t *generic_next_matching_host_chanacs(mychan_t *mc, user_t *u, mowgli_node_t *first);

--- a/libathemecore/phandler.c
+++ b/libathemecore/phandler.c
@@ -56,7 +56,7 @@ void (*sethost_sts) (user_t *source, user_t *target, const char *host) = generic
 void (*fnc_sts) (user_t *source, user_t *u, const char *newnick, int type) = generic_fnc_sts;
 void (*holdnick_sts)(user_t *source, int duration, const char *nick, myuser_t *account) = generic_holdnick_sts;
 void (*invite_sts) (user_t *source, user_t *target, channel_t *channel) = generic_invite_sts;
-void (*svslogin_sts) (char *target, char *nick, char *user, char *host, stringref login) = generic_svslogin_sts;
+void (*svslogin_sts) (char *target, char *nick, char *user, char *host, myuser_t *account) = generic_svslogin_sts;
 void (*sasl_sts) (char *target, char mode, char *data) = generic_sasl_sts;
 mowgli_node_t *(*next_matching_ban)(channel_t *c, user_t *u, int type, mowgli_node_t *first) = generic_next_matching_ban;
 mowgli_node_t *(*next_matching_host_chanacs)(mychan_t *mc, user_t *u, mowgli_node_t *first) = generic_next_matching_host_chanacs;
@@ -261,7 +261,7 @@ void generic_invite_sts(user_t *source, user_t *target, channel_t *channel)
 	/* nothing to do here. */	
 }
 
-void generic_svslogin_sts(char *target, char *nick, char *user, char *host, stringref login)
+void generic_svslogin_sts(char *target, char *nick, char *user, char *host, myuser_t *account)
 {
 	/* nothing to do here. */
 }

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -686,14 +686,14 @@ static void inspircd_holdnick_sts(user_t *source, int duration, const char *nick
 	}
 }
 
-static void inspircd_svslogin_sts(char *target, char *nick, char *user, char *host, stringref login)
+static void inspircd_svslogin_sts(char *target, char *nick, char *user, char *host, myuser_t *account)
 {
 	user_t *tu = user_find(target);
 
 	if(!tu && !ircd->uses_uid)
 		return;
 
-	sts(":%s METADATA %s accountname :%s", me.numeric, target, login);
+	sts(":%s METADATA %s accountname :%s", me.numeric, target, entity(account)->name);
 	if (has_chghostmod)
 		sts(":%s CHGHOST %s %s", me.numeric, target, host);
 }

--- a/modules/protocol/nefarious.c
+++ b/modules/protocol/nefarious.c
@@ -186,14 +186,10 @@ static void nefarious_sasl_sts(char *target, char mode, char *data)
 	sts("%s SASL %c%c %s %c %s", me.numeric, target[0], target[1], target, mode, data);
 }
 
-static void nefarious_svslogin_sts(char *target, char *nick, char *user, char *host, stringref login)
+static void nefarious_svslogin_sts(char *target, char *nick, char *user, char *host, myuser_t *account)
 {
-	myuser_t *mu = myuser_find(login);
-
-	return_if_fail(mu != NULL);
-
-	sts("%s SASL %c%c %s L %s %lu", me.numeric, target[0], target[1], target, login,
-			(unsigned long)mu->registered);
+	sts("%s SASL %c%c %s L %s %lu", me.numeric, target[0], target[1], target,
+			entity(account)->name, (unsigned long)account->registered);
 }
 
 static void nefarious_sethost_sts(user_t *source, user_t *target, const char *host)

--- a/modules/protocol/p10-generic.c
+++ b/modules/protocol/p10-generic.c
@@ -322,9 +322,9 @@ static void p10_sasl_sts(char *target, char mode, char *data)
 	sts("%s XR %c%c %s :SASL:%c:%s", me.numeric, target[0], target[1], target, mode, data);
 }
 
-static void p10_svslogin_sts(char *target, char *nick, char *user, char *host, stringref login)
+static void p10_svslogin_sts(char *target, char *nick, char *user, char *host, myuser_t *account)
 {
-	sts("%s XR %c%c %s :SASL:L:%s", me.numeric, target[0], target[1], target, login);
+	sts("%s XR %c%c %s :SASL:L:%s", me.numeric, target[0], target[1], target, entity(account)->name);
 }
 
 static void m_topic(sourceinfo_t *si, int parc, char *parv[])

--- a/modules/protocol/ts6-generic.c
+++ b/modules/protocol/ts6-generic.c
@@ -461,7 +461,7 @@ static void ts6_fnc_sts(user_t *source, user_t *u, const char *newnick, int type
 			(unsigned long)u->ts);
 }
 
-static void ts6_svslogin_sts(char *target, char *nick, char *user, char *host, stringref login)
+static void ts6_svslogin_sts(char *target, char *nick, char *user, char *host, myuser_t *account)
 {
 	user_t *tu = user_find(target);
 	server_t *s;
@@ -474,7 +474,7 @@ static void ts6_svslogin_sts(char *target, char *nick, char *user, char *host, s
 		return;
 
 	sts(":%s ENCAP %s SVSLOGIN %s %s %s %s %s", ME, s->name,
-			target, nick, user, host, login);
+			target, nick, user, host, entity(account)->name);
 }
 
 static void ts6_sasl_sts(char *target, char mode, char *data)

--- a/modules/protocol/unreal.c
+++ b/modules/protocol/unreal.c
@@ -687,7 +687,7 @@ static void unreal_sasl_sts(char *target, char mode, char *data)
 	sts(":%s SASL %s %s %c %s", saslserv->me->nick, servermask, target, mode, data);
 }
 
-static void unreal_svslogin_sts(char *target, char *nick, char *user, char *host, stringref login)
+static void unreal_svslogin_sts(char *target, char *nick, char *user, char *host, myuser_t *account)
 {
 	char servermask[BUFSIZE], *p;
 	service_t *saslserv;
@@ -702,7 +702,7 @@ static void unreal_svslogin_sts(char *target, char *nick, char *user, char *host
 	if (p != NULL)
 		*p = '\0';
 
-	sts(":%s SVSLOGIN %s %s %s", saslserv->me->nick, servermask, target, login);
+	sts(":%s SVSLOGIN %s %s %s", saslserv->me->nick, servermask, target, entity(account)->name);
 }
 
 static void unreal_mlock_sts(channel_t *c)

--- a/modules/saslserv/main.c
+++ b/modules/saslserv/main.c
@@ -337,7 +337,7 @@ static void sasl_packet(sasl_session_t *p, char *buf, int len)
 				cloak = "*";
 
 			if (!(mu->flags & MU_WAITAUTH))
-				svslogin_sts(p->uid, "*", "*", cloak, entity(mu)->name);
+				svslogin_sts(p->uid, "*", "*", cloak, mu);
 			sasl_sts(p->uid, 'D', "S");
 		}
 		else


### PR DESCRIPTION
Some protocol modules, like nefarious, want to access other fields than just `->name`; this avoids having to call myuser_find() just to find the same myuser that's already known.

It does, however, change the protocol module API.
