### PR TITLE
saslserv/main: Fix unlikely buffer overflow in sasl_packet()

### DIFF
--- a/modules/saslserv/main.c
+++ b/modules/saslserv/main.c
@@ -292,7 +292,7 @@ static void sasl_packet(sasl_session_t *p, char *buf, int len)
 			MOWGLI_ITER_FOREACH(n, sasl_mechanisms.head)
 			{
 				sasl_mechanism_t *mptr = n->data;
-				if(l + strlen(mptr->name) > 510)
+				if(l + strlen(mptr->name) > sizeof(temp))
 					break;
 				strcpy(ptr, mptr->name);
 				ptr += strlen(mptr->name);


### PR DESCRIPTION
An incorrect length check allows for out of bounds stack writes when the mechanism list gets too long.

This is not triggerable by users.
