### PR TITLE
modules/chanserv/clone.c: Gracefully handle chanacs 'setter' being NULL

### DIFF
--- a/modules/chanserv/clone.c
+++ b/modules/chanserv/clone.c
@@ -117,9 +117,9 @@ static void cs_cmd_clone(sourceinfo_t *si, int parc, char *parv[])
 		ca = n->data;
 
 		if (!ca->host)
-			chanacs_change_simple(mc2, ca->entity, NULL, ca->level, 0, myentity_find(ca->setter));
+			chanacs_change_simple(mc2, ca->entity, NULL, ca->level, 0, ca->setter ? myentity_find(ca->setter) : NULL);
 		else if (ca->host != NULL)
-			chanacs_change_simple(mc2, NULL, ca->host, ca->level, 0, myentity_find(ca->setter));
+			chanacs_change_simple(mc2, NULL, ca->host, ca->level, 0, ca->setter ? myentity_find(ca->setter) : NULL);
 	}
 
 	/* Copy ze metadata! */


### PR DESCRIPTION
Using ChanServ CLONE, where some chanacs entries in services.db were created in a legacy format, generates assert spam.

```
PRIVMSG ChanServ :REGISTER #TestChannel
PRIVMSG ChanServ :CLONE #LegacyChannel #TestChannel
<OperServ> (entity.c:84 myentity_find): warning: assertion 'name != ((void *)0)' failed.
<OperServ> (entity.c:84 myentity_find): warning: assertion 'name != ((void *)0)' failed.
<OperServ> (entity.c:84 myentity_find): warning: assertion 'name != ((void *)0)' failed.
etc...
```
