### PR TITLE
Avoiding conditional directives that split up parts of statements.

### DIFF
--- a/modules/crypto/ircservices.c
+++ b/modules/crypto/ircservices.c
@@ -91,14 +91,16 @@ static int encrypt_in_place(char *buf, int size)
 static int check_password(const char *plaintext, const char *password)
 {
     char buf[BUFSIZE];
+    int cmp;
 
     if (myencrypt(plaintext, strlen(plaintext), buf, sizeof(buf)) < 0)
         return -1;
 #ifdef ENCRYPT_MD5
-    if (strcmp(buf, password) == 0)
+    cmp = strcmp(buf, password) == 0;
 #else
-    if (0)
+    cmp = 0;
 #endif
+    if (cmp)
         return 1;
     else
         return 0;


### PR DESCRIPTION
  A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

    https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
    https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.