### PR TITLE
modules/operserv/clones.c: Fix inconsistent inequality check

### DIFF
--- a/modules/operserv/clones.c
+++ b/modules/operserv/clones.c
@@ -700,9 +700,9 @@ static void os_cmd_clones_setexempt(sourceinfo_t *si, int parc, char *parv[])
 						c->warn = 0;
 						return;
 					}
-					else if (clones >= c->allowed)
+					else if (clones > c->allowed)
 					{
-						command_fail(si, fault_badparams, _("Warned clones limit must be lower than the allowed limit of %d"), c->allowed);
+						command_fail(si, fault_badparams, _("Warned clones limit must be lower than or equal to the allowed limit of %d"), c->allowed);
 						return;
 					}
 


### PR DESCRIPTION
Fixes the following inconsistency in the CLONES SETEXEMPT function with regards to warn/allowed limits:
- Adding a new exemption sets WARN = ALLOWED
- Using SETEXEMPT does _not_ allow setting WARN = ALLOWED
- Using SETEXEMPT _does_ allow setting ALLOWED = WARN
