### PR TITLE
chanserv/clear_flags: do not check whether or not the channel is empty

### DIFF
--- a/modules/chanserv/clear_flags.c
+++ b/modules/chanserv/clear_flags.c
@@ -54,12 +54,6 @@ static void cs_cmd_clear_flags(sourceinfo_t *si, int parc, char *parv[])
 		return;
 	}
 
-	if (!mc->chan)
-	{
-		command_fail(si, fault_nosuch_target, "\2%s\2 does not exist.", name);
-		return;
-	}
-
 	if (!chanacs_source_has_flag(mc, si, CA_FOUNDER))
 	{
 		command_fail(si, fault_noprivs, "You are not authorized to perform this operation.");


### PR DESCRIPTION
This restriction is useless. Additionally, users might find this
behavior unintuitive.

Closes atheme/atheme#605 (""CLEAR FLAGS" does not need to check if a
registered channel exists")