### PR TITLE
Mark InspIRCd 1.2 support as deprecated in the config and doc/IRCD

### DIFF
--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -52,7 +52,8 @@
  * Charybdis IRCd                               modules/protocol/charybdis
  * DreamForge 4.6.7 or later                    modules/protocol/dreamforge
  * Hybrid 7.1.2 and later                       modules/protocol/hybrid
- * InspIRCd 1.2 - 2.1 (link protocol 1201-1204) modules/protocol/inspircd
+ * InspIRCd 1.2 [DEPRECATED]                    modules/protocol/inspircd
+ * InspIRCd 2.0                                 modules/protocol/inspircd
  * ircd-ratbox 2.0 and later                    modules/protocol/ratbox
  * IRCNet ircd (ircd 2.11)                      modules/protocol/ircnet
  * ircd-seven                                   modules/protocol/ircd-seven

--- a/doc/IRCD
+++ b/doc/IRCD
@@ -48,7 +48,8 @@ on the network.
 inspircd
 --------
 
-You should use inspircd12 for inspircd 1.2.x, inspircd 2.0.x and inspircd 2.1.x.
+You should use the "inspircd" protocol module for InspIRCd 1.2 and 2.0.
+InspIRCd 1.2 support is deprecated as of atheme 7.1.
 InspIRCd 1.0.x support (inspircd10) and InspIRCd 1.1.x support (inspircd11)
 have been dropped.
 

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -324,7 +324,7 @@ static unsigned int inspircd_server_login(void)
 	 */
 	if (me.numeric == NULL)
 	{
-		slog(LG_ERROR, "inspircd_server_login(): inspircd 1.2 requires a unique identifier. set serverinfo::numeric.");
+		slog(LG_ERROR, "inspircd_server_login(): inspircd requires a unique identifier. set serverinfo::numeric.");
 		exit(EXIT_FAILURE);
 	}
 


### PR DESCRIPTION
InspIRCd 1.2 is unmaintained for more than a year now.
