### PR TITLE
include/Makefile: mark serno.h as phony to force it to be regenerated every time

### DIFF
--- a/include/Makefile
+++ b/include/Makefile
@@ -1,5 +1,7 @@
 include ../extra.mk
 
+.PHONY: serno.h
+
 SUBDIRS = inline protocol
 
 DISTCLEAN = hooktypes.h serno.h


### PR DESCRIPTION
this is desired behavior as a "make distclean" is not always run between git pulls.
