### PR TITLE
include/servtree.h: fix null pointer dereference

### DIFF
--- a/include/servtree.h
+++ b/include/servtree.h
@@ -38,7 +38,7 @@ struct service_ {
 
 static inline const char *service_get_log_target(const service_t *svs)
 {
-	if (svs->logtarget != NULL)
+	if (svs != NULL && svs->logtarget != NULL)
 		return service_get_log_target(svs->logtarget);
 
 	return svs != NULL ? svs->nick : me.name;


### PR DESCRIPTION
`svs` can be NULL when we are logging `/stats <letter> services.` so check
for that case before looking up `->logtarget`.
