### PR TITLE
saslserv/main: free sasl_sourceinfo_t after use

### DIFF
--- a/modules/saslserv/main.c
+++ b/modules/saslserv/main.c
@@ -609,6 +609,7 @@ static myuser_t *login_user(sasl_session_t *p)
 	req.mu = source_mu;
 	req.allowed = true;
 	hook_call_user_can_login(&req);
+	object_unref(req.si);
 	if (!req.allowed)
 	{
 		sasl_logcommand(p, source_mu, CMDLOG_LOGIN, "failed LOGIN to \2%s\2 (denied by hook)", entity(source_mu)->name);


### PR DESCRIPTION
```
==9829== 136 bytes in 1 blocks are definitely lost in loss record 440 of 447
==9829==    at 0x4C2CA40: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==9829==    by 0x52C109A: smalloc (memory.c:35)
==9829==    by 0xC487B92: sasl_sourceinfo_create (main.c:274)
==9829==    by 0xC4887F0: login_user (main.c:605)
==9829==    by 0xC4887F0: sasl_packet.constprop.6 (main.c:467)
==9829==    by 0xC488E6B: sasl_input (main.c:347)
==9829==    by 0x52BE5AD: hook_call_event (hook.c:192)
==9829==    by 0x6FDED40: m_encap.part.15 (ts6-generic.c:1304)
==9829==    by 0x71E3CDA: irc_parse (parse.c:176)
==9829==    by 0x52C31FD: irc_recvq_handler (packet.c:55)
==9829==    by 0x52BB010: recvq_put (datastream.c:266)
==9829==    by 0x5081762: mowgli_epoll_eventloop_select (epoll_pollops.c:188)
==9829==    by 0x50823A3: mowgli_simple_eventloop_timeout_once (null_pollops.c:57)
```