### PR TITLE
SASL: Use a parameter vector to allow arbitrary number of S2S arguments

### DIFF
--- a/include/abirev.h
+++ b/include/abirev.h
@@ -16,7 +16,7 @@
  * digits and set the rest to 0 (e.g. 330000). Otherwise, increment
  * the lower digits.
  */
-#define CURRENT_ABI_REVISION 720001
+#define CURRENT_ABI_REVISION 720002
 
 #endif
 

--- a/include/sasl.h
+++ b/include/sasl.h
@@ -9,6 +9,8 @@
 #ifndef SASL_H
 #define SASL_H
 
+#define SASL_MESSAGE_MAXPARA	8	/* arbitrary, increment if needed in future */
+
 typedef struct sasl_session_ sasl_session_t;
 typedef struct sasl_message_ sasl_message_t;
 typedef struct sasl_mechanism_ sasl_mechanism_t;
@@ -34,8 +36,8 @@ struct sasl_session_ {
 struct sasl_message_ {
   char *uid;
   char mode;
-  char *buf;
-  char *ext;
+  char *parv[SASL_MESSAGE_MAXPARA];
+  int parc;
 
   server_t *server;
 };

--- a/include/sasl.h
+++ b/include/sasl.h
@@ -31,6 +31,7 @@ struct sasl_session_ {
 
   char *host;
   char *ip;
+  bool tls;
 };
 
 struct sasl_message_ {

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -1347,11 +1347,18 @@ static void m_encap(sourceinfo_t *si, int parc, char *parv[])
 		if (parc < 6)
 			return;
 
+		(void) memset(&smsg, 0x00, sizeof smsg);
+
 		smsg.uid = parv[2];
 		smsg.mode = *parv[4];
-		smsg.buf = parv[5];
-		smsg.ext = parc >= 6 ? parv[6] : NULL;
-		smsg.server = si->s ? si->s : NULL;
+		smsg.parc = parc - 5;
+		smsg.server = si->s;
+
+		if (smsg.parc > SASL_MESSAGE_MAXPARA)
+			smsg.parc = SASL_MESSAGE_MAXPARA;
+
+		(void) memcpy(smsg.parv, &parv[5], smsg.parc * sizeof(char *));
+
 		hook_call_sasl_input(&smsg);
 	}
 }

--- a/modules/protocol/nefarious.c
+++ b/modules/protocol/nefarious.c
@@ -650,11 +650,17 @@ static void m_sasl(sourceinfo_t *si, int parc, char *parv[])
 	if (parc < 4)
 		return;
 
+	(void) memset(&smsg, 0x00, sizeof smsg);
+
 	smsg.uid = parv[1];
 	smsg.mode = *parv[2];
-	smsg.buf = parv[3];
-	smsg.ext = parc >= 4 ? parv[4] : NULL;
-	smsg.server = si->s ? si->s : NULL;
+	smsg.parc = parc - 3;
+	smsg.server = si->s;
+
+	if (smsg.parc > SASL_MESSAGE_MAXPARA)
+		smsg.parc = SASL_MESSAGE_MAXPARA;
+
+	(void) memcpy(smsg.parv, &parv[3], smsg.parc * sizeof(char *));
 
 	hook_call_sasl_input(&smsg);
 }

--- a/modules/protocol/ts6-generic.c
+++ b/modules/protocol/ts6-generic.c
@@ -1296,11 +1296,18 @@ static void m_encap(sourceinfo_t *si, int parc, char *parv[])
 		if (parc < 6)
 			return;
 
+		(void) memset(&smsg, 0x00, sizeof smsg);
+
 		smsg.uid = parv[2];
 		smsg.mode = *parv[4];
-		smsg.buf = parv[5];
-		smsg.ext = parc >= 6 ? parv[6] : NULL;
-		smsg.server = si->s ? si->s : NULL;
+		smsg.parc = parc - 5;
+		smsg.server = si->s;
+
+		if (smsg.parc > SASL_MESSAGE_MAXPARA)
+			smsg.parc = SASL_MESSAGE_MAXPARA;
+
+		(void) memcpy(smsg.parv, &parv[5], smsg.parc * sizeof(char *));
+
 		hook_call_sasl_input(&smsg);
 	}
 	else if (!irccasecmp(parv[1], "RSMSG"))

--- a/modules/protocol/unreal.c
+++ b/modules/protocol/unreal.c
@@ -761,11 +761,17 @@ static void m_sasl(sourceinfo_t *si, int parc, char *parv[])
 	if (parc < 4)
 		return;
 
