### PR TITLE
saslserv: make bad_password description more user-friendly

### DIFF
--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -1430,6 +1430,11 @@ saslserv {
 	 * The realname (gecos) information we want SaslServ to have.
 	 */
 	real = "SASL Authentication Agent";
+
+	/* (*)hide_server_names
+	 * Hide server names in the bad_password message.
+	 */
+	#hide_server_names;
 };
 
 /* MemoServ configuration.

--- a/include/sasl.h
+++ b/include/sasl.h
@@ -18,6 +18,8 @@ struct sasl_session_ {
   char *buf, *p;
   int len, flags;
 
+  server_t *server;
+
   struct sasl_mechanism_ *mechptr;
   void *mechdata;
 


### PR DESCRIPTION
Change the SASL `bad_password` description to `Unknown user on <server> (via SASL)`. If `hide_server_names` is set the description is `Unknown user (via SASL)`.