### PR TITLE
nickserv/register: Remove password from registration confirmation

### DIFF
--- a/modules/nickserv/register.c
+++ b/modules/nickserv/register.c
@@ -227,7 +227,7 @@ static void ns_cmd_register(sourceinfo_t *si, int parc, char *parv[])
 		logcommand(si, CMDLOG_ADMIN, "SOPER: \2%s\2 as \2%s\2", get_oper_name(si), entity(mu)->name);
 	}
 
-	command_success_nodata(si, _("\2%s\2 is now registered to \2%s\2, with the password \2%s\2."), entity(mu)->name, mu->email, pass);
+	command_success_nodata(si, _("\2%s\2 is now registered to \2%s\2."), entity(mu)->name, mu->email);
 	hook_call_user_register(mu);
 
 	if (si->su != NULL)


### PR DESCRIPTION
The password should not be sent back to the client for security reasons.

An attacker could potentially read the message from the screen until the
message has been cleared (e.g. when registering in public) or the
message could be logged by the client.

In the latter case, this might not even be known to the user.

As for the former case, many applications obscure the password to
prevent such situations from happening. Since the password is not really
necessary in this case, we can also leave it out.

Typos that go unnoticed during registration can be worked around by
using SENDPASS for now, in the future it might be worth to add a special
VERIFY case to have the user enter the password twice.

Closes atheme/atheme#577 ("When registering the response contains the
password as plain text")