### PR TITLE
Add channel output to flag lines in FLAGS command

### DIFF
--- a/modules/chanserv/flags.c
+++ b/modules/chanserv/flags.c
@@ -133,11 +133,11 @@ static void do_list(sourceinfo_t *si, mychan_t *mc, unsigned int flags)
 		strftime(mod_date, sizeof mod_date, TIME_FORMAT, &tm);
 
 		if (template != NULL)
-			command_success_nodata(si, _("%-5d %-22s %-20s (%s) [modified %s ago, on %s]"),
-				i, ca->entity ? ca->entity->name : ca->host, bitmask_to_flags(ca->level), template, mod_ago, mod_date);
+			command_success_nodata(si, _("%-5d %-22s %-20s (%s) (%s) [modified %s ago, on %s]"),
+				i, ca->entity ? ca->entity->name : ca->host, bitmask_to_flags(ca->level), template, mc->name, mod_ago, mod_date);
 		else
-			command_success_nodata(si, _("%-5d %-22s %-20s [modified %s ago, on %s]"),
-				i, ca->entity ? ca->entity->name : ca->host, bitmask_to_flags(ca->level), mod_ago, mod_date);
+			command_success_nodata(si, _("%-5d %-22s %-20s (%s) [modified %s ago, on %s]"),
+				i, ca->entity ? ca->entity->name : ca->host, bitmask_to_flags(ca->level), mc->name, mod_ago, mod_date);
 		i++;
 	}
 


### PR DESCRIPTION
A simple change to add the name of the channel to each flag line output for the FLAGS command. The advantage of this is that it makes it possible for a bot to be able to read the output of the command - without the #channel output it's not really possible to tell which channel a line in the flag response is concerning. With this change it is easy to key them - e.g. http://ur1.ca/i4hgr
