### PR TITLE
po/Makefile: fix POT creation

### DIFF
--- a/po/Makefile
+++ b/po/Makefile
@@ -12,13 +12,16 @@ LOCALES=es.po ru.po cy.po de.po da.po fr.po
 
 include ../buildsys.mk
 
-POTTEMPLATE=$(PACKAGE).pot
+POTTEMPLATE=$(PACKAGE_NAME).pot
 
 update-pot:
 	@echo Updating $(POTTEMPLATE) ...
-	xgettext --default-domain=$(PACKAGE) --language=C \
+	xgettext --default-domain=$(PACKAGE_NAME) --language=C \
 	--keyword=_ --keyword=N_ --from-code="utf-8" \
-	--directory=.. --files-from=POTFILES.in -o $(POTTEMPLATE)
+	--directory=.. --files-from=POTFILES.in -o $(POTTEMPLATE) \
+	--package-name=$(PACKAGE_NAME) --package-version=$(PACKAGE_VERSION) \
+	--copyright-holder=Atheme \
+	--msgid-bugs-address=https://github.com/atheme/atheme/issues
 
 update-po: update-pot
 	@echo Updating .po -files ...


### PR DESCRIPTION
Fix the following parts of POT creation:

- Update target file variable to use $(PACKAGE_NAME), fixing a problem
  where the POT file would be written as '.pot' instead of 'atheme.pot'.
- Update call to xgettext to supply it with the following information:
  - Define a package name via $(PACKAGE_NAME)
  - Define a package version via $(PACKAGE_VERSION)
  - Define the copyright holder as "Atheme"
  - Define <https://github.com/atheme/atheme/issues> as report address
    for msgid bugs