### PR TITLE
protocols/unreal*: fix wrong source for SVSNICK

### DIFF
--- a/modules/protocol/unreal.c
+++ b/modules/protocol/unreal.c
@@ -649,7 +649,7 @@ static void unreal_sethost_sts(user_t *source, user_t *target, const char *host)
 
 static void unreal_fnc_sts(user_t *source, user_t *u, const char *newnick, int type)
 {
-	sts(":%s SVSNICK %s %s %lu", CLIENT_NAME(source), CLIENT_NAME(u), newnick,
+	sts(":%s SVSNICK %s %s %lu", ME, CLIENT_NAME(u), newnick,
 			(unsigned long)(CURRTIME - 60));
 }
 

--- a/modules/protocol/unreal4.c
+++ b/modules/protocol/unreal4.c
@@ -652,7 +652,7 @@ static void unreal_sethost_sts(user_t *source, user_t *target, const char *host)
 
 static void unreal_fnc_sts(user_t *source, user_t *u, const char *newnick, int type)
 {
-	sts(":%s SVSNICK %s %s %lu", CLIENT_NAME(source), CLIENT_NAME(u), newnick,
+	sts(":%s SVSNICK %s %s %lu", ME, CLIENT_NAME(u), newnick,
 			(unsigned long)(CURRTIME - 60));
 }
 


### PR DESCRIPTION
UnrealIRCd SVSNICK is server only (at least on 3.2.10.6 and 4.0.3.1). When NickServ is used as a source, the following error is sent by the uplink and the SVSNICK command silently fails.

```
[2016-07-11 23:01:51] <- :NickServ NOTICE GL4 :GL has been released.
[2016-07-11 23:01:51] NickServ GL/AAAAAAAAB:GL4!gl@localhost[localhost] RELEASE: GL!GLolol@escape.the.dreamland.ca
[2016-07-11 23:01:51] -> :unreal.midnight.vpn 487 NickServ :SVSNICK is a server only command
```

edit: fix typo in title & commit (-mode)