### PR TITLE
Ignore the serverinfo:numeric setting on UID-less networks

### DIFF
--- a/include/servers.h
+++ b/include/servers.h
@@ -50,7 +50,7 @@ typedef struct {
 	/* space for reason etc here */
 } hook_server_delete_t;
 
-#define SERVER_NAME(serv)	((serv)->sid ? (serv)->sid : (serv)->name)
+#define SERVER_NAME(serv)	(((serv)->sid && ircd->uses_uid) ? (serv)->sid : (serv)->name)
 #define ME			(ircd->uses_uid ? me.numeric : me.name)
 
 /* servers.c */


### PR DESCRIPTION
On UID-less networks such as ngIRCd, defining the numeric option will cause WHOIS responses to break, as they send from the defined SID instead of the server name. (Other commands are not affected though, so this causes a very subtle breakage)

Before:

```
[2017-07-12 07:02:00] -> :james WHOIS chanserv :chanserv
[2017-07-12 07:02:00] <- :0SV 311 james ChanServ ChanServ services.int * :Channel Services
[2017-07-12 07:02:00] <- :0SV 312 james ChanServ services.midnight.int :Atheme IRC Services
[2017-07-12 07:02:00] <- :0SV 313 james ChanServ :is a Network Service
[2017-07-12 07:02:00] <- :0SV 318 james chanserv :End of WHOIS
```

After:

```
[2017-07-12 07:09:51] -> :james WHOIS chanserv :chanserv
[2017-07-12 07:09:51] <- :services.midnight.int 311 james ChanServ ChanServ services.int * :Channel Services
[2017-07-12 07:09:51] <- :services.midnight.int 312 james ChanServ services.midnight.int :Atheme IRC Services
[2017-07-12 07:09:51] <- :services.midnight.int 313 james ChanServ :is a Network Service
[2017-07-12 07:09:51] <- :services.midnight.int 318 james chanserv :End of WHOIS
```