### PR TITLE
Do not set OPERTYPE if ' m_servprotect' module is loaded

### DIFF
--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -357,7 +357,7 @@ static void inspircd_introduce_nick(user_t *u)
 	const char *umode = user_get_umodestr(u);
 
 	sts(":%s UID %s %lu %s %s %s %s 0.0.0.0 %lu %s%s%s%s :%s", me.numeric, u->uid, (unsigned long)u->ts, u->nick, u->host, u->host, u->user, (unsigned long)u->ts, umode, has_hideopermod ? "H" : "", has_hidechansmod ? "I" : "", has_servprotectmod ? "k" : "", u->gecos);
-	if (is_ircop(u))
+	if (is_ircop(u) && !has_servprotectmod)
 		sts(":%s OPERTYPE Services", u->uid);
 }
 


### PR DESCRIPTION
The ' m_servprotect' module will show services as a Service so there's
no need to double up on this information. This also has the added
benefit of making services not show up as opers in /lusers
