### PR TITLE
protocol: Fail extban check if mask contains space

### DIFF
--- a/modules/protocol/charybdis.c
+++ b/modules/protocol/charybdis.c
@@ -291,6 +291,9 @@ static bool charybdis_is_extban(const char *mask)
 	if ((mask_len < 2 || mask[0] != '$'))
 		return NULL;
 
+	if (strchr(mask, ' '))
+		return false;
+
 	if (mask_len > 2 && mask[1] == '~')
 		offset = 1;
 

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -190,7 +190,7 @@ static bool inspircd_is_extban(const char *mask)
 {
 	const size_t mask_len = strlen(mask);
 	/* e.g R:Test */
-	if (mask_len < 2 || mask[1] != ':')
+	if (mask_len < 2 || mask[1] != ':' || strchr(mask, ' '))
 		return false;
 
 	return true;

--- a/modules/protocol/unreal.c
+++ b/modules/protocol/unreal.c
@@ -1251,7 +1251,7 @@ static bool unreal_is_extban(const char *mask)
 	const char mask_len = strlen(mask);
 	unsigned char offset = 0;
 
-	if (mask_len < 4 || mask[0] != '~' || mask[2] != ':')
+	if (mask_len < 4 || mask[0] != '~' || mask[2] != ':' || strchr(mask, ' '))
 		return false;
 
 	if ((mask[1] < 'a' || mask[1] > 'z') && (mask[1] < 'A' || mask[1] > 'Z'))


### PR DESCRIPTION
In certain circumstances, the mask string passed into is_extban can contain space(s) and currently there is no validation in any protocol module implementing extbans that the input mask indeed contains no spaces. An example circumstance is ChanServ's BAN command.

The following command will cause ChanServ to set a ban on the first mask due to how the MODE command works, but fail to add the ban to Atheme itself due to the mask being the full rest of the string as opposed to just a single word.

`/msg ChanServ BAN #channel $a:mask1 $a:mask2`

This patch adds a simple strchr check for the space character to each extban check, fixing the issue outlined above.