### PR TITLE
Show ANTIFLOOD flag in CService INFO

### DIFF
--- a/modules/chanserv/info.c
+++ b/modules/chanserv/info.c
@@ -204,6 +204,14 @@ static void cs_cmd_info(sourceinfo_t *si, int parc, char *parv[])
 
 		strcat(buf, "GUARD");
 	}
+	
+	if (MC_ANTIFLOOD & mc->flags)
+	{
+		if (*buf)
+			strcat(buf, " ");
+
+		strcat(buf, "ANTIFLOOD");
+	}
 
 	if (chansvs.fantasy && !metadata_find(mc, "disable_fantasy"))
 	{


### PR DESCRIPTION
Show ANTIFLOOD (if enabled) in channel INFO flags output
