### PR TITLE
Fix GroupServ issues

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -7,6 +7,7 @@ Chris Fuenty <zimmy@zimmy.co.uk> <zimmaster@cia.com>
 Chris Fuenty <zimmy@zimmy.co.uk> <zimmy@atheme.org>
 Craig Edwards <craigedwards@brainbox.cc> brain <devnull@localhost>
 Daniel Vassdal <shutter@canternet.org> Daniel Vassdal <daniel@daniel-VirtualBox.(none)>
+David Farrell <shokku.ra@gmail.com> Shockk <shokku.ra@gmail.com>
 Diane Bruce <db@db.net> db <devnull@localhost>
 Douglas Freed <dwfreed@mtu.edu> dwfreed <dwfreed@mtu.edu>
 Elfyn McBratney <elfyn.mcbratney@gmail.com> beu <devnull@localhost>

--- a/help/default/groupserv/flags
+++ b/help/default/groupserv/flags
@@ -18,6 +18,7 @@ Syntax: FLAGS <!group> [nickname flag_changes]
 Permissions:
     +f - Enables modification of group access list.
     +F - Grants full founder access.
+    +A - Enables viewing of group access list.
     +m - Read memos sent to the group.
     +c - Have channel access in channels where the group has sufficient
          privileges.

--- a/modules/groupserv/drop.c
+++ b/modules/groupserv/drop.c
@@ -71,7 +71,7 @@ static void gs_cmd_drop(sourceinfo_t *si, int parc, char *parv[])
 		create_challenge(si, entity(mg)->name, 1, key1);
 		if (strcmp(key, key0) && strcmp(key, key1))
 		{
-			command_fail(si, fault_badparams, _("Invalid key for %s."), "DROP");
+			command_fail(si, fault_badparams, _("Invalid key for \2%s\2."), "DROP");
 			return;
 		}
 	}

