### PR TITLE
Change OPERTYPE to say "Service" instead of "Services"

### DIFF
--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -369,7 +369,7 @@ static void inspircd_introduce_nick(user_t *u)
 
 	sts(":%s UID %s %lu %s %s %s %s 0.0.0.0 %lu %s%s%s%s :%s", me.numeric, u->uid, (unsigned long)u->ts, u->nick, u->host, u->host, u->user, (unsigned long)u->ts, umode, has_hideopermod ? "H" : "", has_hidechansmod ? "I" : "", has_servprotectmod ? "k" : "", u->gecos);
 	if (is_ircop(u) && !has_servprotectmod)
-		sts(":%s OPERTYPE Services", u->uid);
+		sts(":%s OPERTYPE Service", u->uid);
 }
 
 static void inspircd_quit_sts(user_t *u, const char *reason)


### PR DESCRIPTION
Fix for grammatical issues in InspIRCd.

Before this PR, when you `/whois` a service client (without m_servprotect), you would see something along the lines of:

```
x :is a Services on <netname>
```

This PR fixes this, changing it to

```
x :is a Service on <netname>
```
