### PR TITLE
libathemecore: Fix double free of the ping uplink timer on ping timeout

### DIFF
--- a/libathemecore/packet.c
+++ b/libathemecore/packet.c
@@ -79,10 +79,7 @@ static void ping_uplink(void *arg)
 	}
 
 	if (!me.connected)
-	{
-		mowgli_timer_destroy(base_eventloop, ping_uplink_timer);
 		ping_uplink_timer = NULL;
-	}
 }
 
 void irc_handle_connect(connection_t *cptr)


### PR DESCRIPTION
The timer was freed in both the tick function and in mowgli_eventloop_run_timers().

All versions are affected.
