### PR TITLE
Move the vendor field to a compile time macro

### DIFF
--- a/configure
+++ b/configure
@@ -4832,6 +4832,10 @@ VERSION=7.2.6
 
 
 
+$as_echo "#define VENDOR_STRING \"Atheme Development Group <http://atheme.github.io>\"" >>confdefs.h
+
+
+
 cat >>confdefs.h <<_ACEOF
 #define PACKAGE "$PACKAGE"
 _ACEOF

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,8 @@ dnl Automake compatibility. --nenolod
 AC_SUBST([PACKAGE], [AC_PACKAGE_TARNAME])
 AC_SUBST([VERSION], [AC_PACKAGE_VERSION])
 
+AC_DEFINE(VENDOR_STRING, "Atheme Development Group <http://atheme.github.io>", [Vendor and URL for modules's "vendor" field])
+
 AC_DEFINE_UNQUOTED(PACKAGE, "$PACKAGE", [Name of package])
 AC_DEFINE_UNQUOTED(VERSION, "$VERSION", [Version number of package])
 

--- a/include/sysconf.h.in
+++ b/include/sysconf.h.in
@@ -228,6 +228,9 @@
 #endif
 
 
+/* Vendor and URL for modules's "vendor" field */
+#undef VENDOR_STRING
+
 /* Version number of package */
 #undef VERSION
 

--- a/modules/auth/dummy.c
+++ b/modules/auth/dummy.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"auth/dummy", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static bool dummy_auth_user(myuser_t *mu, const char *password)

--- a/modules/auth/ldap.c
+++ b/modules/auth/ldap.c
@@ -28,7 +28,7 @@
 
 #include <ldap.h>
 
-DECLARE_MODULE_V1("auth/ldap", false, _modinit, _moddeinit, PACKAGE_STRING, "Atheme Development Group <http://www.atheme.org>");
+DECLARE_MODULE_V1("auth/ldap", false, _modinit, _moddeinit, PACKAGE_STRING, VENDOR_STRING);
 
 mowgli_list_t conf_ldap_table;
 struct

--- a/modules/backend/corestorage.c
+++ b/modules/backend/corestorage.c
@@ -22,7 +22,7 @@ DECLARE_MODULE_V1
 (
 	"backend/corestorage", true, _modinit, NULL,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 unsigned int dbv;

--- a/modules/backend/flatfile.c
+++ b/modules/backend/flatfile.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"backend/flatfile", true, _modinit, NULL,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 /* database versions */

--- a/modules/backend/opensex.c
+++ b/modules/backend/opensex.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"backend/opensex", true, _modinit, NULL,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 typedef struct opensex_ {

--- a/modules/botserv/help.c
+++ b/modules/botserv/help.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"botserv/help", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void bs_cmd_help(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/botserv/info.c
+++ b/modules/botserv/info.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"botserv/info", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://atheme.org/>"
+	VENDOR_STRING
 );
 
 static void bs_cmd_info(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/botserv/set_fantasy.c
+++ b/modules/botserv/set_fantasy.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"botserv/set_fantasy", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **bs_set_cmdtree;

--- a/modules/botserv/set_nobot.c
+++ b/modules/botserv/set_nobot.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"botserv/set_nobot", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **bs_set_cmdtree;

--- a/modules/botserv/set_private.c
+++ b/modules/botserv/set_private.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"botserv/set_private", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **bs_set_cmdtree;

--- a/modules/chanfix/main.c
+++ b/modules/chanfix/main.c
@@ -9,7 +9,7 @@ DECLARE_MODULE_V1
 (
 	"chanfix/main", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 service_t *chanfix;

--- a/modules/chanserv/access.c
+++ b/modules/chanserv/access.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/access", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_access(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/akick.c
+++ b/modules/chanserv/akick.c
@@ -20,7 +20,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/akick", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 command_t cs_akick = { "AKICK", N_("Manipulates a channel's AKICK list."),

--- a/modules/chanserv/antiflood.c
+++ b/modules/chanserv/antiflood.c
@@ -24,7 +24,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/antiflood", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org/>"
+	VENDOR_STRING
 );
 
 static time_t antiflood_msg_time = 60;

--- a/modules/chanserv/ban.c
+++ b/modules/chanserv/ban.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/ban", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_ban(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/clear.c
+++ b/modules/chanserv/clear.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/clear", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_clear(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/clear_akicks.c
+++ b/modules/chanserv/clear_akicks.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/clear_akicks", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_clear_akicks(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/clear_bans.c
+++ b/modules/chanserv/clear_bans.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/clear_bans", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_clear_bans(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/clear_flags.c
+++ b/modules/chanserv/clear_flags.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/clear_flags", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_clear_flags(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/clear_users.c
+++ b/modules/chanserv/clear_users.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/clear_users", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_clear_users(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/clone.c
+++ b/modules/chanserv/clone.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/clone", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://atheme.github.io>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_clone(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/close.c
+++ b/modules/chanserv/close.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/close", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_close(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/count.c
+++ b/modules/chanserv/count.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/count", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_count(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/drop.c
+++ b/modules/chanserv/drop.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/drop", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_drop(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/fflags.c
+++ b/modules/chanserv/fflags.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/fflags", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_fflags(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/flags.c
+++ b/modules/chanserv/flags.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/flags", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_flags(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/ftransfer.c
+++ b/modules/chanserv/ftransfer.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/ftransfer", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_ftransfer(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/getkey.c
+++ b/modules/chanserv/getkey.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/getkey", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_getkey(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/halfop.c
+++ b/modules/chanserv/halfop.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/halfop", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_halfop(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/help.c
+++ b/modules/chanserv/help.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/help", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_help(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/hold.c
+++ b/modules/chanserv/hold.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/hold", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_hold(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/info.c
+++ b/modules/chanserv/info.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/info", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_info(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/invite.c
+++ b/modules/chanserv/invite.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/invite", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_invite(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/kick.c
+++ b/modules/chanserv/kick.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/kick", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_kick(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/list.c
+++ b/modules/chanserv/list.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/list", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_list(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/main.c
+++ b/modules/chanserv/main.c
@@ -15,7 +15,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/main", true, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_join(hook_channel_joinpart_t *hdata);

--- a/modules/chanserv/mark.c
+++ b/modules/chanserv/mark.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/mark", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_mark(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/op.c
+++ b/modules/chanserv/op.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/op", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_op(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/owner.c
+++ b/modules/chanserv/owner.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/owner", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_owner(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/protect.c
+++ b/modules/chanserv/protect.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/protect", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_protect(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/quiet.c
+++ b/modules/chanserv/quiet.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/quiet", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_quiet(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/recover.c
+++ b/modules/chanserv/recover.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/recover", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_recover(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/register.c
+++ b/modules/chanserv/register.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/register", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 unsigned int ratelimit_count = 0;

--- a/modules/chanserv/set.c
+++ b/modules/chanserv/set.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 void _modinit(module_t *m)

--- a/modules/chanserv/set_core.c
+++ b/modules/chanserv/set_core.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_core", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_help_set(sourceinfo_t *si, const char *subcmd);

--- a/modules/chanserv/set_email.c
+++ b/modules/chanserv/set_email.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_email", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_set_email(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/set_entrymsg.c
+++ b/modules/chanserv/set_entrymsg.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_entrymsg", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_set_entrymsg(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/set_fantasy.c
+++ b/modules/chanserv/set_fantasy.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_fantasy", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_set_fantasy_config_ready(void *unused);

--- a/modules/chanserv/set_gameserv.c
+++ b/modules/chanserv/set_gameserv.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_gameserv", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_set_gameserv(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/set_guard.c
+++ b/modules/chanserv/set_guard.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_guard", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_set_guard_config_ready(void *unused);

--- a/modules/chanserv/set_keeptopic.c
+++ b/modules/chanserv/set_keeptopic.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_keeptopic", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_set_keeptopic(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/set_limitflags.c
+++ b/modules/chanserv/set_limitflags.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_limitflags", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_set_limitflags(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/set_mlock.c
+++ b/modules/chanserv/set_mlock.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_mlock", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_set_mlock(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/set_prefix.c
+++ b/modules/chanserv/set_prefix.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_prefix", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_set_prefix_config_ready(void *unused);

--- a/modules/chanserv/set_private.c
+++ b/modules/chanserv/set_private.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_private", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_set_private(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/set_property.c
+++ b/modules/chanserv/set_property.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_property", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_set_property(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/set_pubacl.c
+++ b/modules/chanserv/set_pubacl.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_pubacl", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_set_pubacl(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/set_restricted.c
+++ b/modules/chanserv/set_restricted.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_restricted", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_set_restricted(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/set_secure.c
+++ b/modules/chanserv/set_secure.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_secure", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_set_secure(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/set_topiclock.c
+++ b/modules/chanserv/set_topiclock.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_topiclock", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_set_topiclock(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/set_url.c
+++ b/modules/chanserv/set_url.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_url", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_set_url(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/set_verbose.c
+++ b/modules/chanserv/set_verbose.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/set_verbose", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_set_verbose(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/status.c
+++ b/modules/chanserv/status.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/status", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_status(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/successor_acl.c
+++ b/modules/chanserv/successor_acl.c
@@ -11,7 +11,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/successor_acl", true, _modinit, NULL,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static unsigned int successor_flag = 0;

--- a/modules/chanserv/sync.c
+++ b/modules/chanserv/sync.c
@@ -11,7 +11,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/sync", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_sync(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/taxonomy.c
+++ b/modules/chanserv/taxonomy.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/taxonomy", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_taxonomy(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/template.c
+++ b/modules/chanserv/template.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/template", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void list_generic_flags(sourceinfo_t *si);

--- a/modules/chanserv/topic.c
+++ b/modules/chanserv/topic.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/topic", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_topic(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/unban_self.c
+++ b/modules/chanserv/unban_self.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/unban_self", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_unban(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/version.c
+++ b/modules/chanserv/version.c
@@ -5,7 +5,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/version", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_version(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/voice.c
+++ b/modules/chanserv/voice.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/voice", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_voice(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/why.c
+++ b/modules/chanserv/why.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/why", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void cs_cmd_why(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/chanserv/xop.c
+++ b/modules/chanserv/xop.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"chanserv/xop", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 /* the individual command stuff, now that we've reworked, hardcode ;) --w00t */

--- a/modules/crypto/pbkdf2.c
+++ b/modules/crypto/pbkdf2.c
@@ -22,7 +22,7 @@
 
 #ifdef HAVE_OPENSSL
 
-DECLARE_MODULE_V1("crypto/pbkdf2", false, _modinit, _moddeinit, PACKAGE_VERSION, "Atheme Development Group <http://www.atheme.org>");
+DECLARE_MODULE_V1("crypto/pbkdf2", false, _modinit, _moddeinit, PACKAGE_VERSION, VENDOR_STRING);
 
 #include <openssl/evp.h>
 #include <openssl/sha.h>

--- a/modules/crypto/posix.c
+++ b/modules/crypto/posix.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"crypto/posix", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 #if defined(HAVE_CRYPT)

--- a/modules/crypto/rawmd5.c
+++ b/modules/crypto/rawmd5.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"crypto/rawmd5", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 #define RAWMD5_PREFIX "$rawmd5$"

--- a/modules/crypto/rawsha1.c
+++ b/modules/crypto/rawsha1.c
@@ -17,7 +17,7 @@ DECLARE_MODULE_V1
 (
 	"crypto/rawsha1", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 #define RAWSHA1_PREFIX "$rawsha1$"

--- a/modules/exttarget/chanacs.c
+++ b/modules/exttarget/chanacs.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"exttarget/chanacs", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static mowgli_patricia_t **exttarget_tree = NULL;

--- a/modules/exttarget/channel.c
+++ b/modules/exttarget/channel.c
@@ -11,7 +11,7 @@ DECLARE_MODULE_V1
 (
 	"exttarget/channel", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static mowgli_patricia_t **exttarget_tree = NULL;

--- a/modules/exttarget/main.c
+++ b/modules/exttarget/main.c
@@ -11,7 +11,7 @@ DECLARE_MODULE_V1
 (
 	"exttarget/main", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t *exttarget_tree = NULL;

--- a/modules/exttarget/oper.c
+++ b/modules/exttarget/oper.c
@@ -11,7 +11,7 @@ DECLARE_MODULE_V1
 (
 	"exttarget/oper", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static mowgli_patricia_t **exttarget_tree = NULL;

--- a/modules/exttarget/registered.c
+++ b/modules/exttarget/registered.c
@@ -11,7 +11,7 @@ DECLARE_MODULE_V1
 (
 	"exttarget/registered", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static mowgli_patricia_t **exttarget_tree = NULL;

--- a/modules/exttarget/server.c
+++ b/modules/exttarget/server.c
@@ -11,7 +11,7 @@ DECLARE_MODULE_V1
 (
 	"exttarget/server", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static mowgli_patricia_t **exttarget_tree = NULL;

--- a/modules/gameserv/dice.c
+++ b/modules/gameserv/dice.c
@@ -13,7 +13,7 @@
 
 #include <math.h>
 
-DECLARE_MODULE_V1("gameserv/dice", false, _modinit, _moddeinit, PACKAGE_STRING, "Atheme Development Group <http://www.atheme.org>");
+DECLARE_MODULE_V1("gameserv/dice", false, _modinit, _moddeinit, PACKAGE_STRING, VENDOR_STRING);
 
 static void command_dice(sourceinfo_t *si, int parc, char *parv[]);
 static void command_calc(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/gameserv/eightball.c
+++ b/modules/gameserv/eightball.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"gameserv/eightball", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void command_eightball(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/gameserv/gamecalc.c
+++ b/modules/gameserv/gamecalc.c
@@ -15,7 +15,7 @@ DECLARE_MODULE_V1
 (
 	"gameserv/gamecalc", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void command_wod(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/gameserv/happyfarm.c
+++ b/modules/gameserv/happyfarm.c
@@ -10,7 +10,7 @@
 #include "atheme.h"
 #include "gameserv_common.h"
 
-DECLARE_MODULE_V1("gameserv/happyfarm", false, _modinit, _moddeinit, PACKAGE_STRING, "Atheme Development Group <http://www.atheme.org>");
+DECLARE_MODULE_V1("gameserv/happyfarm", false, _modinit, _moddeinit, PACKAGE_STRING, VENDOR_STRING);
 
 /* Privatedata schema... */
 #define SCHEMA_KEY_HAPPYFARMER		"gameserv:happyfarm:farmer"

--- a/modules/gameserv/help.c
+++ b/modules/gameserv/help.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"gameserv/help", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_help(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/gameserv/lottery.c
+++ b/modules/gameserv/lottery.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"gameserv/lottery", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void command_lottery(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/gameserv/main.c
+++ b/modules/gameserv/main.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"gameserv/main", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 service_t *gs;

--- a/modules/gameserv/namegen.c
+++ b/modules/gameserv/namegen.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"gameserv/namegen", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void command_namegen(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/gameserv/rps.c
+++ b/modules/gameserv/rps.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"gameserv/rps", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void command_rps(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/global/main.c
+++ b/modules/global/main.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"global/main", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 /* global list struct */

--- a/modules/groupserv/acsnolimit.c
+++ b/modules/groupserv/acsnolimit.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/acsnolimit", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_acsnolimit(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/drop.c
+++ b/modules/groupserv/drop.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/drop", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_drop(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/fdrop.c
+++ b/modules/groupserv/fdrop.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/fdrop", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_fdrop(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/fflags.c
+++ b/modules/groupserv/fflags.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/fflags", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_fflags(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/flags.c
+++ b/modules/groupserv/flags.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/flags", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_flags(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/help.c
+++ b/modules/groupserv/help.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/help", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_help(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/info.c
+++ b/modules/groupserv/info.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/info", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_info(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/invite.c
+++ b/modules/groupserv/invite.c
@@ -17,7 +17,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/invite", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_invite(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/join.c
+++ b/modules/groupserv/join.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/join", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_join(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/list.c
+++ b/modules/groupserv/list.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/list", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_list(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/listchans.c
+++ b/modules/groupserv/listchans.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/listchans", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_listchans(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/main/main.c
+++ b/modules/groupserv/main/main.c
@@ -9,7 +9,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/main", MODULE_UNLOAD_CAPABILITY_RELOAD_ONLY, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 service_t *groupsvs;

--- a/modules/groupserv/register.c
+++ b/modules/groupserv/register.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/register", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_register(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/regnolimit.c
+++ b/modules/groupserv/regnolimit.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/regnolimit", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_regnolimit(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/set.c
+++ b/modules/groupserv/set.c
@@ -15,7 +15,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/set", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_help_set(sourceinfo_t *si, const char *subcmd);

--- a/modules/groupserv/set_channel.c
+++ b/modules/groupserv/set_channel.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/set_channel", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_set_channel(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/set_description.c
+++ b/modules/groupserv/set_description.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/set_description", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_set_description(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/set_email.c
+++ b/modules/groupserv/set_email.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/set_email", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_set_email(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/set_groupname.c
+++ b/modules/groupserv/set_groupname.c
@@ -15,7 +15,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/set_groupname", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_set_groupname(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/set_joinflags.c
+++ b/modules/groupserv/set_joinflags.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/set_joinflags", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_set_joinflags(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/set_open.c
+++ b/modules/groupserv/set_open.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/set_open", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_set_open(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/set_public.c
+++ b/modules/groupserv/set_public.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/set_public", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_set_public(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/groupserv/set_url.c
+++ b/modules/groupserv/set_url.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"groupserv/set_url", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void gs_cmd_set_url(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/helpserv/helpme.c
+++ b/modules/helpserv/helpme.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"helpserv/helpme", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 unsigned int ratelimit_count = 0;

--- a/modules/helpserv/main.c
+++ b/modules/helpserv/main.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"helpserv/main", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 service_t *helpserv;

--- a/modules/helpserv/services.c
+++ b/modules/helpserv/services.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"helpserv/services", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void helpserv_cmd_services(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/hostserv/group.c
+++ b/modules/hostserv/group.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"hostserv/group", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void hs_cmd_group(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/hostserv/help.c
+++ b/modules/hostserv/help.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"hostserv/help", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void hs_cmd_help(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/hostserv/main.c
+++ b/modules/hostserv/main.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"hostserv/main", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void on_user_identify(user_t *u);

--- a/modules/hostserv/onoff.c
+++ b/modules/hostserv/onoff.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"hostserv/onoff", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void hs_cmd_on(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/hostserv/vhost.c
+++ b/modules/hostserv/vhost.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"hostserv/vhost", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void hs_cmd_vhost(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/hostserv/vhostnick.c
+++ b/modules/hostserv/vhostnick.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"hostserv/vhostnick", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void hs_cmd_vhostnick(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/infoserv/main.c
+++ b/modules/infoserv/main.c
@@ -18,7 +18,7 @@ DECLARE_MODULE_V1
 (
 	"infoserv/main", true, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 struct logoninfo_ {

--- a/modules/memoserv/delete.c
+++ b/modules/memoserv/delete.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"memoserv/delete", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ms_cmd_delete(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/memoserv/forward.c
+++ b/modules/memoserv/forward.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"memoserv/forward", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ms_cmd_forward(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/memoserv/help.c
+++ b/modules/memoserv/help.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"memoserv/help", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ms_cmd_help(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/memoserv/ignore.c
+++ b/modules/memoserv/ignore.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"memoserv/ignore", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ms_cmd_ignore(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/memoserv/list.c
+++ b/modules/memoserv/list.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"memoserv/list", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ms_cmd_list(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/memoserv/main.c
+++ b/modules/memoserv/main.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"memoserv/main", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void on_user_identify(user_t *u);

--- a/modules/memoserv/read.c
+++ b/modules/memoserv/read.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"memoserv/read", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 #define MAX_READ_AT_ONCE 5

--- a/modules/memoserv/send.c
+++ b/modules/memoserv/send.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"memoserv/send", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ms_cmd_send(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/memoserv/sendall.c
+++ b/modules/memoserv/sendall.c
@@ -11,7 +11,7 @@ DECLARE_MODULE_V1
 (
 	"memoserv/sendall", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ms_cmd_sendall(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/memoserv/sendgroup.c
+++ b/modules/memoserv/sendgroup.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"memoserv/sendgroup", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ms_cmd_sendgroup(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/memoserv/sendops.c
+++ b/modules/memoserv/sendops.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"memoserv/sendops", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ms_cmd_sendops(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/misc/canon_gmail.c
+++ b/modules/misc/canon_gmail.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"misc/canon_gmail", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void canonicalize_gmail(char email[EMAILLEN + 1], void *user_data)

--- a/modules/misc/httpd.c
+++ b/modules/misc/httpd.c
@@ -16,7 +16,7 @@ DECLARE_MODULE_V1
 (
 	"misc/httpd", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 connection_t *listener;

--- a/modules/nickserv/access.c
+++ b/modules/nickserv/access.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/access", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_access(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/cracklib.c
+++ b/modules/nickserv/cracklib.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/cracklib", false, _modinit, _moddeinit,
         PACKAGE_STRING,
-        "Atheme Development Group <http://www.atheme.org>"
+        VENDOR_STRING
 );
 
 bool cracklib_warn;

--- a/modules/nickserv/drop.c
+++ b/modules/nickserv/drop.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/drop", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_drop(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/enforce.c
+++ b/modules/nickserv/enforce.c
@@ -19,7 +19,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/enforce",false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 typedef struct {

--- a/modules/nickserv/freeze.c
+++ b/modules/nickserv/freeze.c
@@ -15,7 +15,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/freeze", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_freeze(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/ghost.c
+++ b/modules/nickserv/ghost.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/ghost", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_ghost(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/group.c
+++ b/modules/nickserv/group.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/group", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_group(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/help.c
+++ b/modules/nickserv/help.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/help", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_help(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/hold.c
+++ b/modules/nickserv/hold.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/hold", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_hold(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/identify.c
+++ b/modules/nickserv/identify.c
@@ -21,7 +21,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/" COMMAND_LC, false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_login(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/info.c
+++ b/modules/nickserv/info.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/info", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_info(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/info_lastquit.c
+++ b/modules/nickserv/info_lastquit.c
@@ -11,7 +11,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/info_lastquit", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void user_delete_info_hook(hook_user_delete_t *hdata)

--- a/modules/nickserv/list.c
+++ b/modules/nickserv/list.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/list", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_list(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/listchans.c
+++ b/modules/nickserv/listchans.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/listchans", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_listchans(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/listgroups.c
+++ b/modules/nickserv/listgroups.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/listgroups", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_listgroups(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/listmail.c
+++ b/modules/nickserv/listmail.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/listmail", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_listmail(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/listownmail.c
+++ b/modules/nickserv/listownmail.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/listownmail", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_listownmail(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/logout.c
+++ b/modules/nickserv/logout.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/logout", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_logout(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/main.c
+++ b/modules/nickserv/main.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/main", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 struct

--- a/modules/nickserv/mark.c
+++ b/modules/nickserv/mark.c
@@ -17,7 +17,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/mark", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_mark(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/multimark.c
+++ b/modules/nickserv/multimark.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/multimark", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_multimark(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/register.c
+++ b/modules/nickserv/register.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/register", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 unsigned int ratelimit_count = 0;

--- a/modules/nickserv/regnolimit.c
+++ b/modules/nickserv/regnolimit.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/regnolimit", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_regnolimit(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/resetpass.c
+++ b/modules/nickserv/resetpass.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/resetpass", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_resetpass(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/restrict.c
+++ b/modules/nickserv/restrict.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/restrict", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_restrict(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/return.c
+++ b/modules/nickserv/return.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/return", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_return(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/sendpass.c
+++ b/modules/nickserv/sendpass.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/sendpass", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_sendpass(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/sendpass_user.c
+++ b/modules/nickserv/sendpass_user.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/sendpass_user", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_sendpass(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/set.c
+++ b/modules/nickserv/set.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 void _modinit(module_t *m)

--- a/modules/nickserv/set_accountname.c
+++ b/modules/nickserv/set_accountname.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set_accountname", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **ns_set_cmdtree;

--- a/modules/nickserv/set_core.c
+++ b/modules/nickserv/set_core.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set_core", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_help_set(sourceinfo_t *si, const char *subcmd);

--- a/modules/nickserv/set_email.c
+++ b/modules/nickserv/set_email.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set_email", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **ns_set_cmdtree;

--- a/modules/nickserv/set_emailmemos.c
+++ b/modules/nickserv/set_emailmemos.c
@@ -16,7 +16,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set_emailmemos", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **ns_set_cmdtree;

--- a/modules/nickserv/set_enforcetime.c
+++ b/modules/nickserv/set_enforcetime.c
@@ -11,7 +11,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set_enforcetime",false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **ns_set_cmdtree;

--- a/modules/nickserv/set_hidemail.c
+++ b/modules/nickserv/set_hidemail.c
@@ -16,7 +16,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set_hidemail", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **ns_set_cmdtree;

--- a/modules/nickserv/set_language.c
+++ b/modules/nickserv/set_language.c
@@ -16,7 +16,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set_language", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **ns_set_cmdtree;

--- a/modules/nickserv/set_nevergroup.c
+++ b/modules/nickserv/set_nevergroup.c
@@ -16,7 +16,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set_nevergroup", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **ns_set_cmdtree;

--- a/modules/nickserv/set_neverop.c
+++ b/modules/nickserv/set_neverop.c
@@ -16,7 +16,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set_neverop", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **ns_set_cmdtree;

--- a/modules/nickserv/set_nogreet.c
+++ b/modules/nickserv/set_nogreet.c
@@ -16,7 +16,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set_nogreet", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **ns_set_cmdtree;

--- a/modules/nickserv/set_nomemo.c
+++ b/modules/nickserv/set_nomemo.c
@@ -15,7 +15,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set_nomemo", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **ns_set_cmdtree;

--- a/modules/nickserv/set_noop.c
+++ b/modules/nickserv/set_noop.c
@@ -16,7 +16,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set_noop", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **ns_set_cmdtree;

--- a/modules/nickserv/set_password.c
+++ b/modules/nickserv/set_password.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set_password", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **ns_set_cmdtree;

--- a/modules/nickserv/set_private.c
+++ b/modules/nickserv/set_private.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set_private", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **ns_set_cmdtree;

--- a/modules/nickserv/set_privmsg.c
+++ b/modules/nickserv/set_privmsg.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set_privmsg", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **ns_set_cmdtree;

--- a/modules/nickserv/set_property.c
+++ b/modules/nickserv/set_property.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set_property", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **ns_set_cmdtree;

--- a/modules/nickserv/set_quietchg.c
+++ b/modules/nickserv/set_quietchg.c
@@ -16,7 +16,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/set_quietchg", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_patricia_t **ns_set_cmdtree;

--- a/modules/nickserv/setpass.c
+++ b/modules/nickserv/setpass.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/setpass", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void clear_setpass_key(user_t *u);

--- a/modules/nickserv/status.c
+++ b/modules/nickserv/status.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/status", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_acc(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/taxonomy.c
+++ b/modules/nickserv/taxonomy.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/taxonomy", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_taxonomy(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/vacation.c
+++ b/modules/nickserv/vacation.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/vacation", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_vacation(sourceinfo_t *si, int parc, char *parv[])

--- a/modules/nickserv/verify.c
+++ b/modules/nickserv/verify.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/verify", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void ns_cmd_verify(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/nickserv/vhost.c
+++ b/modules/nickserv/vhost.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"nickserv/vhost", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void vhost_on_identify(user_t *u);

--- a/modules/operserv/akill.c
+++ b/modules/operserv/akill.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/akill", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_akill_newuser(hook_user_nick_t *data);

--- a/modules/operserv/clones.c
+++ b/modules/operserv/clones.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/clones", true, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 #define CLONESDB_VERSION	3

--- a/modules/operserv/greplog.c
+++ b/modules/operserv/greplog.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/greplog", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_greplog(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/help.c
+++ b/modules/operserv/help.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/help", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_help(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/identify.c
+++ b/modules/operserv/identify.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/identify", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_identify(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/ignore.c
+++ b/modules/operserv/ignore.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/ignore", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_ignore(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/info.c
+++ b/modules/operserv/info.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/info", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_info(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/inject.c
+++ b/modules/operserv/inject.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/inject", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_inject(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/jupe.c
+++ b/modules/operserv/jupe.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/jupe", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_jupe(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/main.c
+++ b/modules/operserv/main.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/main", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 service_t *opersvs = NULL;

--- a/modules/operserv/mode.c
+++ b/modules/operserv/mode.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/mode", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_mode(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/modinspect.c
+++ b/modules/operserv/modinspect.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/modinspect", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_modinspect(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/modlist.c
+++ b/modules/operserv/modlist.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/modlist", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_modlist(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/modload.c
+++ b/modules/operserv/modload.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/modload", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_modload(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/modreload.c
+++ b/modules/operserv/modreload.c
@@ -7,7 +7,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/modreload", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_modreload(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/modunload.c
+++ b/modules/operserv/modunload.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/modunload", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_modunload(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/noop.c
+++ b/modules/operserv/noop.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/noop", true, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 typedef struct noop_ noop_t;

--- a/modules/operserv/override.c
+++ b/modules/operserv/override.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/override", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_override(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/rakill.c
+++ b/modules/operserv/rakill.c
@@ -17,7 +17,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/rakill", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_rakill(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/raw.c
+++ b/modules/operserv/raw.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/raw", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_raw(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/readonly.c
+++ b/modules/operserv/readonly.c
@@ -11,7 +11,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/readonly", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_readonly(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/rehash.c
+++ b/modules/operserv/rehash.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/rehash", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_rehash(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/restart.c
+++ b/modules/operserv/restart.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/restart", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_restart(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/rmatch.c
+++ b/modules/operserv/rmatch.c
@@ -17,7 +17,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/rmatch", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_rmatch(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/rwatch.c
+++ b/modules/operserv/rwatch.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/rwatch", true, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void rwatch_newuser(hook_user_nick_t *data);

--- a/modules/operserv/set.c
+++ b/modules/operserv/set.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/set", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_help_set(sourceinfo_t *si, const char *subcmd);

--- a/modules/operserv/sgline.c
+++ b/modules/operserv/sgline.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/sgline", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_sgline_newuser(hook_user_nick_t *data);

--- a/modules/operserv/shutdown.c
+++ b/modules/operserv/shutdown.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/shutdown", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_shutdown(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/soper.c
+++ b/modules/operserv/soper.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/soper", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_soper(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/specs.c
+++ b/modules/operserv/specs.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/specs", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_specs(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/sqline.c
+++ b/modules/operserv/sqline.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/sqline", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_sqline_newuser(hook_user_nick_t *data);

--- a/modules/operserv/update.c
+++ b/modules/operserv/update.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/update", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_update(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/operserv/uptime.c
+++ b/modules/operserv/uptime.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"operserv/uptime", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void os_cmd_uptime(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/protocol/asuka.c
+++ b/modules/protocol/asuka.c
@@ -13,7 +13,7 @@
 #include "pmodule.h"
 #include "protocol/asuka.h"
 
-DECLARE_MODULE_V1("protocol/asuka", true, _modinit, NULL, PACKAGE_STRING, "Atheme Development Group <http://www.atheme.org>");
+DECLARE_MODULE_V1("protocol/asuka", true, _modinit, NULL, PACKAGE_STRING, VENDOR_STRING);
 
 /* *INDENT-OFF* */
 

--- a/modules/protocol/bahamut.c
+++ b/modules/protocol/bahamut.c
@@ -12,7 +12,7 @@
 #include "pmodule.h"
 #include "protocol/bahamut.h"
 
-DECLARE_MODULE_V1("protocol/bahamut", true, _modinit, NULL, PACKAGE_STRING, "Atheme Development Group <http://www.atheme.org>");
+DECLARE_MODULE_V1("protocol/bahamut", true, _modinit, NULL, PACKAGE_STRING, VENDOR_STRING);
 
 /* *INDENT-OFF* */
 

--- a/modules/protocol/base36uid.c
+++ b/modules/protocol/base36uid.c
@@ -23,7 +23,7 @@
 
 #include "atheme.h"
 
-DECLARE_MODULE_V1("protocol/base36uid", true, _modinit, NULL, PACKAGE_STRING, "Atheme Development Group <http://www.atheme.org>");
+DECLARE_MODULE_V1("protocol/base36uid", true, _modinit, NULL, PACKAGE_STRING, VENDOR_STRING);
 
 static char new_uid[10]; /* allow for \0 */
 static unsigned int uindex = 0;

--- a/modules/protocol/charybdis.c
+++ b/modules/protocol/charybdis.c
@@ -12,7 +12,7 @@
 #include "pmodule.h"
 #include "protocol/charybdis.h"
 
-DECLARE_MODULE_V1("protocol/charybdis", true, _modinit, NULL, PACKAGE_STRING, "Atheme Development Group <http://www.atheme.org>");
+DECLARE_MODULE_V1("protocol/charybdis", true, _modinit, NULL, PACKAGE_STRING, VENDOR_STRING);
 
 /* *INDENT-OFF* */
 

--- a/modules/protocol/ircd-seven.c
+++ b/modules/protocol/ircd-seven.c
@@ -13,7 +13,7 @@
 #include "protocol/charybdis.h"
 #include "protocol/ircd-seven.h"
 
-DECLARE_MODULE_V1("protocol/ircd-seven", true, _modinit, NULL, PACKAGE_STRING, "Atheme Development Group <http://www.atheme.org>");
+DECLARE_MODULE_V1("protocol/ircd-seven", true, _modinit, NULL, PACKAGE_STRING, VENDOR_STRING);
 
 /* *INDENT-OFF* */
 

--- a/modules/protocol/ircnet.c
+++ b/modules/protocol/ircnet.c
@@ -13,7 +13,7 @@
 #include "pmodule.h"
 #include "protocol/ircnet.h"
 
-DECLARE_MODULE_V1("protocol/ircnet", true, _modinit, NULL, PACKAGE_STRING, "Atheme Development Group <http://www.atheme.org>");
+DECLARE_MODULE_V1("protocol/ircnet", true, _modinit, NULL, PACKAGE_STRING, VENDOR_STRING);
 
 /* *INDENT-OFF* */
 

--- a/modules/protocol/mixin_nohalfops.c
+++ b/modules/protocol/mixin_nohalfops.c
@@ -17,7 +17,7 @@ DECLARE_MODULE_V1
 (
 	"protocol/mixin_nohalfops", true, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 bool oldflag;

--- a/modules/protocol/mixin_noholdnick.c
+++ b/modules/protocol/mixin_noholdnick.c
@@ -11,7 +11,7 @@ DECLARE_MODULE_V1
 (
 	"protocol/mixin_noholdnick", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 int oldflag;

--- a/modules/protocol/mixin_noowner.c
+++ b/modules/protocol/mixin_noowner.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"protocol/mixin_noowner", true, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 bool oldflag;

--- a/modules/protocol/mixin_noprotect.c
+++ b/modules/protocol/mixin_noprotect.c
@@ -14,7 +14,7 @@ DECLARE_MODULE_V1
 (
 	"protocol/mixin_noprotect", true, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 bool oldflag;

--- a/modules/protocol/nefarious.c
+++ b/modules/protocol/nefarious.c
@@ -13,7 +13,7 @@
 #include "pmodule.h"
 #include "protocol/nefarious.h"
 
-DECLARE_MODULE_V1("protocol/nefarious", true, _modinit, NULL, PACKAGE_STRING, "Atheme Development Group <http://www.atheme.org>");
+DECLARE_MODULE_V1("protocol/nefarious", true, _modinit, NULL, PACKAGE_STRING, VENDOR_STRING);
 
 /* *INDENT-OFF* */
 

--- a/modules/protocol/ngircd.c
+++ b/modules/protocol/ngircd.c
@@ -10,7 +10,7 @@
 #include "pmodule.h"
 #include "protocol/ngircd.h"
 
-DECLARE_MODULE_V1("protocol/ngircd", true, _modinit, NULL, PACKAGE_STRING, "Atheme Development Group <http://www.atheme.org>");
+DECLARE_MODULE_V1("protocol/ngircd", true, _modinit, NULL, PACKAGE_STRING, VENDOR_STRING);
 
 /* *INDENT-OFF* */
 

--- a/modules/protocol/p10-generic.c
+++ b/modules/protocol/p10-generic.c
@@ -12,7 +12,7 @@
 #include "uplink.h"
 #include "pmodule.h"
 
-DECLARE_MODULE_V1("protocol/p10-generic", true, _modinit, NULL, PACKAGE_STRING, "Atheme Development Group <http://www.atheme.org>");
+DECLARE_MODULE_V1("protocol/p10-generic", true, _modinit, NULL, PACKAGE_STRING, VENDOR_STRING);
 
 static void check_hidehost(user_t *u);
 

--- a/modules/protocol/ratbox.c
+++ b/modules/protocol/ratbox.c
@@ -12,7 +12,7 @@
 #include "pmodule.h"
 #include "protocol/ratbox.h"
 
-DECLARE_MODULE_V1("protocol/ratbox", true, _modinit, NULL, PACKAGE_STRING, "Atheme Development Group <http://www.atheme.org>");
+DECLARE_MODULE_V1("protocol/ratbox", true, _modinit, NULL, PACKAGE_STRING, VENDOR_STRING);
 
 /* *INDENT-OFF* */
 

--- a/modules/protocol/ts6-generic.c
+++ b/modules/protocol/ts6-generic.c
@@ -37,7 +37,7 @@
 #include "uplink.h"
 #include "pmodule.h"
 
-DECLARE_MODULE_V1("protocol/ts6-generic", true, _modinit, NULL, PACKAGE_STRING, "Atheme Development Group <http://www.atheme.org>");
+DECLARE_MODULE_V1("protocol/ts6-generic", true, _modinit, NULL, PACKAGE_STRING, VENDOR_STRING);
 
 static bool use_rserv_support = false;
 static bool use_tb = false;

--- a/modules/protocol/unreal.c
+++ b/modules/protocol/unreal.c
@@ -12,7 +12,7 @@
 #include "pmodule.h"
 #include "protocol/unreal.h"
 
-DECLARE_MODULE_V1("protocol/unreal", true, _modinit, NULL, PACKAGE_STRING, "Atheme Development Group <http://www.atheme.org>");
+DECLARE_MODULE_V1("protocol/unreal", true, _modinit, NULL, PACKAGE_STRING, VENDOR_STRING);
 
 static bool has_protoctl = false;
 static bool use_esvid = false;

--- a/modules/proxyscan/dnsbl.c
+++ b/modules/proxyscan/dnsbl.c
@@ -67,7 +67,7 @@ DECLARE_MODULE_V1
 (
 	"contrib/dnsbl", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_list_t blacklist_list = { NULL, NULL, 0 };

--- a/modules/rpgserv/enable.c
+++ b/modules/rpgserv/enable.c
@@ -8,7 +8,7 @@ DECLARE_MODULE_V1
 (
 	"rpgserv/enable", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void rs_cmd_enable(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/rpgserv/help.c
+++ b/modules/rpgserv/help.c
@@ -8,7 +8,7 @@ DECLARE_MODULE_V1
 (
 	"rpgserv/help", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void rs_cmd_help(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/rpgserv/info.c
+++ b/modules/rpgserv/info.c
@@ -9,7 +9,7 @@ DECLARE_MODULE_V1
 (
 	"rpgserv/info", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void rs_cmd_info(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/rpgserv/list.c
+++ b/modules/rpgserv/list.c
@@ -7,7 +7,7 @@ DECLARE_MODULE_V1
 (
 	"rpgserv/list", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void rs_cmd_list(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/rpgserv/main.c
+++ b/modules/rpgserv/main.c
@@ -8,7 +8,7 @@ DECLARE_MODULE_V1
 (
 	"rpgserv/main", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 service_t *rpgserv;

--- a/modules/rpgserv/search.c
+++ b/modules/rpgserv/search.c
@@ -8,7 +8,7 @@ DECLARE_MODULE_V1
 (
 	"rpgserv/search", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void rs_cmd_search(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/rpgserv/set.c
+++ b/modules/rpgserv/set.c
@@ -9,7 +9,7 @@ DECLARE_MODULE_V1
 (
 	"rpgserv/set", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void rs_cmd_set(sourceinfo_t *si, int parc, char *parv[]);

--- a/modules/saslserv/authcookie.c
+++ b/modules/saslserv/authcookie.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"saslserv/authcookie", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 sasl_mech_register_func_t *regfuncs;

--- a/modules/saslserv/ecdsa-nist256p-challenge.c
+++ b/modules/saslserv/ecdsa-nist256p-challenge.c
@@ -22,7 +22,7 @@ DECLARE_MODULE_V1
 (
 	"saslserv/ecdsa-nist256p-challenge", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 sasl_mech_register_func_t *regfuncs;

--- a/modules/saslserv/external.c
+++ b/modules/saslserv/external.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"saslserv/external", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 sasl_mech_register_func_t *regfuncs;

--- a/modules/saslserv/main.c
+++ b/modules/saslserv/main.c
@@ -13,7 +13,7 @@ DECLARE_MODULE_V1
 (
 	"saslserv/main", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 mowgli_list_t sessions;

--- a/modules/saslserv/plain.c
+++ b/modules/saslserv/plain.c
@@ -12,7 +12,7 @@ DECLARE_MODULE_V1
 (
 	"saslserv/plain", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 sasl_mech_register_func_t *regfuncs;

--- a/modules/scripting/perl/perl_module.c
+++ b/modules/scripting/perl/perl_module.c
@@ -17,7 +17,7 @@ DECLARE_MODULE_V1
 (
 	"scripting/perl", false, _modinit, _moddeinit,
 	"$Id$",
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 /*

--- a/modules/security/cmdperm.c
+++ b/modules/security/cmdperm.c
@@ -20,7 +20,7 @@
 
 #include "atheme.h"
 
-DECLARE_MODULE_V1("security/cmdperm", false, _modinit, _moddeinit, PACKAGE_VERSION, "Atheme Development Group <http://www.atheme.org>");
+DECLARE_MODULE_V1("security/cmdperm", false, _modinit, _moddeinit, PACKAGE_VERSION, VENDOR_STRING);
 
 static bool (*parent_command_authorize)(service_t *svs, sourceinfo_t *si, command_t *c, const char *userlevel) = NULL;
 

--- a/modules/transport/jsonrpc/main.c
+++ b/modules/transport/jsonrpc/main.c
@@ -16,7 +16,7 @@ DECLARE_MODULE_V1
 (
 	"transport/jsonrpc", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void handle_request(connection_t *cptr, void *requestbuf);

--- a/modules/transport/p10.c
+++ b/modules/transport/p10.c
@@ -29,7 +29,7 @@ DECLARE_MODULE_V1
 (
 	"transport/p10", true, _modinit, _moddeinit,
 	PACKAGE_VERSION,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 /* parses a P10 IRC stream */

--- a/modules/transport/rfc1459/main.c
+++ b/modules/transport/rfc1459/main.c
@@ -29,7 +29,7 @@ DECLARE_MODULE_V1
 (
 	"transport/rfc1459", true, _modinit, _moddeinit,
 	PACKAGE_VERSION,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 void _modinit(module_t *m)

--- a/modules/transport/xmlrpc/main.c
+++ b/modules/transport/xmlrpc/main.c
@@ -16,7 +16,7 @@ DECLARE_MODULE_V1
 (
 	"transport/xmlrpc", false, _modinit, _moddeinit,
 	PACKAGE_STRING,
-	"Atheme Development Group <http://www.atheme.org>"
+	VENDOR_STRING
 );
 
 static void handle_request(connection_t *cptr, void *requestbuf);


### PR DESCRIPTION
In the case of http://www.atheme.org going away, change that whole string to an autoconf variable/macro in case the URL changes down the road again. (e.g. get a new domain, add SSL, etc.). Yes I'm aware that AC_INIT has a URL field, but this is more of a full "vendor"-y deal with extra info and not specifically a URL thing so it's probably best to keep it separate and keep AC_INIT's URL field reserved for future use.