### PR TITLE
Fix NickServ ACC command short description

### DIFF
--- a/modules/nickserv/status.c
+++ b/modules/nickserv/status.c
@@ -19,7 +19,7 @@ static void ns_cmd_acc(sourceinfo_t *si, int parc, char *parv[]);
 static void ns_cmd_status(sourceinfo_t *si, int parc, char *parv[]);
 
 command_t ns_status = { "STATUS", N_("Displays session information."), AC_NONE, 0, ns_cmd_status, { .path = "nickserv/status" } };
-command_t ns_acc = { "ACC", N_("Displays parsable session information"), AC_NONE, 2, ns_cmd_acc, { .path = "nickserv/acc" } };
+command_t ns_acc = { "ACC", N_("Displays parsable session information."), AC_NONE, 2, ns_cmd_acc, { .path = "nickserv/acc" } };
 
 void _modinit(module_t *m)
 {


### PR DESCRIPTION
All command short descriptions returned by `/msg NickServ HELP COMMANDS` end with a period except for the ACC command. This pull request simply fixes a grammatical inconsistency in the project.
