### PR TITLE
Add CERT IDENTIFY command to NickServ.

### DIFF
--- a/help/default/nickserv/cert
+++ b/help/default/nickserv/cert
@@ -2,12 +2,15 @@ Help for CERT:
 
 CERT maintains a list of CertFP fingerprints that will allow
 &nick& to recognize you and authenticate you automatically.
+It also allows you to re-identify yourself using your current
+CertFP.
 
 You cannot add the same fingerprint to multiple accounts.
 
 Syntax: CERT LIST
 Syntax: CERT ADD [fingerprint]
 Syntax: CERT DEL <fingerprint>
+Syntax: CERT IDENTIFY
 #if priv user:auspex
 
 Operators with user:auspex privilege can also
@@ -20,3 +23,4 @@ Examples:
     /msg &nick& CERT LIST
     /msg &nick& CERT ADD f3a1aad46ca88e180c25c9c7021a4b3a
     /msg &nick& CERT DEL f3a1aad46ca88e180c25c9c7021a4b3a
+    /msg &nick& CERT IDENTIFY


### PR DESCRIPTION
This adds a new subcommand to the CERT command which allows you to re-identify to NickServ using your current CertFP, without reconnecting.
