### PR TITLE
Make Perl API forward compatible

### DIFF
--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -174,6 +174,13 @@ while (<$hooktypes>) {
 		next;
 	}
 	next if grep { $_ eq $arg_type } @unsupported_types;
+	unless ($perl_api_types{$arg_type} ||
+	        $hook_structs{$arg_type} ||
+	        (grep { $_ eq $arg_type } @special_types) ||
+	        $arg_type eq "void") {
+		warn "Hook type '$arg_type' is neither specified for use nor marked as currently unsupported\n";
+		next;
+	}
 
 	$hooks{$hookname} = $arg_type;
 	$arg_types{$arg_type} = 1 unless grep { $_ eq $arg_type } @special_types;

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -204,7 +204,7 @@ EOF
 # Write the hook-data marshalling functions.
 #
 
-foreach my $arg_type (keys %arg_types) {
+foreach my $arg_type (sort keys %arg_types) {
 	next if ($arg_type eq 'void');
 
 	if (defined $perl_api_types{$arg_type}) {
@@ -231,7 +231,8 @@ EOF
 
 		my @members;
 
-		while (my ($member, $definition) = each %$struct) {
+		foreach my $member (sort keys %$struct) {
+			my $definition = $struct->{$member};
 			my ($type, $pretty_name, $rw);
 
 			if (ref $definition eq 'ARRAY') {
@@ -301,7 +302,8 @@ EOF
 # Now write the actual hook handlers.
 #
 
-while (my ($hookname, $arg_type) = each %hooks) {
+foreach my $hookname (sort keys %hooks) {
+	my $arg_type = $hooks{$hookname};
 	next if grep { $_ eq $arg_type } @special_types;
 	print $outfile <<"EOF";
 static void perl_hook_$hookname ($arg_type * data)
@@ -346,7 +348,7 @@ print $outfile <<EOF;
 void enable_perl_hook_handler(const char *hookname)
 {
 EOF
-foreach my $hookname (keys %hooks) {
+foreach my $hookname (sort keys %hooks) {
 	print $outfile <<"EOF";
 	if (0 == strcmp(hookname, "$hookname")) {
 		hook_add_$hookname(perl_hook_$hookname);
@@ -363,7 +365,7 @@ print $outfile <<EOF;
 void disable_perl_hook_handler(const char *hookname)
 {
 EOF
-foreach my $hookname (keys %hooks) {
+foreach my $hookname (sort keys %hooks) {
 	print $outfile <<"EOF";
 	if (0 == strcmp(hookname, "$hookname")) {
 		hook_del_$hookname(perl_hook_$hookname);


### PR DESCRIPTION
This pull request firstly fixes the lack of ordering of the code output in `perl_hooks.c` to allow the second patch and future patches to be verified for correctness by `diff`ing the generated file with the file generated by the unmodified code. Details on why this first patch is necessary can be found in its commit message.

The second patch makes the Perl API forward compatible with any new hooks added to Atheme and is outlined in more detail in its commit message.