### PR TITLE
nickserv/{info,status}: show entity ID in 'ACC' and 'INFO'

### DIFF
--- a/modules/nickserv/info.c
+++ b/modules/nickserv/info.c
@@ -133,10 +133,7 @@ static void ns_cmd_info(sourceinfo_t *si, int parc, char *parv[])
 		command_success_nodata(si, _("User reg.  : %s (%s ago)"), strfbuf, time_ago(mu->registered));
 	}
 
-	if (has_user_auspex)
-	{
-		command_success_nodata(si, _("Entity ID  : %s"), entity(mu)->id);
-	}
+	command_success_nodata(si, _("Entity ID  : %s"), entity(mu)->id);
 
 	md = metadata_find(mu, "private:usercloak");
 	vhost = md ? md->value : NULL;

--- a/modules/nickserv/status.c
+++ b/modules/nickserv/status.c
@@ -69,12 +69,12 @@ static void ns_cmd_acc(sourceinfo_t *si, int parc, char *parv[])
 	}
 
 	if (u->myuser == mu)
-		command_success_nodata(si, "%s%s%s ACC 3", u->nick, parc >= 2 ? " -> " : "", parc >= 2 ? entity(mu)->name : "");
+		command_success_nodata(si, "%s%s%s ACC 3 %s", u->nick, parc >= 2 ? " -> " : "", parc >= 2 ? entity(mu)->name : "", entity(mu)->id);
 	else if ((mn = mynick_find(u->nick)) != NULL && mn->owner == mu &&
 			myuser_access_verify(u, mu))
-		command_success_nodata(si, "%s%s%s ACC 2", u->nick, parc >= 2 ? " -> " : "", parc >= 2 ? entity(mu)->name : "");
+		command_success_nodata(si, "%s%s%s ACC 2 %s", u->nick, parc >= 2 ? " -> " : "", parc >= 2 ? entity(mu)->name : "", entity(mu)->id);
 	else
-		command_success_nodata(si, "%s%s%s ACC 1", u->nick, parc >= 2 ? " -> " : "", parc >= 2 ? entity(mu)->name : "");
+		command_success_nodata(si, "%s%s%s ACC 1 %s", u->nick, parc >= 2 ? " -> " : "", parc >= 2 ? entity(mu)->name : "", entity(mu)->id);
 }
 
 static void ns_cmd_status(sourceinfo_t *si, int parc, char *parv[])


### PR DESCRIPTION
As in issue #253, it would be useful to uniquely identify users across
account renames and such. Privacy issues (/ns info ?<eid>) should not be
a problem, since there already are other ways to chase account renames.
