### PR TITLE
SCRAM-SHA-1 bugfixes

### DIFF
--- a/libathemecore/function.c
+++ b/libathemecore/function.c
@@ -30,14 +30,14 @@ char ch[] = "abcdefghijklmnopqrstuvwxyz";
  */
 char *random_string(size_t sz)
 {
-	char *buf = smalloc(sz + 1); /* padding */
+	unsigned char *buf = smalloc(sz + 1); /* padding */
 
 	(void) arc4random_buf(buf, sz);
 
 	for (size_t i = 0; i < sz; i++)
 		buf[i] = ch[buf[i] % 26];
 
-	return buf;
+	return (char *) buf;
 }
 
 void create_challenge(sourceinfo_t *si, const char *name, int v, char *dest)

--- a/modules/saslserv/scram-sha.c
+++ b/modules/saslserv/scram-sha.c
@@ -243,7 +243,7 @@ sasl_scramsha_step_clientfirst(sasl_session_t *const restrict p, char *const res
 	/*
 	 * TODO: Normalise the username
 	 */
-	if (! (s->mu = myuser_find(input['n'])))
+	if (! (s->mu = myuser_find_by_nick(input['n'])))
 	{
 		(void) slog(LG_DEBUG, "%s: no such user '%s'", __func__, input['n']);
 		goto fail;

--- a/modules/saslserv/scram-sha.c
+++ b/modules/saslserv/scram-sha.c
@@ -271,8 +271,8 @@ sasl_scramsha_step_clientfirst(sasl_session_t *const restrict p, char *const res
 	p->username = sstrdup(input['n']);
 	s->c_gs2_len = (size_t) (message - header);
 	s->c_gs2_buf = sstrndup(header, s->c_gs2_len);
-	s->c_msg_len = len;
-	s->c_msg_buf = sstrndup(message, len);
+	s->c_msg_len = len - s->c_gs2_len;
+	s->c_msg_buf = sstrndup(message, s->c_msg_len);
 	s->cn = sstrdup(input['r']);
 	s->sn = random_string(NONCE_LENGTH);
 	*out = smalloc(RESPONSE_LENGTH);


### PR DESCRIPTION
With this, I can successfully authenticate using both gsasl and Pidgin (cyrus-sasl) as clients.

One remaining issue is that the mechanism isn't re-registered on `/os modreload saslserv/scram-sha`; I have to additionally `/os rehash` to make it work again.