### PR TITLE
libathemecore/flags: Add flag 'f' for MC_ANTIFLOOD to mc_flags (fix bug #333)

### DIFF
--- a/libathemecore/flags.c
+++ b/libathemecore/flags.c
@@ -85,6 +85,7 @@ struct gflags mc_flags[] = {
 	{ 'g', MC_GUARD },
 	{ 'p', MC_PRIVATE },
 	{ 'n', MC_NOSYNC },
+	{ 'f', MC_ANTIFLOOD },
 	{ 0, 0 },
 };
 


### PR DESCRIPTION
This will allow the ANTIFLOOD flag to be saved to and loaded from the storage
backend, fixing bug #333.