+	(void) memset(&smsg, 0x00, sizeof smsg);
+
 	smsg.uid = parv[1];
 	smsg.mode = *parv[2];
-	smsg.buf = parv[3];
-	smsg.ext = parc >= 4 ? parv[4] : NULL;
-	smsg.server = si->s ? si->s : NULL;
+	smsg.parc = parc - 3;
+	smsg.server = si->s;
+
+	if (smsg.parc > SASL_MESSAGE_MAXPARA)
+		smsg.parc = SASL_MESSAGE_MAXPARA;
+
+	(void) memcpy(smsg.parv, &parv[3], smsg.parc * sizeof(char *));
 
 	hook_call_sasl_input(&smsg);
 }

--- a/modules/protocol/unreal4.c
+++ b/modules/protocol/unreal4.c
@@ -764,11 +764,17 @@ static void m_sasl(sourceinfo_t *si, int parc, char *parv[])
 	if (parc < 4)
 		return;
 
+	(void) memset(&smsg, 0x00, sizeof smsg);
+
 	smsg.uid = parv[1];
 	smsg.mode = *parv[2];
-	smsg.buf = parv[3];
-	smsg.ext = parc >= 4 ? parv[4] : NULL;
-	smsg.server = si->s ? si->s : NULL;
+	smsg.parc = parc - 3;
+	smsg.server = si->s;
+
+	if (smsg.parc > SASL_MESSAGE_MAXPARA)
+		smsg.parc = SASL_MESSAGE_MAXPARA;
+
+	(void) memcpy(smsg.parv, &parv[3], smsg.parc * sizeof(char *));
 
 	hook_call_sasl_input(&smsg);
 }

--- a/modules/saslserv/main.c
+++ b/modules/saslserv/main.c
@@ -291,7 +291,7 @@ static sourceinfo_t *sasl_sourceinfo_create(sasl_session_t *p)
 static void sasl_input(sasl_message_t *smsg)
 {
 	sasl_session_t *p = make_session(smsg->uid, smsg->server);
-	int len = strlen(smsg->buf);
+	int len = strlen(smsg->parv[0]);
 	char *tmpbuf;
 	int tmplen;
 
@@ -299,16 +299,16 @@ static void sasl_input(sasl_message_t *smsg)
 	{
 	case 'H':
 		/* (H)ost information */
-		p->host = sstrdup(smsg->buf);
-		p->ip   = sstrdup(smsg->ext);
+		p->host = sstrdup(smsg->parv[0]);
+		p->ip   = sstrdup(smsg->parv[1]);
 		return;
 
 	case 'S':
 		/* (S)tart authentication */
-		if(smsg->mode == 'S' && smsg->ext != NULL && !strcmp(smsg->buf, "EXTERNAL"))
+		if(smsg->mode == 'S' && smsg->parc >= 2 && !strcmp(smsg->parv[0], "EXTERNAL"))
 		{
 			free(p->certfp);
-			p->certfp = sstrdup(smsg->ext);
+			p->certfp = sstrdup(smsg->parv[1]);
 		}
 		/* fallthrough to 'C' */
 
@@ -334,7 +334,7 @@ static void sasl_input(sasl_message_t *smsg)
 			p->len += len;
 		}
 
-		memcpy(p->p, smsg->buf, len);
+		memcpy(p->p, smsg->parv[0], len);
 
 		/* Messages not exactly 400 bytes are the end of a packet. */
 		if(len < 400)

--- a/modules/saslserv/main.c
+++ b/modules/saslserv/main.c
@@ -301,6 +301,10 @@ static void sasl_input(sasl_message_t *smsg)
 		/* (H)ost information */
 		p->host = sstrdup(smsg->parv[0]);
 		p->ip   = sstrdup(smsg->parv[1]);
+
+		if (smsg->parc >= 3 && strcmp(smsg->parv[2], "P") != 0)
+			p->tls = true;
+
 		return;
 
 	case 'S':
@@ -309,6 +313,7 @@ static void sasl_input(sasl_message_t *smsg)
 		{
 			free(p->certfp);
 			p->certfp = sstrdup(smsg->parv[1]);
+			p->tls = true;
 		}
 		/* fallthrough to 'C' */
 


### PR DESCRIPTION
This can be used in future to restrict the authentication mechanisms
that plaintext clients are allowed to perform (for example, to
prevent password disclosure to passive observers by preventing
SASL PLAIN).

c.f. https://github.com/charybdis-ircd/charybdis/commit/754c1edf2e9c