### PR TITLE
Remove trailing '.' from "set flags" report.

### DIFF
--- a/modules/chanserv/flags.c
+++ b/modules/chanserv/flags.c
@@ -475,7 +475,7 @@ static void cs_cmd_flags(sourceinfo_t *si, int parc, char *parv[])
 		flagstr = bitmask_to_flags2(addflags, removeflags);
 		command_success_nodata(si, _("Flags \2%s\2 were set on \2%s\2 in \2%s\2."), flagstr, target, channel);
 		logcommand(si, CMDLOG_SET, "FLAGS: \2%s\2 \2%s\2 \2%s\2", mc->name, target, flagstr);
-		verbose(mc, "\2%s\2 set flags \2%s\2 on \2%s\2.", get_source_name(si), flagstr, target);
+		verbose(mc, "\2%s\2 set flags \2%s\2 on \2%s\2", get_source_name(si), flagstr, target);
 	}
 
 	free(target);


### PR DESCRIPTION
It's unclear that it isn't part of the mask that was set.
