### PR TITLE
Stylistic edits

### DIFF
--- a/include/flags.h
+++ b/include/flags.h
@@ -36,9 +36,9 @@ typedef struct gflags {
 	unsigned int value;
 } gflags_t;
 
-E struct gflags mu_flags[];
-E struct gflags mc_flags[];
-E struct gflags soper_flags[];
+E gflags_t mu_flags[];
+E gflags_t mc_flags[];
+E gflags_t soper_flags[];
 
 E char *gflags_tostr(gflags_t *gflags, unsigned int flags);
 E bool gflags_fromstr(gflags_t *gflags, const char *f, unsigned int *res);

--- a/libathemecore/cidr.c
+++ b/libathemecore/cidr.c
@@ -368,7 +368,8 @@ match_cidr(const char *s1, const char *s2)
 
 int valid_ip_or_mask(const char *src)
 {
-	char ipaddr[HOSTLEN + 6], buf[IN6ADDRSZ];
+	char ipaddr[HOSTLEN + 6];
+	u_char buf[IN6ADDRSZ];
 	char *mask, *end;
 	unsigned long cidrlen;
 

--- a/libathemecore/flags.c
+++ b/libathemecore/flags.c
@@ -52,7 +52,7 @@ struct flags_table chanacs_flags[256] = {
 	['e'] = {CA_EXEMPT, 0, true,     "exempt"},
 };
 
-struct gflags mu_flags[] = {
+gflags_t mu_flags[] = {
 	{ 'h', MU_HOLD },
 	{ 'n', MU_NEVEROP },
 	{ 'o', MU_NOOP },
@@ -72,7 +72,7 @@ struct gflags mu_flags[] = {
 	{ 0, 0 },
 };
 
-struct gflags mc_flags[] = {
+gflags_t mc_flags[] = {
 	{ 'h', MC_HOLD },
 	{ 'o', MC_NOOP },
 	{ 'l', MC_LIMITFLAGS },
@@ -89,7 +89,7 @@ struct gflags mc_flags[] = {
 	{ 0, 0 },
 };
 
-struct gflags soper_flags[] = {
+gflags_t soper_flags[] = {
 	{ 'c', SOPER_CONF },
 	{ 0, 0 },
 };

--- a/modules/groupserv/groupserv.h
+++ b/modules/groupserv/groupserv.h
@@ -29,7 +29,7 @@ mowgli_list_t * (*myentity_get_membership_list)(myentity_t *mu);
 const char * (*mygroup_founder_names)(mygroup_t *mg);
 void (*remove_group_chanacs)(mygroup_t *mg);
 
-struct gflags *ga_flags;
+gflags_t *ga_flags;
 
 groupserv_config_t *gs_config;
 

--- a/modules/groupserv/main/groupserv.c
+++ b/modules/groupserv/main/groupserv.c
@@ -5,7 +5,7 @@
 #include "atheme.h"
 #include "groupserv_main.h"
 
-struct gflags ga_flags[] = {
+gflags_t ga_flags[] = {
 	{ 'F', GA_FOUNDER },
 	{ 'f', GA_FLAGS },
 	{ 's', GA_SET },
@@ -18,7 +18,7 @@ struct gflags ga_flags[] = {
 	{ 0, 0 }
 };
 
-struct gflags mg_flags[] = {
+gflags_t mg_flags[] = {
 	{ 'r', MG_REGNOLIMIT },
 	{ 'a', MG_ACSNOLIMIT },
 	{ 'o', MG_OPEN },

--- a/modules/groupserv/main/groupserv_main.h
+++ b/modules/groupserv/main/groupserv_main.h
@@ -42,8 +42,8 @@ E const char *mygroup_founder_names(mygroup_t *mg);
 E service_t *groupsvs;
 E mowgli_list_t gs_cmdtree;
 E mowgli_list_t conf_gs_table;
-E struct gflags ga_flags[];
-E struct gflags mg_flags[];
+E gflags_t ga_flags[];
+E gflags_t mg_flags[];
 
 
 


### PR DESCRIPTION
* Replace all remaining uses of `struct gflags` with `gflags_t` for consistency
* Declare a buffer in `cidr.c` as unsigned to suppress a type warning when compiled with clang