### PR TITLE
Fix ANTIFLOOD response when already set  (Fixes #336)

### DIFF
--- a/modules/chanserv/antiflood.c
+++ b/modules/chanserv/antiflood.c
@@ -432,6 +432,11 @@ cs_set_cmd_antiflood(sourceinfo_t *si, int parc, char *parv[])
 	}
 	else if (!strcasecmp(parv[1], "ON"))
 	{
+		if (MC_ANTIFLOOD & mc->flags)
+		{
+			command_fail(si, fault_nochange, _("The \2%s\2 flag is already set for channel \2%s\2."), "ANTIFLOOD", mc->name);
+			return;
+		}
 		mc->flags |= MC_ANTIFLOOD;
 		metadata_delete(mc, METADATA_KEY_ENFORCE_METHOD);
 


### PR DESCRIPTION
Inform user that ANTIFLOOD is already enabled when the default ON option
is used. (This resolves issue #336)
