### PR TITLE
chanserv/flags: Require single parameter starting with '+' for filtered flag listing

### DIFF
--- a/modules/chanserv/flags.c
+++ b/modules/chanserv/flags.c
@@ -183,7 +183,7 @@ static void cs_cmd_flags(sourceinfo_t *si, int parc, char *parv[])
 		return;
 	}
 
-	if (!target || (target && !is_valid_nick(target)))
+	if (!target || (target && target[0] == '+' && flagstr == NULL))
 	{
 		unsigned int flags = (target != NULL) ? flags_to_bitmask(target, 0) : 0;
 


### PR DESCRIPTION
This avoids triggering the filtered flag listing when trying to view or
modify flags on a hostmask, exttarget or group.
