### PR TITLE
protocol/inspircd: Allow all METADATA accountname messages to set the internal account name of a user

### DIFF
--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -1387,12 +1387,8 @@ static void m_metadata(sourceinfo_t *si, int parc, char *parv[])
 
 		if (parv[2][0] == '\0')
 			handle_clearlogin(si, u);
-		else if (si->s == u->server && (!(si->s->flags & SF_EOB) ||
-					(u->myuser != NULL &&
-					 !irccasecmp(entity(u->myuser)->name, parv[2]))))
-			handle_burstlogin(u, parv[2], 0);
 		else
-			handle_setlogin(si, u, parv[2], 0);
+			handle_burstlogin(u, parv[2], 0);
 	}
 	else if (!irccasecmp(parv[1], "ssl_cert"))
 	{


### PR DESCRIPTION
Fixes #308
