### PR TITLE
protocol/inspircd: Remove misleading debug message from m_capab()

### DIFF
--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -1587,10 +1587,6 @@ static void m_capab(sourceinfo_t *si, int parc, char *parv[])
 			slog(LG_INFO, "m_capab(): you didn't load m_svshold into inspircd. nickname enforcers will not work.");
 		}
 	}
-	else
-	{
-		slog(LG_DEBUG, "m_capab(): unknown CAPAB type %s - out of date protocol module?", parv[0]);
-	}
 }
 
 /* Server ended their burst: warn all their users if necessary -- jilles */


### PR DESCRIPTION
This message appeared every time we connected to our uplink because we don't parse CAPAB CHANMODES

Please backport to 7.1.
