### PR TITLE
protocol/inspircd: Change VERSION string and IDLE reply

### DIFF
--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -1203,13 +1203,15 @@ static void m_squit(sourceinfo_t *si, int parc, char *parv[])
 static void m_server(sourceinfo_t *si, int parc, char *parv[])
 {
 	server_t *s;
+	const crypt_impl_t *ci;
 
 	slog(LG_DEBUG, "m_server(): new server: %s", parv[0]);
 	if (si->s == NULL)
 	{
 		sts(":%s BURST", me.numeric);
-		sts(":%s VERSION :%s. %s %s",
-				me.name, PACKAGE_STRING, me.numeric, get_conf_opts());
+		ci = crypt_get_default_provider();
+		sts(":%s VERSION :%s. %s %s :%s [%s] [enc:%s] Build Date: %s",
+			me.numeric, PACKAGE_STRING, me.name, revision, get_conf_opts(), ircd->ircdname, ci->id, __DATE__);
 		services_init();
 		sts(":%s ENDBURST", me.numeric);
 	}


### PR DESCRIPTION
Don't send current time in response to IDLE
This will cause InspIRCd to not send RPL_WHOISIDLE (317) to the user doing the whois

Send a VERSION string that is similiar to what we send to other ircds

Fix non-uid/non-sid usage when sending VERSION and IDLE
