### PR TITLE
Protocol patches for Nefarious

### DIFF
--- a/modules/protocol/nefarious.c
+++ b/modules/protocol/nefarious.c
@@ -365,10 +365,18 @@ static void m_nick(sourceinfo_t *si, int parc, char *parv[])
 	{
 		/* -> AB N jilles 1 1137687480 jilles jaguar.test +oiwgrx jilles B]AAAB ABAAE :Jilles Tjoelker */
 		/* -> AB N test4 1 1137690148 jilles jaguar.test +iw B]AAAB ABAAG :Jilles Tjoelker */
-		slog(LG_DEBUG, "m_nick(): new user on `%s': %s", si->s->name, parv[0]);
+
+		/*
+		 * -> Mh N jilles 1 1460435852 jilles 127.0.0.1 +ixCc 1A130C.572B1.6F53B5.8DD3B8.IP 1A130C.572B1.6F53B5.8DD3B8.IP DSBHPW Mhw2O :Real Name
+		 * It looks like the protocol was altered a bit in Nefarious 2 (the current version).
+		 */
+		slog(LG_DEBUG, "m_nick(): new user on `%s': %s@%s (%s)", si->s->name, parv[0],parv[4],parv[7]);
 
 		decode_p10_ip(parv[parc - 3], ipstring);
-		u = user_add(parv[0], parv[3], parv[4], NULL, ipstring, parv[parc - 2], parv[parc - 1], si->s, atoi(parv[2]));
+		/*
+		 * For the purpose of banning users, changing the fourth argument from NULL to parv[7] will stop Atheme from exposing unmasked IP addresses when banning an unregistered user. -- x
+		 */
+		u = user_add(parv[0], parv[3], parv[4], parv[7], ipstring, parv[parc - 2], parv[parc - 1], si->s, atoi(parv[2]));
 		if (u == NULL)
 			return;
 
@@ -690,6 +698,15 @@ static void check_hidehost(user_t *u)
 	slog(LG_DEBUG, "check_hidehost(): %s -> %s", u->nick, u->vhost);
 }
 
+static void p10_kline_sts(const char *server, const char *user, const char *host, long duration, const char *reason)
+{
+	/* hold permanent akills for four weeks -- jilles
+	 * It looks like Nefarious 2 changed up the protocol a bit when it comes to glines.
+	 * This will make GLines work in Nefarious 2. Credit goes to tacocat/GLolol @ freenode. -- x
+	 */
+	sts("%s GL * +%s@%s %ld %lu :%s", me.numeric, user, host, duration > 0 ? duration : 2419200, (unsigned long)CURRTIME, reason);
+}
+
 void _modinit(module_t * m)
 {
 	MODULE_TRY_REQUEST_DEPENDENCY(m, "protocol/p10-generic");
@@ -705,7 +722,7 @@ void _modinit(module_t * m)
 	sethost_sts = &nefarious_sethost_sts;
 	svslogin_sts = &nefarious_svslogin_sts;
 	quarantine_sts = &nefarious_quarantine_sts;
-
+	kline_sts = &p10_kline_sts;
 	mode_list = nefarious_mode_list;
 	ignore_mode_list = nefarious_ignore_mode_list;
 	status_mode_list = nefarious_status_mode_list;

--- a/modules/protocol/nefarious.c
+++ b/modules/protocol/nefarious.c
@@ -369,9 +369,6 @@ static void m_nick(sourceinfo_t *si, int parc, char *parv[])
 		slog(LG_DEBUG, "m_nick(): new user on `%s': %s@%s (%s)", si->s->name, parv[0],parv[4],parv[7]);
 
 		decode_p10_ip(parv[parc - 3], ipstring);
-		/*
-		 * Give Atheme the masked ip/host from Nefarious2.
-		 */
 		u = user_add(parv[0], parv[3], parv[4], parv[7], ipstring, parv[parc - 2], parv[parc - 1], si->s, atoi(parv[2]));
 		if (u == NULL)
 			return;

--- a/modules/protocol/nefarious.c
+++ b/modules/protocol/nefarious.c
@@ -363,18 +363,14 @@ static void m_nick(sourceinfo_t *si, int parc, char *parv[])
 	/* got the right number of args for an introduction? */
 	if (parc >= 8)
 	{
-		/* -> AB N jilles 1 1137687480 jilles jaguar.test +oiwgrx jilles B]AAAB ABAAE :Jilles Tjoelker */
-		/* -> AB N test4 1 1137690148 jilles jaguar.test +iw B]AAAB ABAAG :Jilles Tjoelker */
-
 		/*
 		 * -> Mh N jilles 1 1460435852 jilles 127.0.0.1 +ixCc 1A130C.572B1.6F53B5.8DD3B8.IP 1A130C.572B1.6F53B5.8DD3B8.IP DSBHPW Mhw2O :Real Name
-		 * It looks like the protocol was altered a bit in Nefarious 2 (the current version).
 		 */
 		slog(LG_DEBUG, "m_nick(): new user on `%s': %s@%s (%s)", si->s->name, parv[0],parv[4],parv[7]);
 
 		decode_p10_ip(parv[parc - 3], ipstring);
 		/*
-		 * For the purpose of banning users, changing the fourth argument from NULL to parv[7] will stop Atheme from exposing unmasked IP addresses when banning an unregistered user. -- x
+		 * Give Atheme the masked ip/host from Nefarious2.
 		 */
 		u = user_add(parv[0], parv[3], parv[4], parv[7], ipstring, parv[parc - 2], parv[parc - 1], si->s, atoi(parv[2]));
 		if (u == NULL)
@@ -701,8 +697,7 @@ static void check_hidehost(user_t *u)
 static void p10_kline_sts(const char *server, const char *user, const char *host, long duration, const char *reason)
 {
 	/* hold permanent akills for four weeks -- jilles
-	 * It looks like Nefarious 2 changed up the protocol a bit when it comes to glines.
-	 * This will make GLines work in Nefarious 2. Credit goes to tacocat/GLolol @ freenode. -- x
+	 *  This was changed in Nefarious 2.
 	 */
 	sts("%s GL * +%s@%s %ld %lu :%s", me.numeric, user, host, duration > 0 ? duration : 2419200, (unsigned long)CURRTIME, reason);
 }


### PR DESCRIPTION
Fixes issue where Atheme is unable to enforce & send glines to other servers on Nefarous. (Credit to tacocat)
Fixes issue where unregistered users uncloaked IP address is exposed when banning with services on Nefarious.