### PR TITLE
Add a couple login-related hooks

### DIFF
--- a/include/account.h
+++ b/include/account.h
@@ -340,6 +340,7 @@ typedef struct {
 typedef struct {
 	sourceinfo_t *si;
 	user_t *u;
+	const bool relogin;
 	bool allowed;
 } hook_user_logout_check_t;
 

--- a/include/account.h
+++ b/include/account.h
@@ -355,6 +355,13 @@ typedef struct {
 } hook_metadata_change_t;
 
 typedef struct {
+	sourceinfo_t *si;
+	myuser_t *mu;
+	mynick_t *mn;
+	bool allowed;
+} hook_user_rename_check_t;
+
+typedef struct {
 	myuser_t *mu;
 	const char *oldname;
 } hook_user_rename_t;

--- a/include/account.h
+++ b/include/account.h
@@ -338,6 +338,12 @@ typedef struct {
 } hook_user_login_check_t;
 
 typedef struct {
+	sourceinfo_t *si;
+	user_t *u;
+	bool allowed;
+} hook_user_logout_check_t;
+
+typedef struct {
 	user_t *u;
 	mynick_t *mn;
 } hook_nick_enforce_t;

--- a/include/hooktypes.in
+++ b/include/hooktypes.in
@@ -70,6 +70,7 @@ sasl_input         sasl_message_t *
 service_introduce  service_t *
 user_can_register  hook_user_register_check_t *
 user_can_login     hook_user_login_check_t *
+user_can_logout    hook_user_logout_check_t *
 user_drop          myuser_t *
 user_identify      user_t *
 user_info          hook_user_req_t *

--- a/include/hooktypes.in
+++ b/include/hooktypes.in
@@ -79,6 +79,7 @@ user_register      myuser_t *
 user_verify_register  hook_user_req_t *
 user_check_expire  hook_expiry_req_t *
 user_rename        hook_user_rename_t *
+user_can_rename    hook_user_rename_check_t *
 user_sethost       user_t *
 user_needforce     hook_user_needforce_t *
 myuser_delete      myuser_t *

--- a/include/services.h
+++ b/include/services.h
@@ -112,6 +112,7 @@ E void verbose(mychan_t *mychan, const char *fmt, ...) PRINTFLIKE(2, 3);
 E void (*notice)(const char *from, const char *target, const char *fmt, ...) PRINTFLIKE(3, 4);
 E void change_notify(const char *from, user_t *to, const char *message, ...) PRINTFLIKE(3, 4);
 E bool bad_password(sourceinfo_t *si, myuser_t *mu);
+E bool ircd_logout_or_kill(user_t *u, const char *login);
 
 E sourceinfo_t *sourceinfo_create(void);
 E void command_fail(sourceinfo_t *si, cmd_faultcode_t code, const char *fmt, ...) PRINTFLIKE(3, 4);

--- a/libathemecore/account.c
+++ b/libathemecore/account.c
@@ -212,7 +212,7 @@ void myuser_delete(myuser_t *mu)
 	MOWGLI_ITER_FOREACH_SAFE(n, tn, mu->logins.head)
 	{
 		u = (user_t *)n->data;
-		if (!authservice_loaded || !ircd_on_logout(u, entity(mu)->name))
+		if (!authservice_loaded || !ircd_logout_or_kill(u, entity(mu)->name))
 		{
 			u->myuser = NULL;
 			mowgli_node_delete(n, &mu->logins);

--- a/libathemecore/services.c
+++ b/libathemecore/services.c
@@ -392,11 +392,14 @@ void handle_nickchange(user_t *u)
 bool ircd_logout_or_kill(user_t *u, const char *login)
 {
 	service_t *svs = service_find("operserv");
-	hook_user_logout_check_t req;
 
-	req.si = NULL;
-	req.u = u;
-	req.allowed = true;
+	hook_user_logout_check_t req = {
+		.si      = NULL,
+		.u       = u,
+		.allowed = true,
+		.relogin = false,
+	};
+
 	hook_call_user_can_logout(&req);
 
 	if (req.allowed)

--- a/modules/nickserv/enforce.c
+++ b/modules/nickserv/enforce.c
@@ -69,7 +69,7 @@ static bool log_enforce_victim_out(user_t *u, myuser_t *mu)
 	if ((mn = mynick_find(u->nick)) != NULL)
 		mn->lastseen = CURRTIME;
 
-	if (!ircd_on_logout(u, entity(u->myuser)->name))
+	if (!ircd_logout_or_kill(u, entity(u->myuser)->name))
 	{
 		MOWGLI_ITER_FOREACH_SAFE(n, tn, u->myuser->logins.head)
 		{
@@ -417,7 +417,7 @@ static void ns_cmd_regain(sourceinfo_t *si, int parc, char *parv[])
 			{
 				command_success_nodata(si, _("You have been logged out of \2%s\2."), entity(si->smu)->name);
 
-				if (ircd_on_logout(si->su, entity(si->smu)->name))
+				if (ircd_logout_or_kill(si->su, entity(si->smu)->name))
 					/* logout killed the user... */
 					return;
 				si->smu->lastlogin = CURRTIME;

--- a/modules/nickserv/freeze.c
+++ b/modules/nickserv/freeze.c
@@ -122,7 +122,7 @@ static void ns_cmd_freeze(sourceinfo_t *si, int parc, char *parv[])
 		MOWGLI_ITER_FOREACH_SAFE(n, tn, mu->logins.head)
 		{
 			u = (user_t *)n->data;
-			if (!ircd_on_logout(u, entity(mu)->name))
+			if (!ircd_logout_or_kill(u, entity(mu)->name))
 			{
 				u->myuser = NULL;
 				mowgli_node_delete(n, &mu->logins);

--- a/modules/nickserv/identify.c
+++ b/modules/nickserv/identify.c
@@ -61,8 +61,6 @@ static void ns_cmd_login(sourceinfo_t *si, int parc, char *parv[])
 	const char *target = parv[0];
 	const char *password = parv[1];
 	char lau[BUFSIZE];
-	hook_user_login_check_t login_req;
-	hook_user_logout_check_t logout_req;
 
 	if (si->su == NULL)
 	{
@@ -92,12 +90,17 @@ static void ns_cmd_login(sourceinfo_t *si, int parc, char *parv[])
 		return;
 	}
 
-	login_req.si = si;
-	login_req.mu = mu;
-	login_req.allowed = true;
-	logout_req.si = si;
-	logout_req.u = u;
-	logout_req.allowed = true;
+	hook_user_login_check_t login_req = {
+		.si      = si,
+		.mu      = mu,
+		.allowed = true,
+	};
+	hook_user_logout_check_t logout_req = {
+		.si      = si,
+		.u       = u,
+		.allowed = true,
+		.relogin = true,
+	};
 	hook_call_user_can_login(&login_req);
 	if (login_req.allowed && u->myuser)
 		hook_call_user_can_logout(&logout_req);

--- a/modules/nickserv/logout.c
+++ b/modules/nickserv/logout.c
@@ -38,7 +38,6 @@ static void ns_cmd_logout(sourceinfo_t *si, int parc, char *parv[])
 	mynick_t *mn;
 	char *user = parv[0];
 	char *pass = parv[1];
-	hook_user_logout_check_t req;
 
 	if ((!si->smu) && (!user || !pass))
 	{
@@ -69,9 +68,12 @@ static void ns_cmd_logout(sourceinfo_t *si, int parc, char *parv[])
 		return;
 	}
 
-	req.si = si;
-	req.u = u;
-	req.allowed = true;
+	hook_user_logout_check_t req = {
+		.si      = si,
+		.u       = u,
+		.allowed = true,
+		.relogin = false,
+	};
 	hook_call_user_can_logout(&req);
 	if (!req.allowed)
 	{

--- a/modules/nickserv/return.c
+++ b/modules/nickserv/return.c
@@ -94,7 +94,7 @@ static void ns_cmd_return(sourceinfo_t *si, int parc, char *parv[])
 	MOWGLI_ITER_FOREACH_SAFE(n, tn, mu->logins.head)
 	{
 		u = (user_t *)n->data;
-		if (!ircd_on_logout(u, entity(mu)->name))
+		if (!ircd_logout_or_kill(u, entity(mu)->name))
 		{
 			u->myuser = NULL;
 			mowgli_node_delete(n, &mu->logins);


### PR DESCRIPTION
* Add a user_can_logout(si, u) hook that can prevent a user from logging out

  In a few dubious cases where it would be incorrect/impossible to deny the operation, the target user is killed instead (as if on P10).

* Add a user_can_rename(si, mu, mn) hook