--- a/modules/groupserv/flags.c
+++ b/modules/groupserv/flags.c
@@ -179,7 +179,7 @@ no_founder:
 	{
 		if (MOWGLI_LIST_LENGTH(&mg->acs) > gs_config->maxgroupacs && (!(mg->flags & MG_ACSNOLIMIT)))
 		{
-			command_fail(si, fault_toomany, _("Group %s access list is full."), entity(mg)->name);
+			command_fail(si, fault_toomany, _("Group \2%s\2 access list is full."), entity(mg)->name);
 			return;
 		}
 		ga = groupacs_add(mg, mt, flags);

--- a/modules/groupserv/flags.c
+++ b/modules/groupserv/flags.c
@@ -159,7 +159,15 @@ static void gs_cmd_flags(sourceinfo_t *si, int parc, char *parv[])
 
 no_founder:
 	if (ga != NULL && flags != 0)
-		ga->flags = flags;
+	{
+		if (ga->flags != flags)
+			ga->flags = flags;
+		else
+		{
+			command_fail(si, fault_nochange, _("Group \2%s\2 access for \2%s\2 unchanged."), entity(mg)->name, mt->name);
+			return;
+		}
+	}
 	else if (ga != NULL)
 	{
 		groupacs_delete(mg, mt);
@@ -167,7 +175,7 @@ no_founder:
 		logcommand(si, CMDLOG_SET, "FLAGS:REMOVE: \2%s\2 on \2%s\2", mt->name, entity(mg)->name);
 		return;
 	}
-	else
+	else if (flags != 0)
 	{
 		if (MOWGLI_LIST_LENGTH(&mg->acs) > gs_config->maxgroupacs && (!(mg->flags & MG_ACSNOLIMIT)))
 		{
@@ -175,6 +183,11 @@ no_founder:
 			return;
 		}
 		ga = groupacs_add(mg, mt, flags);
+	}
+	else
+	{
+		command_fail(si, fault_nochange, _("Group \2%s\2 access for \2%s\2 unchanged."), entity(mg)->name, mt->name);
+		return;
 	}
 
 	MOWGLI_ITER_FOREACH(n, entity(mg)->chanacs.head)

--- a/modules/groupserv/invite.c
+++ b/modules/groupserv/invite.c
@@ -82,13 +82,13 @@ static void gs_cmd_invite(sourceinfo_t *si, int parc, char *parv[])
 
 	if ((svs = service_find("memoserv")) != NULL)
 	{
-		snprintf(buf, BUFSIZE, "%s [auto memo] You have been invited to the group %s.", user, group);
+		snprintf(buf, BUFSIZE, "%s [auto memo] You have been invited to the group \2%s\2.", user, group);
 
 		command_exec_split(svs, si, "SEND", buf, svs->commands);
 	}
 	else
 	{
-		myuser_notice(si->service->nick, mu, "You have been invited to the group %s.", group);
+		myuser_notice(si->service->nick, mu, "You have been invited to the group \2%s\2.", group);
 	}
 
 	logcommand(si, CMDLOG_SET, "INVITE: \2%s\2 \2%s\2", group, user);

--- a/modules/groupserv/join.c
+++ b/modules/groupserv/join.c
@@ -69,7 +69,7 @@ static void gs_cmd_join(sourceinfo_t *si, int parc, char *parv[])
 
 	if (MOWGLI_LIST_LENGTH(&mg->acs) > gs_config->maxgroupacs && (!(mg->flags & MG_ACSNOLIMIT)) && !invited)
         {
-                command_fail(si, fault_toomany, _("Group %s access list is full."), entity(mg)->name);
+                command_fail(si, fault_toomany, _("Group \2%s\2 access list is full."), entity(mg)->name);
                 return;
         }
 

--- a/modules/groupserv/main/groupserv.c
+++ b/modules/groupserv/main/groupserv.c
@@ -308,7 +308,11 @@ unsigned int gs_flags_parser(char *flagstring, bool allow_minus, unsigned int fl
 			if (dir)
 				flags = 0;
 			else
-				flags = GA_ALL;
+			{
+				/* preserve existing flags except GA_BAN */
+				flags |= GA_ALL;
+				flags &= ~GA_BAN;
+			}
 			break;
 		default:
 			while (ga_flags[n].ch != 0 && flag == 0)

--- a/modules/groupserv/main/groupserv.c
+++ b/modules/groupserv/main/groupserv.c
@@ -287,11 +287,14 @@ unsigned int gs_flags_parser(char *flagstring, bool allow_minus, unsigned int fl
 {
 	char *c;
 	unsigned int dir = 0;
+	unsigned int flag;
+	unsigned char n;
 
-	/* XXX: this sucks. :< */
 	c = flagstring;
 	while (*c)
 	{
+		flag = 0;
+		n = 0;
 		switch(*c)
 		{
 		case '+':
@@ -307,55 +310,20 @@ unsigned int gs_flags_parser(char *flagstring, bool allow_minus, unsigned int fl
 			else
 				flags = GA_ALL;
 			break;
-		case 'F':
-			if (dir)
-				flags &= ~GA_FOUNDER;
-			else
-				flags |= GA_FOUNDER;
-			break;
-		case 'f':
-			if (dir)
-				flags &= ~GA_FLAGS;
-			else
-				flags |= GA_FLAGS;
-			break;
-		case 's':
-			if (dir)
-				flags &= ~GA_SET;
-			else
-				flags |= GA_SET;
-			break;
-		case 'v':
-			if (dir)
-				flags &= ~GA_VHOST;
-			else
-				flags |= GA_VHOST;
-			break;
-		case 'c':
-			if (dir)
-				flags &= ~GA_CHANACS;
-			else
-				flags |= GA_CHANACS;
-			break;
-		case 'm':
-			if (dir)
-				flags &= ~GA_MEMOS;
-			else
-				flags |= GA_MEMOS;
-			break;
-		case 'b':
-			if (dir)
-				flags &= ~GA_BAN;
-			else
-				flags |= GA_BAN;
-			break;
-		case 'i':
-			if (dir)
-				flags &= ~GA_INVITE;
-			else
-				flags |= GA_INVITE;
-			break;
 		default:
+			while (ga_flags[n].ch != 0 && flag == 0)
+			{
+				if (ga_flags[n].ch == *c)
+					flag = ga_flags[n].value;
+				else
+					n++;
+			}
+			if (flag == 0)
+				break;
+			if (dir)
+				flags &= ~flag;
+			else
+				flags |= flag;
 			break;
 		}
 


### PR DESCRIPTION
This pull request eliminates issues arising from hardcoded parsing of flags in the GroupServ flags parser. The GroupServ FLAGS help text is updated to reflect the now functional GroupServ flag +A (allows viewing of group access list). Additionally, issues with flags +* are fixed and now the behaviour is more consistent with that of ChanServ.

More details are available in the individual commit messages.