### PR TITLE
services.c: remove unused pointer

### DIFF
--- a/libathemecore/services.c
+++ b/libathemecore/services.c
@@ -628,7 +628,6 @@ void myuser_login(service_t *svs, user_t *u, myuser_t *mu, bool sendaccount)
 	metadata_t *md_failnum;
 	struct tm tm;
 	mynick_t *mn;
-	operclass_t *operclass;
 
 	return_if_fail(svs != NULL && svs->me != NULL);
 	return_if_fail(u->myuser == NULL);


### PR DESCRIPTION
Introduced by the merge of https://github.com/XthemeOrg/Xtheme/commit/fdebfad3f3023c67b6b24e8c62307d5140ae9ea7 but not used in this function.