### PR TITLE
email templates: Fix leading whitespace

### DIFF
--- a/email/default/register
+++ b/email/default/register
@@ -9,7 +9,7 @@ Date: &date&
 In order to complete your account registration, you must type the following
 command on IRC:
 
-   /msg &nicksvs& VERIFY REGISTER &accountname& &param&
+/msg &nicksvs& VERIFY REGISTER &accountname& &param&
 
 Thank you for registering your account on the &netname& IRC network!
 

--- a/email/default/setemail
+++ b/email/default/setemail
@@ -9,7 +9,7 @@ Date: &date&
 In order to complete the e-mail address change, you must verify your new
 e-mail address by issuing the following command on IRC:
 
-   /msg &nicksvs& VERIFY EMAILCHG &accountname& &param&
+/msg &nicksvs& VERIFY EMAILCHG &accountname& &param&
 
 Thank you for updating your e-mail address on file with the &netname&
 IRC network!

--- a/email/default/setpass
+++ b/email/default/setpass
@@ -14,7 +14,7 @@ compromise your account.
 In order to set a new password, you must send the following command
 on IRC, where <password> is the new password you wish to set.
 
-   /msg &nicksvs& SETPASS &accountname& &param& <password>
+/msg &nicksvs& SETPASS &accountname& &param& <password>
 
 --
 If this message is unsolicited, please contact &replyto&


### PR DESCRIPTION
The leading whitespace is barely visible in many email clients and was often cause for sending the message directly to the channel for clients that do not interpret " /command" as a command. This was most notable for qwebirc.

This change was not tested to work (I don't have a good test environment), but from discussion in `#atheme` it appears that this should be sufficient.