### PR TITLE
protocol/inspircd: Only set hideoper mode on oper pseudoclients

### DIFF
--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -367,9 +367,10 @@ static void inspircd_introduce_nick(user_t *u)
 {
 	/* :penguin.omega.org.za UID 497AAAAAB 1188302517 OperServ 127.0.0.1 127.0.0.1 OperServ +s 127.0.0.1 :Operator Server */
 	const char *umode = user_get_umodestr(u);
+	const bool send_oper = (is_ircop(u) && !has_servprotectmod);
 
-	sts(":%s UID %s %lu %s %s %s %s 0.0.0.0 %lu %s%s%s%s :%s", me.numeric, u->uid, (unsigned long)u->ts, u->nick, u->host, u->host, u->user, (unsigned long)u->ts, umode, has_hideopermod ? "H" : "", has_hidechansmod ? "I" : "", has_servprotectmod ? "k" : "", u->gecos);
-	if (is_ircop(u) && !has_servprotectmod)
+	sts(":%s UID %s %lu %s %s %s %s 0.0.0.0 %lu %s%s%s%s :%s", me.numeric, u->uid, (unsigned long)u->ts, u->nick, u->host, u->host, u->user, (unsigned long)u->ts, umode, (send_oper && has_hideopermod) ? "H" : "", has_hidechansmod ? "I" : "", has_servprotectmod ? "k" : "", u->gecos);
+	if (send_oper)
 		sts(":%s OPERTYPE Service", u->uid);
 }
 


### PR DESCRIPTION
This fixes an issue when Atheme is used with an InspIRCd network with the hideoper module loaded. InspIRCd adjusts the number of online opers shown in reply to LUSERS according to the number of hidden opers (+H clients). This breaks if non-oper clients have the (otherwise oper-only) hideoper mode set. (Plus it also does not make much sense to set the hideoper mode on non-opers.)

This patch changes the protocol module so that the hideoper mode is only set on pseudoclients which are also opered.