### PR TITLE
Nuke 'E' from orbit

### DIFF
--- a/include/account.h
+++ b/include/account.h
@@ -365,7 +365,7 @@ typedef struct {
 } hook_user_needforce_t;
 
 /* pmodule.c XXX */
-E bool backend_loaded;
+extern bool backend_loaded;
 
 /* dbhandler.c */
 /* BLOCKING:     wait for the write to finish; cancel previous write if necessary
@@ -377,125 +377,125 @@ typedef enum {
 	DB_SAVE_BG_REGULAR,
 	DB_SAVE_BG_IMPORTANT
 } db_save_strategy_t;
-E void (*db_save)(void *arg, db_save_strategy_t strategy);
-E void (*db_load)(const char *arg);
+extern void (*db_save)(void *arg, db_save_strategy_t strategy);
+extern void (*db_load)(const char *arg);
 
 /* function.c */
-E bool is_founder(mychan_t *mychan, myentity_t *myuser);
+extern bool is_founder(mychan_t *mychan, myentity_t *myuser);
 
 /* node.c */
-E mowgli_list_t klnlist;
+extern mowgli_list_t klnlist;
 
-E kline_t *kline_add_with_id(const char *user, const char *host, const char *reason, long duration, const char *setby, unsigned long id);
-E kline_t *kline_add(const char *user, const char *host, const char *reason, long duration, const char *setby);
-E kline_t *kline_add_user(user_t *user, const char *reason, long duration, const char *setby);
-E void kline_delete(kline_t *k);
-E kline_t *kline_find(const char *user, const char *host);
-E kline_t *kline_find_num(unsigned long number);
-E kline_t *kline_find_user(user_t *u);
-E void kline_expire(void *arg);
+extern kline_t *kline_add_with_id(const char *user, const char *host, const char *reason, long duration, const char *setby, unsigned long id);
+extern kline_t *kline_add(const char *user, const char *host, const char *reason, long duration, const char *setby);
+extern kline_t *kline_add_user(user_t *user, const char *reason, long duration, const char *setby);
+extern void kline_delete(kline_t *k);
+extern kline_t *kline_find(const char *user, const char *host);
+extern kline_t *kline_find_num(unsigned long number);
+extern kline_t *kline_find_user(user_t *u);
+extern void kline_expire(void *arg);
 
-E mowgli_list_t xlnlist;
+extern mowgli_list_t xlnlist;
 
-E xline_t *xline_add(const char *realname, const char *reason, long duration, const char *setby);
-E void xline_delete(const char *realname);
-E xline_t *xline_find(const char *realname);
-E xline_t *xline_find_num(unsigned int number);
-E xline_t *xline_find_user(user_t *u);
-E void xline_expire(void *arg);
+extern xline_t *xline_add(const char *realname, const char *reason, long duration, const char *setby);
+extern void xline_delete(const char *realname);
+extern xline_t *xline_find(const char *realname);
+extern xline_t *xline_find_num(unsigned int number);
+extern xline_t *xline_find_user(user_t *u);
+extern void xline_expire(void *arg);
 
-E mowgli_list_t qlnlist;
+extern mowgli_list_t qlnlist;
 
-E qline_t *qline_add(const char *mask, const char *reason, long duration, const char *setby);
-E void qline_delete(const char *mask);
-E qline_t *qline_find(const char *mask);
-E qline_t *qline_find_match(const char *mask);
-E qline_t *qline_find_num(unsigned int number);
-E qline_t *qline_find_user(user_t *u);
-E qline_t *qline_find_channel(channel_t *c);
-E void qline_expire(void *arg);
+extern qline_t *qline_add(const char *mask, const char *reason, long duration, const char *setby);
+extern void qline_delete(const char *mask);
+extern qline_t *qline_find(const char *mask);
+extern qline_t *qline_find_match(const char *mask);
+extern qline_t *qline_find_num(unsigned int number);
+extern qline_t *qline_find_user(user_t *u);
+extern qline_t *qline_find_channel(channel_t *c);
+extern void qline_expire(void *arg);
 
 /* account.c */
-E mowgli_patricia_t *nicklist;
-E mowgli_patricia_t *oldnameslist;
-E mowgli_patricia_t *mclist;
+extern mowgli_patricia_t *nicklist;
+extern mowgli_patricia_t *oldnameslist;
+extern mowgli_patricia_t *mclist;
 
-E void init_accounts(void);
+extern void init_accounts(void);
 
-E myuser_t *myuser_add(const char *name, const char *pass, const char *email, unsigned int flags);
-E myuser_t *myuser_add_id(const char *id, const char *name, const char *pass, const char *email, unsigned int flags);
-E void myuser_delete(myuser_t *mu);
+extern myuser_t *myuser_add(const char *name, const char *pass, const char *email, unsigned int flags);
+extern myuser_t *myuser_add_id(const char *id, const char *name, const char *pass, const char *email, unsigned int flags);
+extern void myuser_delete(myuser_t *mu);
 //inline myuser_t *myuser_find(const char *name);
-E void myuser_rename(myuser_t *mu, const char *name);
-E void myuser_set_email(myuser_t *mu, const char *newemail);
-E myuser_t *myuser_find_ext(const char *name);
-E void myuser_notice(const char *from, myuser_t *target, const char *fmt, ...) PRINTFLIKE(3, 4);
+extern void myuser_rename(myuser_t *mu, const char *name);
+extern void myuser_set_email(myuser_t *mu, const char *newemail);
+extern myuser_t *myuser_find_ext(const char *name);
+extern void myuser_notice(const char *from, myuser_t *target, const char *fmt, ...) PRINTFLIKE(3, 4);
 
-E bool myuser_access_verify(user_t *u, myuser_t *mu);
-E bool myuser_access_add(myuser_t *mu, const char *mask);
-E char *myuser_access_find(myuser_t *mu, const char *mask);
-E void myuser_access_delete(myuser_t *mu, const char *mask);
+extern bool myuser_access_verify(user_t *u, myuser_t *mu);
+extern bool myuser_access_add(myuser_t *mu, const char *mask);
+extern char *myuser_access_find(myuser_t *mu, const char *mask);
+extern void myuser_access_delete(myuser_t *mu, const char *mask);
 
-E mynick_t *mynick_add(myuser_t *mu, const char *name);
-E void mynick_delete(mynick_t *mn);
+extern mynick_t *mynick_add(myuser_t *mu, const char *name);
+extern void mynick_delete(mynick_t *mn);
 //inline mynick_t *mynick_find(const char *name);
 
-E myuser_name_t *myuser_name_add(const char *name);
+extern myuser_name_t *myuser_name_add(const char *name);
 //inline myuser_name_t *myuser_name_find(const char *name);
-E void myuser_name_remember(const char *name, myuser_t *mu);
-E void myuser_name_restore(const char *name, myuser_t *mu);
+extern void myuser_name_remember(const char *name, myuser_t *mu);
+extern void myuser_name_restore(const char *name, myuser_t *mu);
 
-E mycertfp_t *mycertfp_add(myuser_t *mu, const char *certfp);
-E void mycertfp_delete(mycertfp_t *mcfp);
-E mycertfp_t *mycertfp_find(const char *certfp);
+extern mycertfp_t *mycertfp_add(myuser_t *mu, const char *certfp);
+extern void mycertfp_delete(mycertfp_t *mcfp);
+extern mycertfp_t *mycertfp_find(const char *certfp);
 
-E mychan_t *mychan_add(char *name);
+extern mychan_t *mychan_add(char *name);
 //inline mychan_t *mychan_find(const char *name);
-E bool mychan_isused(mychan_t *mc);
-E unsigned int mychan_num_founders(mychan_t *mc);
-E const char *mychan_founder_names(mychan_t *mc);
-E myuser_t *mychan_pick_candidate(mychan_t *mc, unsigned int minlevel);
-E myuser_t *mychan_pick_successor(mychan_t *mc);
-E const char *mychan_get_mlock(mychan_t *mc);
-E const char *mychan_get_sts_mlock(mychan_t *mc);
+extern bool mychan_isused(mychan_t *mc);
+extern unsigned int mychan_num_founders(mychan_t *mc);
+extern const char *mychan_founder_names(mychan_t *mc);
+extern myuser_t *mychan_pick_candidate(mychan_t *mc, unsigned int minlevel);
+extern myuser_t *mychan_pick_successor(mychan_t *mc);
+extern const char *mychan_get_mlock(mychan_t *mc);
+extern const char *mychan_get_sts_mlock(mychan_t *mc);
 
-E chanacs_t *chanacs_add(mychan_t *mychan, myentity_t *myuser, unsigned int level, time_t ts, myentity_t *setter);
-E chanacs_t *chanacs_add_host(mychan_t *mychan, const char *host, unsigned int level, time_t ts, myentity_t *setter);
+extern chanacs_t *chanacs_add(mychan_t *mychan, myentity_t *myuser, unsigned int level, time_t ts, myentity_t *setter);
+extern chanacs_t *chanacs_add_host(mychan_t *mychan, const char *host, unsigned int level, time_t ts, myentity_t *setter);
 
-E chanacs_t *chanacs_find(mychan_t *mychan, myentity_t *myuser, unsigned int level);
-E unsigned int chanacs_entity_flags(mychan_t *mychan, myentity_t *myuser);
+extern chanacs_t *chanacs_find(mychan_t *mychan, myentity_t *myuser, unsigned int level);
+extern unsigned int chanacs_entity_flags(mychan_t *mychan, myentity_t *myuser);
 //inline bool chanacs_entity_has_flag(mychan_t *mychan, myentity_t *mt, unsigned int level)
-E chanacs_t *chanacs_find_literal(mychan_t *mychan, myentity_t *myuser, unsigned int level);
-E chanacs_t *chanacs_find_host(mychan_t *mychan, const char *host, unsigned int level);
-E unsigned int chanacs_host_flags(mychan_t *mychan, const char *host);
-E chanacs_t *chanacs_find_host_literal(mychan_t *mychan, const char *host, unsigned int level);
-E chanacs_t *chanacs_find_host_by_user(mychan_t *mychan, user_t *u, unsigned int level);
-E chanacs_t *chanacs_find_by_mask(mychan_t *mychan, const char *mask, unsigned int level);
-E bool chanacs_user_has_flag(mychan_t *mychan, user_t *u, unsigned int level);
-E unsigned int chanacs_user_flags(mychan_t *mychan, user_t *u);
+extern chanacs_t *chanacs_find_literal(mychan_t *mychan, myentity_t *myuser, unsigned int level);
+extern chanacs_t *chanacs_find_host(mychan_t *mychan, const char *host, unsigned int level);
+extern unsigned int chanacs_host_flags(mychan_t *mychan, const char *host);
+extern chanacs_t *chanacs_find_host_literal(mychan_t *mychan, const char *host, unsigned int level);
+extern chanacs_t *chanacs_find_host_by_user(mychan_t *mychan, user_t *u, unsigned int level);
+extern chanacs_t *chanacs_find_by_mask(mychan_t *mychan, const char *mask, unsigned int level);
+extern bool chanacs_user_has_flag(mychan_t *mychan, user_t *u, unsigned int level);
+extern unsigned int chanacs_user_flags(mychan_t *mychan, user_t *u);
 //inline bool chanacs_source_has_flag(mychan_t *mychan, sourceinfo_t *si, unsigned int level);
-E unsigned int chanacs_source_flags(mychan_t *mychan, sourceinfo_t *si);
+extern unsigned int chanacs_source_flags(mychan_t *mychan, sourceinfo_t *si);
 
-E chanacs_t *chanacs_open(mychan_t *mychan, myentity_t *mt, const char *hostmask, bool create, myentity_t *setter);
+extern chanacs_t *chanacs_open(mychan_t *mychan, myentity_t *mt, const char *hostmask, bool create, myentity_t *setter);
 //inline void chanacs_close(chanacs_t *ca);
-E bool chanacs_modify(chanacs_t *ca, unsigned int *addflags, unsigned int *removeflags, unsigned int restrictflags, myuser_t *setter);
-E bool chanacs_modify_simple(chanacs_t *ca, unsigned int addflags, unsigned int removeflags, myuser_t *setter);
+extern bool chanacs_modify(chanacs_t *ca, unsigned int *addflags, unsigned int *removeflags, unsigned int restrictflags, myuser_t *setter);
+extern bool chanacs_modify_simple(chanacs_t *ca, unsigned int addflags, unsigned int removeflags, myuser_t *setter);
 
 //inline bool chanacs_is_table_full(chanacs_t *ca);
 
-E bool chanacs_change(mychan_t *mychan, myentity_t *mt, const char *hostmask, unsigned int *addflags, unsigned int *removeflags, unsigned int restrictflags, myentity_t *setter);
-E bool chanacs_change_simple(mychan_t *mychan, myentity_t *mt, const char *hostmask, unsigned int addflags, unsigned int removeflags, myentity_t *setter);
+extern bool chanacs_change(mychan_t *mychan, myentity_t *mt, const char *hostmask, unsigned int *addflags, unsigned int *removeflags, unsigned int restrictflags, myentity_t *setter);
+extern bool chanacs_change_simple(mychan_t *mychan, myentity_t *mt, const char *hostmask, unsigned int addflags, unsigned int removeflags, myentity_t *setter);
 
-E void expire_check(void *arg);
+extern void expire_check(void *arg);
 /* Check the database for (version) problems common to all backends */
-E void db_check(void);
+extern void db_check(void);
 
 /* svsignore.c */
-E mowgli_list_t svs_ignore_list;
+extern mowgli_list_t svs_ignore_list;
 
-E svsignore_t *svsignore_find(user_t *user);
-E svsignore_t *svsignore_add(const char *mask, const char *reason);
-E void svsignore_delete(svsignore_t *svsignore);
+extern svsignore_t *svsignore_find(user_t *user);
+extern svsignore_t *svsignore_add(const char *mask, const char *reason);
+extern void svsignore_delete(svsignore_t *svsignore);
 
 #include "entity-validation.h"
 

--- a/include/atheme.h
+++ b/include/atheme.h
@@ -11,9 +11,6 @@
 
 /* *INDENT-OFF* */
 
-#define E extern
-#define DLE
-
 #include "sysconf.h"
 #include "stdinc.h"
 #include "i18n.h"

--- a/include/atheme_memory.h
+++ b/include/atheme_memory.h
@@ -9,11 +9,11 @@
 #ifndef ATHEME_MEMORY_H
 #define ATHEME_MEMORY_H
 
-E void *smalloc(size_t size);
-E void *scalloc(size_t elsize, size_t els);
-E void *srealloc(void *oldptr, size_t newsize);
-E char *sstrdup(const char *s);
-E char *sstrndup(const char *s, size_t len);
+extern void *smalloc(size_t size);
+extern void *scalloc(size_t elsize, size_t els);
+extern void *srealloc(void *oldptr, size_t newsize);
+extern char *sstrdup(const char *s);
+extern char *sstrndup(const char *s, size_t len);
 
 #endif
 

--- a/include/atheme_string.h
+++ b/include/atheme_string.h
@@ -9,15 +9,15 @@
 #ifndef ATHEME_STRING_H
 #define ATHEME_STRING_H
 
-E void strip(char *line);
-E void strip_ctrl(char *line);
+extern void strip(char *line);
+extern void strip_ctrl(char *line);
 
 #ifndef HAVE_STRTOK_R
-E char *strtok_r(char *s, const char *delim, char **lasts);
+extern char *strtok_r(char *s, const char *delim, char **lasts);
 #endif
 
 #ifndef HAVE_STRCASESTR
-E char *strcasestr(char *s, const char *find);
+extern char *strcasestr(char *s, const char *find);
 #endif
 
 #endif

--- a/include/auth.h
+++ b/include/auth.h
@@ -9,11 +9,11 @@
 #ifndef AUTH_H
 #define AUTH_H
 
-E void set_password(myuser_t *mu, const char *newpassword);
-E bool verify_password(myuser_t *mu, const char *password);
+extern void set_password(myuser_t *mu, const char *newpassword);
+extern bool verify_password(myuser_t *mu, const char *password);
 
-E bool auth_module_loaded;
-E bool (*auth_user_custom)(myuser_t *mu, const char *password);
+extern bool auth_module_loaded;
+extern bool (*auth_user_custom)(myuser_t *mu, const char *password);
 
 #endif
 

--- a/include/authcookie.h
+++ b/include/authcookie.h
@@ -20,13 +20,13 @@ struct authcookie_ {
 	mowgli_node_t node;
 };
 
-E void authcookie_init(void);
-E authcookie_t *authcookie_create(myuser_t *mu);
-E authcookie_t *authcookie_find(const char *ticket, myuser_t *myuser);
-E void authcookie_destroy(authcookie_t *ac);
-E void authcookie_destroy_all(myuser_t *mu);
-E bool authcookie_validate(const char *ticket, myuser_t *myuser);
-E void authcookie_expire(void *arg);
+extern void authcookie_init(void);
+extern authcookie_t *authcookie_create(myuser_t *mu);
+extern authcookie_t *authcookie_find(const char *ticket, myuser_t *myuser);
+extern void authcookie_destroy(authcookie_t *ac);
+extern void authcookie_destroy_all(myuser_t *mu);
+extern bool authcookie_validate(const char *ticket, myuser_t *myuser);
+extern void authcookie_expire(void *arg);
 
 #endif
 

--- a/include/channels.h
+++ b/include/channels.h
@@ -140,45 +140,45 @@ typedef struct {
 } hook_channel_mode_change_t;
 
 /* cmode.c */
-E char *flags_to_string(unsigned int flags);
-E int mode_to_flag(char c);
-E void channel_mode(user_t *source, channel_t *chan, int parc, char *parv[]);
-E void channel_mode_va(user_t *source, channel_t *chan, int parc, char *parv0, ...);
-E void clear_simple_modes(channel_t *c);
-E char *channel_modes(channel_t *c, bool doparams);
-E void modestack_flush_channel(channel_t *channel);
-E void modestack_forget_channel(channel_t *channel);
-E void modestack_finalize_channel(channel_t *channel);
-E void check_modes(mychan_t *mychan, bool sendnow);
+extern char *flags_to_string(unsigned int flags);
+extern int mode_to_flag(char c);
+extern void channel_mode(user_t *source, channel_t *chan, int parc, char *parv[]);
+extern void channel_mode_va(user_t *source, channel_t *chan, int parc, char *parv0, ...);
+extern void clear_simple_modes(channel_t *c);
+extern char *channel_modes(channel_t *c, bool doparams);
+extern void modestack_flush_channel(channel_t *channel);
+extern void modestack_forget_channel(channel_t *channel);
+extern void modestack_finalize_channel(channel_t *channel);
+extern void check_modes(mychan_t *mychan, bool sendnow);
 
-E void modestack_mode_simple_real(const char *source, channel_t *channel, int dir, int flags);
-E void modestack_mode_limit_real(const char *source, channel_t *channel, int dir, unsigned int limit);
-E void modestack_mode_ext_real(const char *source, channel_t *channel, int dir, unsigned int i, const char *value);
-E void modestack_mode_param_real(const char *source, channel_t *channel, int dir, char type, const char *value);
+extern void modestack_mode_simple_real(const char *source, channel_t *channel, int dir, int flags);
+extern void modestack_mode_limit_real(const char *source, channel_t *channel, int dir, unsigned int limit);
+extern void modestack_mode_ext_real(const char *source, channel_t *channel, int dir, unsigned int i, const char *value);
+extern void modestack_mode_param_real(const char *source, channel_t *channel, int dir, char type, const char *value);
 
-E void (*modestack_mode_simple)(const char *source, channel_t *channel, int dir, int flags);
-E void (*modestack_mode_limit)(const char *source, channel_t *channel, int dir, unsigned int limit);
-E void (*modestack_mode_ext)(const char *source, channel_t *channel, int dir, unsigned int i, const char *value);
-E void (*modestack_mode_param)(const char *source, channel_t *channel, int dir, char type, const char *value);
+extern void (*modestack_mode_simple)(const char *source, channel_t *channel, int dir, int flags);
+extern void (*modestack_mode_limit)(const char *source, channel_t *channel, int dir, unsigned int limit);
+extern void (*modestack_mode_ext)(const char *source, channel_t *channel, int dir, unsigned int i, const char *value);
+extern void (*modestack_mode_param)(const char *source, channel_t *channel, int dir, char type, const char *value);
 
-E void modestack_flush_now(void);
+extern void modestack_flush_now(void);
 
 /* channels.c */
-E mowgli_patricia_t *chanlist;
+extern mowgli_patricia_t *chanlist;
 
-E void init_channels(void);
+extern void init_channels(void);
 
-E channel_t *channel_add(const char *name, time_t ts, server_t *creator);
-E void channel_delete(channel_t *c);
+extern channel_t *channel_add(const char *name, time_t ts, server_t *creator);
+extern void channel_delete(channel_t *c);
 //inline channel_t *channel_find(const char *name);
 
-E chanuser_t *chanuser_add(channel_t *chan, const char *user);
-E void chanuser_delete(channel_t *chan, user_t *user);
-E chanuser_t *chanuser_find(channel_t *chan, user_t *user);
+extern chanuser_t *chanuser_add(channel_t *chan, const char *user);
+extern void chanuser_delete(channel_t *chan, user_t *user);
+extern chanuser_t *chanuser_find(channel_t *chan, user_t *user);
 
-E chanban_t *chanban_add(channel_t *chan, const char *mask, int type);
-E void chanban_delete(chanban_t *c);
-E chanban_t *chanban_find(channel_t *chan, const char *mask, int type);
+extern chanban_t *chanban_add(channel_t *chan, const char *mask, int type);
+extern void chanban_delete(chanban_t *c);
+extern chanban_t *chanban_find(channel_t *chan, const char *mask, int type);
 //inline void chanban_clear(channel_t *chan);
 
 #endif

--- a/include/commandtree.h
+++ b/include/commandtree.h
@@ -24,21 +24,21 @@ struct commandentry_ {
 };
 
 /* commandtree.c */
-E void command_add(command_t *cmd, mowgli_patricia_t *commandtree);
-E void command_delete(command_t *cmd, mowgli_patricia_t *commandtree);
-E command_t *command_find(mowgli_patricia_t *commandtree, const char *command);
-E void command_exec(service_t *svs, sourceinfo_t *si, command_t *c, int parc, char *parv[]);
-E void command_exec_split(service_t *svs, sourceinfo_t *si, const char *cmd, char *text, mowgli_patricia_t *commandtree);
-E void command_help(sourceinfo_t *si, mowgli_patricia_t *commandtree);
-E void command_help_short(sourceinfo_t *si, mowgli_patricia_t *commandtree, const char *maincmds);
-E bool (*command_authorize)(service_t *svs, sourceinfo_t *si, command_t *c, const char *userlevel);
+extern void command_add(command_t *cmd, mowgli_patricia_t *commandtree);
+extern void command_delete(command_t *cmd, mowgli_patricia_t *commandtree);
+extern command_t *command_find(mowgli_patricia_t *commandtree, const char *command);
+extern void command_exec(service_t *svs, sourceinfo_t *si, command_t *c, int parc, char *parv[]);
+extern void command_exec_split(service_t *svs, sourceinfo_t *si, const char *cmd, char *text, mowgli_patricia_t *commandtree);
+extern void command_help(sourceinfo_t *si, mowgli_patricia_t *commandtree);
+extern void command_help_short(sourceinfo_t *si, mowgli_patricia_t *commandtree, const char *maincmds);
+extern bool (*command_authorize)(service_t *svs, sourceinfo_t *si, command_t *c, const char *userlevel);
 
 /* help.c */
-E void help_display(sourceinfo_t *si, service_t *service, const char *command, mowgli_patricia_t *list);
-E void help_display_as_subcmd(sourceinfo_t *si, service_t *service, const char *subcmd_of, const char *command, mowgli_patricia_t *list);
+extern void help_display(sourceinfo_t *si, service_t *service, const char *command, mowgli_patricia_t *list);
+extern void help_display_as_subcmd(sourceinfo_t *si, service_t *service, const char *subcmd_of, const char *command, mowgli_patricia_t *list);
 
 /* logger.c */
-E void logaudit_denycmd(sourceinfo_t *si, command_t *cmd, const char *userlevel);
+extern void logaudit_denycmd(sourceinfo_t *si, command_t *cmd, const char *userlevel);
 
 #endif
 

--- a/include/conf.h
+++ b/include/conf.h
@@ -8,17 +8,17 @@
 #ifndef CONF_H
 #define CONF_H
 
-E bool conf_parse(const char *);
-E void conf_init(void);
-E bool conf_rehash(void);
-E bool conf_check(void);
+extern bool conf_parse(const char *);
+extern void conf_init(void);
+extern bool conf_rehash(void);
+extern bool conf_check(void);
 
-E void init_newconf(void);
+extern void init_newconf(void);
 
 /* XXX Unstable module api to add things to the standard conf blocks */
-E mowgli_list_t conf_si_table; /* serverinfo{} */
-E mowgli_list_t conf_gi_table; /* general{} */
-E mowgli_list_t conf_la_table; /* language{} */
+extern mowgli_list_t conf_si_table; /* serverinfo{} */
+extern mowgli_list_t conf_gi_table; /* general{} */
+extern mowgli_list_t conf_la_table; /* language{} */
 
 #endif
 

--- a/include/confprocess.h
+++ b/include/confprocess.h
@@ -18,36 +18,36 @@ struct Token
 
 struct ConfTable;
 
-E void init_confprocess(void);
-E struct ConfTable *find_top_conf(const char *name);
-E struct ConfTable *find_conf_item(const char *name, mowgli_list_t *conflist);
-E void add_top_conf(const char *name, int (*handler)(mowgli_config_file_entry_t *ce));
-E void add_subblock_top_conf(const char *name, mowgli_list_t *list);
-E void add_conf_item(const char *name, mowgli_list_t *conflist, int (*handler)(mowgli_config_file_entry_t *ce));
-E void add_uint_conf_item(const char *name, mowgli_list_t *conflist, unsigned int flags, unsigned int *var, unsigned int min, unsigned int max, unsigned int def);
-E void add_duration_conf_item(const char *name, mowgli_list_t *conflist, unsigned int flags, unsigned int *var, const char *defunit, unsigned int def);
-E void add_dupstr_conf_item(const char *name, mowgli_list_t *conflist, unsigned int flags, char **var, const char *def);
-E void add_bool_conf_item(const char *name, mowgli_list_t *conflist, unsigned int flags, bool *var, bool def);
-E void del_top_conf(const char *name);
-E void del_conf_item(const char *name, mowgli_list_t *conflist);
-E int subblock_handler(mowgli_config_file_entry_t *ce, mowgli_list_t *entries);
-E bool process_uint_configentry(mowgli_config_file_entry_t *ce, unsigned int *var,
+extern void init_confprocess(void);
+extern struct ConfTable *find_top_conf(const char *name);
+extern struct ConfTable *find_conf_item(const char *name, mowgli_list_t *conflist);
+extern void add_top_conf(const char *name, int (*handler)(mowgli_config_file_entry_t *ce));
+extern void add_subblock_top_conf(const char *name, mowgli_list_t *list);
+extern void add_conf_item(const char *name, mowgli_list_t *conflist, int (*handler)(mowgli_config_file_entry_t *ce));
+extern void add_uint_conf_item(const char *name, mowgli_list_t *conflist, unsigned int flags, unsigned int *var, unsigned int min, unsigned int max, unsigned int def);
+extern void add_duration_conf_item(const char *name, mowgli_list_t *conflist, unsigned int flags, unsigned int *var, const char *defunit, unsigned int def);
+extern void add_dupstr_conf_item(const char *name, mowgli_list_t *conflist, unsigned int flags, char **var, const char *def);
+extern void add_bool_conf_item(const char *name, mowgli_list_t *conflist, unsigned int flags, bool *var, bool def);
+extern void del_top_conf(const char *name);
+extern void del_conf_item(const char *name, mowgli_list_t *conflist);
+extern int subblock_handler(mowgli_config_file_entry_t *ce, mowgli_list_t *entries);
+extern bool process_uint_configentry(mowgli_config_file_entry_t *ce, unsigned int *var,
 		unsigned int min, unsigned int max);
-E bool process_duration_configentry(mowgli_config_file_entry_t *ce, unsigned int *var,
+extern bool process_duration_configentry(mowgli_config_file_entry_t *ce, unsigned int *var,
 		const char *defunit);
-E void conf_report_warning(mowgli_config_file_entry_t *ce, const char *fmt, ...) PRINTFLIKE (2, 3);
+extern void conf_report_warning(mowgli_config_file_entry_t *ce, const char *fmt, ...) PRINTFLIKE (2, 3);
 /* sort of a hack for servtree.c */
 typedef int (*conf_handler_t)(mowgli_config_file_entry_t *);
-E conf_handler_t conftable_get_conf_handler(struct ConfTable *ct);
+extern conf_handler_t conftable_get_conf_handler(struct ConfTable *ct);
 
-E void conf_process(mowgli_config_file_t *cfp);
+extern void conf_process(mowgli_config_file_t *cfp);
 
-E int token_to_value(struct Token token_table[], const char *token);
+extern int token_to_value(struct Token token_table[], const char *token);
 /* special return values for token_to_value */
 #define TOKEN_UNMATCHED -1
 #define TOKEN_ERROR -2
 
-E bool conf_need_rehash;
+extern bool conf_need_rehash;
 
 #endif
 

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -22,13 +22,13 @@ typedef struct {
 
 } crypt_impl_t;
 
-E void crypt_register(crypt_impl_t *impl);
-E void crypt_unregister(crypt_impl_t *impl);
+extern void crypt_register(crypt_impl_t *impl);
+extern void crypt_unregister(crypt_impl_t *impl);
 
-E const crypt_impl_t *crypt_get_default_provider(void);
-E const crypt_impl_t *crypt_verify_password(const char *password, const char *parameters, unsigned int *flags);
-E const char *crypt_password(const char *password);
-E const char *crypt_string(const char *password, const char *parameters);
+extern const crypt_impl_t *crypt_get_default_provider(void);
+extern const crypt_impl_t *crypt_verify_password(const char *password, const char *parameters, unsigned int *flags);
+extern const char *crypt_password(const char *password);
+extern const char *crypt_string(const char *password, const char *parameters);
 
 #endif
 

--- a/include/culture.h
+++ b/include/culture.h
@@ -9,22 +9,22 @@
 #ifndef CULTURE_H
 #define CULTURE_H
 
-E const char *translation_get(const char *name);
-E void itranslation_create(const char *str, const char *trans);
-E void itranslation_destroy(const char *str);
-E void translation_create(const char *str, const char *trans);
-E void translation_destroy(const char *str);
-E void translation_init(void);
+extern const char *translation_get(const char *name);
+extern void itranslation_create(const char *str, const char *trans);
+extern void itranslation_destroy(const char *str);
+extern void translation_create(const char *str, const char *trans);
+extern void translation_destroy(const char *str);
+extern void translation_init(void);
 
 typedef struct language_ language_t;
 
-E language_t *language_add(const char *name);
-E language_t *language_find(const char *name);
-E const char *language_names(void);
-E const char *language_get_name(const language_t *lang);
-E const char *language_get_real_name(const language_t *lang);
-E bool language_is_valid(const language_t *lang);
-E void language_set_active(language_t *lang);
+extern language_t *language_add(const char *name);
+extern language_t *language_find(const char *name);
+extern const char *language_names(void);
+extern const char *language_get_name(const language_t *lang);
+extern const char *language_get_real_name(const language_t *lang);
+extern bool language_is_valid(const language_t *lang);
+extern void language_set_active(language_t *lang);
 
 #endif
 

--- a/include/database_backend.h
+++ b/include/database_backend.h
@@ -10,7 +10,7 @@
 
 #include "common.h"
 
-E bool strict_mode;
+extern bool strict_mode;
 
 struct database_handle_;
 typedef struct database_handle_ database_handle_t;
@@ -57,39 +57,39 @@ typedef struct {
 	void (*db_parse)(database_handle_t *db);
 } database_module_t;
 
-E database_handle_t *db_open(const char *filename, database_transaction_t txn);
-E void db_close(database_handle_t *db);
-E void db_parse(database_handle_t *db);
+extern database_handle_t *db_open(const char *filename, database_transaction_t txn);
+extern void db_close(database_handle_t *db);
+extern void db_parse(database_handle_t *db);
 
-E bool db_read_next_row(database_handle_t *db);
+extern bool db_read_next_row(database_handle_t *db);
 
-E const char *db_read_word(database_handle_t *db);
-E const char *db_read_str(database_handle_t *db);
-E bool db_read_int(database_handle_t *db, int *r);
-E bool db_read_uint(database_handle_t *db, unsigned int *r);
-E bool db_read_time(database_handle_t *db, time_t *t);
+extern const char *db_read_word(database_handle_t *db);
+extern const char *db_read_str(database_handle_t *db);
+extern bool db_read_int(database_handle_t *db, int *r);
+extern bool db_read_uint(database_handle_t *db, unsigned int *r);
+extern bool db_read_time(database_handle_t *db, time_t *t);
 
-E const char *db_sread_word(database_handle_t *db);
-E const char *db_sread_str(database_handle_t *db);
-E int db_sread_int(database_handle_t *db);
-E unsigned int db_sread_uint(database_handle_t *db);
-E time_t db_sread_time(database_handle_t *db);
+extern const char *db_sread_word(database_handle_t *db);
+extern const char *db_sread_str(database_handle_t *db);
+extern int db_sread_int(database_handle_t *db);
+extern unsigned int db_sread_uint(database_handle_t *db);
+extern time_t db_sread_time(database_handle_t *db);
 
-E bool db_start_row(database_handle_t *db, const char *type);
-E bool db_write_word(database_handle_t *db, const char *word);
-E bool db_write_str(database_handle_t *db, const char *str);
-E bool db_write_int(database_handle_t *db, int num);
-E bool db_write_uint(database_handle_t *db, unsigned int num);
-E bool db_write_time(database_handle_t *db, time_t time);
-E bool db_write_format(database_handle_t *db, const char *str, ...);
-E bool db_commit_row(database_handle_t *db);
+extern bool db_start_row(database_handle_t *db, const char *type);
+extern bool db_write_word(database_handle_t *db, const char *word);
+extern bool db_write_str(database_handle_t *db, const char *str);
+extern bool db_write_int(database_handle_t *db, int num);
+extern bool db_write_uint(database_handle_t *db, unsigned int num);
+extern bool db_write_time(database_handle_t *db, time_t time);
+extern bool db_write_format(database_handle_t *db, const char *str, ...);
+extern bool db_commit_row(database_handle_t *db);
 
 typedef void (*database_handler_f)(database_handle_t *db, const char *type);
 
-E void db_register_type_handler(const char *type, database_handler_f fun);
-E void db_unregister_type_handler(const char *type);
-E void db_process(database_handle_t *db, const char *type);
-E void db_init(void);
-E database_module_t *db_mod;
+extern void db_register_type_handler(const char *type, database_handler_f fun);
+extern void db_unregister_type_handler(const char *type);
+extern void db_process(database_handle_t *db, const char *type);
+extern void db_init(void);
+extern database_module_t *db_mod;
 
 #endif

--- a/include/datastream.h
+++ b/include/datastream.h
@@ -9,18 +9,18 @@
 #ifndef ATHEME_DATASTREAM_H
 #define ATHEME_DATASTREAM_H
 
-E void sendq_add(connection_t *cptr, char *buf, size_t len);
-E void sendq_add_eof(connection_t *cptr);
-E void sendq_flush(connection_t *cptr);
-E bool sendq_nonempty(connection_t *cptr);
-E void sendq_set_limit(connection_t *cptr, size_t len);
+extern void sendq_add(connection_t *cptr, char *buf, size_t len);
+extern void sendq_add_eof(connection_t *cptr);
+extern void sendq_flush(connection_t *cptr);
+extern bool sendq_nonempty(connection_t *cptr);
+extern void sendq_set_limit(connection_t *cptr, size_t len);
 
-E int recvq_length(connection_t *cptr);
-E void recvq_put(connection_t *cptr);
-E int recvq_get(connection_t *cptr, char *buf, size_t len);
-E int recvq_getline(connection_t *cptr, char *buf, size_t len);
+extern int recvq_length(connection_t *cptr);
+extern void recvq_put(connection_t *cptr);
+extern int recvq_get(connection_t *cptr, char *buf, size_t len);
+extern int recvq_getline(connection_t *cptr, char *buf, size_t len);
 
-E void sendqrecvq_free(connection_t *cptr);
+extern void sendqrecvq_free(connection_t *cptr);
 
 #endif
 

--- a/include/entity-validation.h
+++ b/include/entity-validation.h
@@ -13,6 +13,6 @@ struct entity_chanacs_validation_vtable {
 	bool (*allow_foundership)(myentity_t *mt);
 };
 
-E entity_chanacs_validation_vtable_t *myentity_get_chanacs_validator(myentity_t *mt);
+extern entity_chanacs_validation_vtable_t *myentity_get_chanacs_validator(myentity_t *mt);
 
 #endif

--- a/include/entity.h
+++ b/include/entity.h
@@ -48,21 +48,21 @@ typedef struct {
 	myentity_type_t type;
 } myentity_iteration_state_t;
 
-E void myentity_foreach(int (*cb)(myentity_t *me, void *privdata), void *privdata);
-E void myentity_foreach_t(myentity_type_t type, int (*cb)(myentity_t *me, void *privdata), void *privdata);
-E void myentity_foreach_start(myentity_iteration_state_t *state, myentity_type_t type);
-E void myentity_foreach_next(myentity_iteration_state_t *state);
-E myentity_t *myentity_foreach_cur(myentity_iteration_state_t *state);
+extern void myentity_foreach(int (*cb)(myentity_t *me, void *privdata), void *privdata);
+extern void myentity_foreach_t(myentity_type_t type, int (*cb)(myentity_t *me, void *privdata), void *privdata);
+extern void myentity_foreach_start(myentity_iteration_state_t *state, myentity_type_t type);
+extern void myentity_foreach_next(myentity_iteration_state_t *state);
+extern myentity_t *myentity_foreach_cur(myentity_iteration_state_t *state);
 
 #define MYENTITY_FOREACH_T(elem, state, type) for (myentity_foreach_start(state, type); (elem = myentity_foreach_cur(state)); myentity_foreach_next(state))
 #define MYENTITY_FOREACH(elem, state) MYENTITY_FOREACH_T(elem, state, 0)
 
-E void myentity_stats(void (*cb)(const char *line, void *privdata), void *privdata);
+extern void myentity_stats(void (*cb)(const char *line, void *privdata), void *privdata);
 
 /* chanacs */
-E unsigned int myentity_count_channels_with_flagset(myentity_t *mt, unsigned int flagset);
-E bool myentity_can_register_channel(myentity_t *mt);
-E bool myentity_allow_foundership(myentity_t *mt);
+extern unsigned int myentity_count_channels_with_flagset(myentity_t *mt, unsigned int flagset);
+extern bool myentity_can_register_channel(myentity_t *mt);
+extern bool myentity_allow_foundership(myentity_t *mt);
 
 typedef struct {
 	myentity_t *entity;

--- a/include/flags.h
+++ b/include/flags.h
@@ -17,35 +17,35 @@ struct flags_table
 	const char *name;
 };
 
-E unsigned int ca_all;
-E struct flags_table chanacs_flags[256];
+extern unsigned int ca_all;
+extern struct flags_table chanacs_flags[256];
 
-E unsigned int flags_associate(unsigned char flag, unsigned int restrictflags, bool def, const char *name);
-E void flags_clear(unsigned char flag);
-E unsigned int flags_find_slot(void);
+extern unsigned int flags_associate(unsigned char flag, unsigned int restrictflags, bool def, const char *name);
+extern void flags_clear(unsigned char flag);
+extern unsigned int flags_find_slot(void);
 
-E void flags_make_bitmasks(const char *string, unsigned int *addflags, unsigned int *removeflags);
-E unsigned int flags_to_bitmask(const char *, unsigned int flags);
-E char *bitmask_to_flags(unsigned int);
-E char *bitmask_to_flags2(unsigned int, unsigned int);
-E unsigned int allow_flags(mychan_t *mc, unsigned int flags);
-E void update_chanacs_flags(void);
+extern void flags_make_bitmasks(const char *string, unsigned int *addflags, unsigned int *removeflags);
+extern unsigned int flags_to_bitmask(const char *, unsigned int flags);
+extern char *bitmask_to_flags(unsigned int);
+extern char *bitmask_to_flags2(unsigned int, unsigned int);
+extern unsigned int allow_flags(mychan_t *mc, unsigned int flags);
+extern void update_chanacs_flags(void);
 
 typedef struct gflags {
 	char ch;
 	unsigned int value;
 } gflags_t;
 
-E gflags_t mu_flags[];
-E gflags_t mc_flags[];
-E gflags_t soper_flags[];
+extern gflags_t mu_flags[];
+extern gflags_t mc_flags[];
+extern gflags_t soper_flags[];
 
-E char *gflags_tostr(gflags_t *gflags, unsigned int flags);
-E bool gflags_fromstr(gflags_t *gflags, const char *f, unsigned int *res);
+extern char *gflags_tostr(gflags_t *gflags, unsigned int flags);
+extern bool gflags_fromstr(gflags_t *gflags, const char *f, unsigned int *res);
 
-E unsigned int xflag_lookup(const char *name);
-E unsigned int xflag_apply(unsigned int in, const char *name);
-E const char *xflag_tostr(unsigned int flags);
+extern unsigned int xflag_lookup(const char *name);
+extern unsigned int xflag_apply(unsigned int in, const char *name);
+extern const char *xflag_tostr(unsigned int flags);
 
 #endif
 

--- a/include/global.h
+++ b/include/global.h
@@ -61,7 +61,7 @@ struct me
   bool hidden;			/* whether or not we should hide ourselves in /links (if the ircd supports it) */
 };
 
-E me_t me;
+extern me_t me;
 
 /* values for me.auth */
 #define AUTH_NONE  0
@@ -116,7 +116,7 @@ struct ConfOption
   bool show_entity_id;		/* do not require user:auspex to see entity IDs */
 };
 
-E struct ConfOption config_options;
+extern struct ConfOption config_options;
 
 /* keep track of how many of what we have */
 struct cnt
@@ -145,7 +145,7 @@ struct cnt
   unsigned int myuser_name;
 };
 
-E struct cnt cnt;
+extern struct cnt cnt;
 
 typedef struct claro_state_ {
 	unsigned int node;
@@ -154,12 +154,12 @@ typedef struct claro_state_ {
 	int maxfd;
 } claro_state_t;
 
-E claro_state_t claro_state;
+extern claro_state_t claro_state;
 
 #define CURRTIME claro_state.currtime
 
 /* run flags */
-E int runflags;
+extern int runflags;
 
 #define RF_LIVE         0x00000001      /* don't fork  */
 #define RF_SHUTDOWN     0x00000002      /* shut down   */
@@ -168,36 +168,36 @@ E int runflags;
 #define RF_REHASHING    0x00000010      /* rehashing   */
 
 /* node.c */
-E void init_nodes(void);
+extern void init_nodes(void);
 /* The following currently only do uplinks -- jilles */
-E void mark_all_illegal(void);
-E void unmark_all_illegal(void);
-E void remove_illegals(void);
+extern void mark_all_illegal(void);
+extern void unmark_all_illegal(void);
+extern void remove_illegals(void);
 
 /* atheme.c */
-E mowgli_eventloop_t *base_eventloop;
-E bool cold_start;
-E bool readonly;
-E bool offline_mode;
-E bool permissive_mode;
-E char *config_file;
-E char *datadir;
+extern mowgli_eventloop_t *base_eventloop;
+extern bool cold_start;
+extern bool readonly;
+extern bool offline_mode;
+extern bool permissive_mode;
+extern char *config_file;
+extern char *datadir;
 
 /* conf.c */
-E const char *get_conf_opts(void);
+extern const char *get_conf_opts(void);
 
 /* version.c */
-E const char *creation;
-E const char *platform;
-E const char *version;
-E const char *revision;
-E const char *osinfo;
-E const char *infotext[];
+extern const char *creation;
+extern const char *platform;
+extern const char *version;
+extern const char *revision;
+extern const char *osinfo;
+extern const char *infotext[];
 
 /* signal.c */
-E void check_signals(void);
-E void childproc_add(pid_t pid, const char *desc, void (*cb)(pid_t pid, int status, void *data), void *data);
-E void childproc_delete_all(void (*cb)(pid_t pid, int status, void *data));
+extern void check_signals(void);
+extern void childproc_add(pid_t pid, const char *desc, void (*cb)(pid_t pid, int status, void *data), void *data);
+extern void childproc_delete_all(void (*cb)(pid_t pid, int status, void *data));
 
 #endif
 

--- a/include/hook.h
+++ b/include/hook.h
@@ -16,15 +16,15 @@ struct hook_ {
 	mowgli_list_t hooks;
 };
 
-E hook_t *hook_add_event(const char *);
-E void hook_del_event(const char *);
-E void hook_del_hook(const char *, hookfn_t);
-E void hook_add_hook(const char *, hookfn_t);
-E void hook_add_hook_first(const char *, hookfn_t);
-E void hook_call_event(const char *, void *);
+extern hook_t *hook_add_event(const char *);
+extern void hook_del_event(const char *);
+extern void hook_del_hook(const char *, hookfn_t);
+extern void hook_add_hook(const char *, hookfn_t);
+extern void hook_add_hook_first(const char *, hookfn_t);
+extern void hook_call_event(const char *, void *);
 
-E void hook_stop(void);
-E void hook_continue(void *newptr);
+extern void hook_stop(void);
+extern void hook_continue(void *newptr);
 
 #endif
 

--- a/include/match.h
+++ b/include/match.h
@@ -11,14 +11,14 @@
 #define ATHEME_MATCH_H
 
 /* cidr.c */
-E int match_ips(const char *mask, const char *address);
-E int match_cidr(const char *mask, const char *address);
+extern int match_ips(const char *mask, const char *address);
+extern int match_cidr(const char *mask, const char *address);
 
 /* match.c */
 #define MATCH_RFC1459   0
 #define MATCH_ASCII     1
 
-E int match_mapping;
+extern int match_mapping;
 
 #define IsLower(c)  ((unsigned char)(c) > 0x5f)
 #define IsUpper(c)  ((unsigned char)(c) < 0x60)
@@ -28,7 +28,7 @@ E int match_mapping;
 #define C_NICK  0x00000004
 #define C_USER  0x00000008
 
-E const unsigned int charattrs[];
+extern const unsigned int charattrs[];
 
 #define IsAlpha(c)      (charattrs[(unsigned char) (c)] & C_ALPHA)
 #define IsDigit(c)      (charattrs[(unsigned char) (c)] & C_DIGIT)
@@ -37,23 +37,23 @@ E const unsigned int charattrs[];
 #define IsAlphaNum(c)   (IsAlpha((c)) || IsDigit((c)))
 #define IsNon(c)        (!IsAlphaNum((c)))
 
-E const unsigned char ToLowerTab[];
-E const unsigned char ToUpperTab[];
+extern const unsigned char ToLowerTab[];
+extern const unsigned char ToUpperTab[];
 
 void set_match_mapping(int);
 
-E int ToLower(int);
-E int ToUpper(int);
+extern int ToLower(int);
+extern int ToUpper(int);
 
-E int irccasecmp(const char *, const char *);
-E int ircncasecmp(const char *, const char *, size_t);
+extern int irccasecmp(const char *, const char *);
+extern int ircncasecmp(const char *, const char *, size_t);
 
-E void irccasecanon(char *);
-E void strcasecanon(char *);
-E void noopcanon(char *);
+extern void irccasecanon(char *);
+extern void strcasecanon(char *);
+extern void noopcanon(char *);
 
-E int match(const char *, const char *);
-E char *collapse(char *);
+extern int match(const char *, const char *);
+extern char *collapse(char *);
 
 /* regex_create() flags */
 #define AREGEX_ICASE	1 /* case insensitive */
@@ -62,10 +62,10 @@ E char *collapse(char *);
 
 typedef struct atheme_regex_ atheme_regex_t;
 
-E atheme_regex_t *regex_create(char *pattern, int flags);
-E char *regex_extract(char *pattern, char **pend, int *pflags);
-E bool regex_match(atheme_regex_t *preg, char *string);
-E bool regex_destroy(atheme_regex_t *preg);
+extern atheme_regex_t *regex_create(char *pattern, int flags);
+extern char *regex_extract(char *pattern, char **pend, int *pflags);
+extern bool regex_match(atheme_regex_t *preg, char *string);
+extern bool regex_destroy(atheme_regex_t *preg);
 
 #endif
 

--- a/include/module.h
+++ b/include/module.h
@@ -95,15 +95,15 @@ typedef struct module_dependency_ {
 	module_unload_capability_t can_unload;
 } module_dependency_t;
 
-E void modules_init(void);
-E module_t *module_load(const char *filespec);
-E void module_load_dir(const char *dirspec);
-E void module_load_dir_match(const char *dirspec, const char *pattern);
-E void *module_locate_symbol(const char *modname, const char *sym);
-E void module_unload(module_t *m, module_unload_intent_t intent);
-E module_t *module_find(const char *name);
-E module_t *module_find_published(const char *name);
-E bool module_request(const char *name);
+extern void modules_init(void);
+extern module_t *module_load(const char *filespec);
+extern void module_load_dir(const char *dirspec);
+extern void module_load_dir_match(const char *dirspec, const char *pattern);
+extern void *module_locate_symbol(const char *modname, const char *sym);
+extern void module_unload(module_t *m, module_unload_intent_t intent);
+extern module_t *module_find(const char *name);
+extern module_t *module_find_published(const char *name);
+extern bool module_request(const char *name);
 
 #define DECLARE_MODULE_V1(name, unloadcap, modinit, moddeinit, ver, ven)   \
         v4_moduleheader_t _header = {                                      \

--- a/include/object.h
+++ b/include/object.h
@@ -28,24 +28,24 @@ typedef struct {
 #endif
 } object_t;
 
-E void init_metadata(void);
+extern void init_metadata(void);
 
-E void object_init(object_t *, const char *name, destructor_t destructor);
-E void *object_ref(void *);
-E void *object_sink_ref(void *);
-E void object_unref(void *);
-E void object_dispose(void *);
+extern void object_init(object_t *, const char *name, destructor_t destructor);
+extern void *object_ref(void *);
+extern void *object_sink_ref(void *);
+extern void object_unref(void *);
+extern void object_dispose(void *);
 
-E metadata_t *metadata_add(void *target, const char *name, const char *value);
-E void metadata_delete(void *target, const char *name);
-E metadata_t *metadata_find(void *target, const char *name);
-E void metadata_delete_all(void *target);
+extern metadata_t *metadata_add(void *target, const char *name, const char *value);
+extern void metadata_delete(void *target, const char *name);
+extern metadata_t *metadata_find(void *target, const char *name);
+extern void metadata_delete_all(void *target);
 
-E void *privatedata_get(void *target, const char *key);
-E void privatedata_set(void *target, const char *key, void *data);
+extern void *privatedata_get(void *target, const char *key);
+extern void privatedata_set(void *target, const char *key, void *data);
 
 #ifdef OBJECT_DEBUG
-E mowgli_list_t object_list;
+extern mowgli_list_t object_list;
 #endif
 
 #define object(x) ((object_t *) x)

--- a/include/phandler.h
+++ b/include/phandler.h
@@ -80,96 +80,96 @@ typedef struct ircd_ ircd_t;
  * you can still change ircd->uses_uid at this point
  * set me.bursting = true
  * return 1 if sts() failed (by returning 1), otherwise 0 */
-E unsigned int (*server_login)(void);
+extern unsigned int (*server_login)(void);
 /* introduce a client on the services server */
-E void (*introduce_nick)(user_t *u);
+extern void (*introduce_nick)(user_t *u);
 /* send an invite for a given user to a channel
  * the source may not be on the channel */
-E void (*invite_sts)(user_t *source, user_t *target, channel_t *channel);
+extern void (*invite_sts)(user_t *source, user_t *target, channel_t *channel);
 /* quit a client on the services server with the given message */
-E void (*quit_sts)(user_t *u, const char *reason);
+extern void (*quit_sts)(user_t *u, const char *reason);
 /* send wallops
  * use something that only opers can see if easily possible */
-E void (*wallops_sts)(const char *text);
+extern void (*wallops_sts)(const char *text);
 /* join a channel with a client on the services server
  * the client should be introduced opped
  * isnew indicates the channel modes (and bans XXX) should be bursted
  * note that the channelts can still be old in this case (e.g. kills)
  * modes is a convenience argument giving the simple modes with parameters
  * do not rely upon chanuser_find(c,u) */
-E void (*join_sts)(channel_t *c, user_t *u, bool isnew, char *modes);
+extern void (*join_sts)(channel_t *c, user_t *u, bool isnew, char *modes);
 /* lower the TS of a channel, joining it with the given client on the
  * services server (opped), replacing the current simple modes with the
  * ones stored in the channel_t and clearing all other statuses
  * if bans are timestamped on this ircd, call chanban_clear()
  * if the topic is timestamped on this ircd, clear it */
-E void (*chan_lowerts)(channel_t *c, user_t *u);
+extern void (*chan_lowerts)(channel_t *c, user_t *u);
 /* kick a user from a channel
  * source is a client on the services server which may or may not be
  * on the channel */
-E void (*kick)(user_t *source, channel_t *c, user_t *u, const char *reason);
+extern void (*kick)(user_t *source, channel_t *c, user_t *u, const char *reason);
 /* send a privmsg
  * here it's ok to assume the source is able to send */
-E void (*msg)(const char *from, const char *target, const char *fmt, ...) PRINTFLIKE(3, 4);
+extern void (*msg)(const char *from, const char *target, const char *fmt, ...) PRINTFLIKE(3, 4);
 /* send a global privmsg to all users on servers matching the mask
  * from is a client on the services server
  * mask is either "*" or it has a non-wildcard TLD */
-E void (*msg_global_sts)(user_t *from, const char *mask, const char *text);
+extern void (*msg_global_sts)(user_t *from, const char *mask, const char *text);
 /* send a notice to a user
  * from can be a client on the services server or the services server
  * itself (NULL) */
-E void (*notice_user_sts)(user_t *from, user_t *target, const char *text);
+extern void (*notice_user_sts)(user_t *from, user_t *target, const char *text);
 /* send a global notice to all users on servers matching the mask
  * from is a client on the services server
  * mask is either "*" or it has a non-wildcard TLD */
-E void (*notice_global_sts)(user_t *from, const char *mask, const char *text);
+extern void (*notice_global_sts)(user_t *from, const char *mask, const char *text);
 /* send a notice to a channel
  * from can be a client on the services server or the services server
  * itself (NULL)
  * if the source cannot send because it is not on the channel, send the
  * notice from the server or join for a moment */
-E void (*notice_channel_sts)(user_t *from, channel_t *target, const char *text);
+extern void (*notice_channel_sts)(user_t *from, channel_t *target, const char *text);
 /* send a notice to ops in a channel
  * source may or may not be on channel
  * generic_wallchops() sends an individual notice to each channel operator */
-E void (*wallchops)(user_t *source, channel_t *target, const char *message);
+extern void (*wallchops)(user_t *source, channel_t *target, const char *message);
 /* send a numeric from must currently be me.me */
-E void (*numeric_sts)(server_t *from, int numeric, user_t *target, const char *fmt, ...) PRINTFLIKE(4, 5);
+extern void (*numeric_sts)(server_t *from, int numeric, user_t *target, const char *fmt, ...) PRINTFLIKE(4, 5);
 /* kill a user
  * killer can be a client on the services server or NULL for the
  * services server itself
  * unlike other functions, the target is specified by a UID or nick;
  * do not call user_find(), user_find_named() or similar on it */
-E void (*kill_id_sts)(user_t *killer, const char *id, const char *reason);
+extern void (*kill_id_sts)(user_t *killer, const char *id, const char *reason);
 /* part a channel with a client on the services server */
-E void (*part_sts)(channel_t *c, user_t *u);
+extern void (*part_sts)(channel_t *c, user_t *u);
 /* add a kline on the servers matching the given mask
  * duration is in seconds, 0 for a permanent kline
  * if the ircd requires klines to be sent from users, use opersvs */
-E void (*kline_sts)(const char *server, const char *user, const char *host, long duration, const char *reason);
+extern void (*kline_sts)(const char *server, const char *user, const char *host, long duration, const char *reason);
 /* remove a kline on the servers matching the given mask
  * if the ircd requires unklines to be sent from users, use opersvs */
-E void (*unkline_sts)(const char *server, const char *user, const char *host);
+extern void (*unkline_sts)(const char *server, const char *user, const char *host);
 /* add a xline on the servers matching the given mask
  * duration is in seconds, 0 for a permanent xline
  * if the ircd requires xlines to be sent from users, use opersvs */
-E void (*xline_sts)(const char *server, const char *realname, long duration, const char *reason);
+extern void (*xline_sts)(const char *server, const char *realname, long duration, const char *reason);
 /* remove a xline on the servers matching the given mask
  * if the ircd requires unxlines to be sent from users, use opersvs */
-E void (*unxline_sts)(const char *server, const char *realname);
+extern void (*unxline_sts)(const char *server, const char *realname);
 /* add a qline on the servers matching the given mask
  * duration is in seconds, 0 for a permanent qline
  * if the ircd requires qlines to be sent from users, use opersvs */
-E void (*qline_sts)(const char *server, const char *mask, long duration, const char *reason);
+extern void (*qline_sts)(const char *server, const char *mask, long duration, const char *reason);
 /* remove a qline on the servers matching the given mask
  * if the ircd requires unqlines to be sent from users, use opersvs */
-E void (*unqline_sts)(const char *server, const char *mask);
+extern void (*unqline_sts)(const char *server, const char *mask);
 /* add a dline (sometimes called zline) on the servers matching mask
  * if the ircd requires dlines to be sent from users, use opersvs */
-E void (*dline_sts)(const char *server, const char *host, long duration, const char *reason);
+extern void (*dline_sts)(const char *server, const char *host, long duration, const char *reason);
 /* remove a dline (sometimes called zline) on the servers matching the given mask
  * if the ircd requires undlines to be sent from users, use opersvs */
-E void (*undline_sts)(const char *server, const char *host);
+extern void (*undline_sts)(const char *server, const char *host);
 /* make the given service set a topic on a channel
  * setter and ts should be used if the ircd supports topics to be set
  * with a given topicsetter and topicts; ts is not a channelts
@@ -177,22 +177,22 @@ E void (*undline_sts)(const char *server, const char *host);
  * useful in optimizing which form of topic change to use
  * if the given topicts was not set and topicts is used on the ircd,
  * set c->topicts to the value used */
-E void (*topic_sts)(channel_t *c, user_t *source, const char *setter, time_t ts, time_t prevts, const char *topic);
+extern void (*topic_sts)(channel_t *c, user_t *source, const char *setter, time_t ts, time_t prevts, const char *topic);
 /* set modes on a channel by the given sender; sender must be a client
  * on the services server; sender may or may not be on channel */
-E void (*mode_sts)(char *sender, channel_t *target, char *modes);
+extern void (*mode_sts)(char *sender, channel_t *target, char *modes);
 /* ping the uplink
  * first check if me.connected is true and bail if not */
-E void (*ping_sts)(void);
+extern void (*ping_sts)(void);
 /* mark user 'u' as logged in as 'account'
  * wantedhost is currently not used
  * first check if me.connected is true and bail if not */
-E void (*ircd_on_login)(user_t *u, myuser_t *account, const char *wantedhost);
+extern void (*ircd_on_login)(user_t *u, myuser_t *account, const char *wantedhost);
 /* mark user 'u' as logged out
  * first check if me.connected is true and bail if not
  * return false if successful or logins are not supported
  * return true if the user was killed to force logout (P10) */
-E bool (*ircd_on_logout)(user_t *u, const char *account);
+extern bool (*ircd_on_logout)(user_t *u, const char *account);
 /* introduce a fake server
  * it is ok to use opersvs to squit the old server
  * if SQUIT uses kill semantics (e.g. charybdis), server_delete() the server
@@ -200,108 +200,108 @@ E bool (*ircd_on_logout)(user_t *u, const char *account);
  * if SQUIT uses unconnect semantics (e.g. bahamut), set SF_JUPE_PENDING on
  * the server and return; you will be called again when the server is really
  * deleted */
-E void (*jupe)(const char *server, const char *reason);
+extern void (*jupe)(const char *server, const char *reason);
 /* set a dynamic spoof on a user
  * if the ircd does not notify the user of this, do
  * notice(source->nick, target->nick, "Setting your host to \2%s\2.", host); */
-E void (*sethost_sts)(user_t *source, user_t *target, const char *host);
+extern void (*sethost_sts)(user_t *source, user_t *target, const char *host);
 /* force a nickchange for a user
  * possible values for type:
  * FNC_REGAIN: give a registered user their nick back
  * FNC_FORCE:  force a user off their nick (kill if unsupported)
  */
-E void (*fnc_sts)(user_t *source, user_t *u, const char *newnick, int type);
+extern void (*fnc_sts)(user_t *source, user_t *u, const char *newnick, int type);
 /* temporarily make a nick unavailable to users
  * source is the responsible service
  * duration is in seconds, 0 to remove the effect of a previous call
  * account is an account that may still use the nick, or NULL */
-E void (*holdnick_sts)(user_t *source, int duration, const char *nick, myuser_t *account);
+extern void (*holdnick_sts)(user_t *source, int duration, const char *nick, myuser_t *account);
 /* change nick, user, host and/or services login name for a user
  * target may also be a not yet fully introduced UID (for SASL) */
-E void (*svslogin_sts)(char *target, char *nick, char *user, char *host, myuser_t *account);
+extern void (*svslogin_sts)(char *target, char *nick, char *user, char *host, myuser_t *account);
 /* send sasl message */
-E void (*sasl_sts) (const char *target, char mode, const char *data);
+extern void (*sasl_sts) (const char *target, char mode, const char *data);
 /* send sasl mech list */
-E void (*sasl_mechlist_sts)(const char *mechlist);
+extern void (*sasl_mechlist_sts)(const char *mechlist);
 /* find next channel ban (or other ban-like mode) matching user */
-E mowgli_node_t *(*next_matching_ban)(channel_t *c, user_t *u, int type, mowgli_node_t *first);
+extern mowgli_node_t *(*next_matching_ban)(channel_t *c, user_t *u, int type, mowgli_node_t *first);
 /* find next host channel access matching user */
-E mowgli_node_t *(*next_matching_host_chanacs)(mychan_t *mc, user_t *u, mowgli_node_t *first);
+extern mowgli_node_t *(*next_matching_host_chanacs)(mychan_t *mc, user_t *u, mowgli_node_t *first);
 /* check a nickname for validity; normally you don't need to override this */
-E bool (*is_valid_nick)(const char *nick);
+extern bool (*is_valid_nick)(const char *nick);
 /* check a username for validity; normally you don't need to override this */
-E bool (*is_valid_username)(const char *username);
+extern bool (*is_valid_username)(const char *username);
 /* check a vhost for validity; the core will already have checked for
  * @!?*, space, empty, : at start, length and cidr masks */
-E bool (*is_valid_host)(const char *host);
+extern bool (*is_valid_host)(const char *host);
 /* burst a channel mlock. */
-E void (*mlock_sts)(channel_t *c);
+extern void (*mlock_sts)(channel_t *c);
 /* burst a channel topiclock */
-E void (*topiclock_sts)(channel_t *c);
+extern void (*topiclock_sts)(channel_t *c);
 /* attempt to quarantine a user.
  * in Unreal-esque terms, this means SHUN.
  * in Hybrid, this means CAPTURE.
  * pretty much the same thing either way.
  */
-E void (*quarantine_sts)(user_t *source, user_t *victim, long duration, const char *reason);
+extern void (*quarantine_sts)(user_t *source, user_t *victim, long duration, const char *reason);
 /* Ask the proto module if this is valid as an extban */
-E bool (*is_extban)(const char *mask);
+extern bool (*is_extban)(const char *mask);
 
-E unsigned int generic_server_login(void);
-E void generic_introduce_nick(user_t *u);
-E void generic_invite_sts(user_t *source, user_t *target, channel_t *channel);
-E void generic_quit_sts(user_t *u, const char *reason);
-E void generic_wallops_sts(const char *text);
-E void generic_join_sts(channel_t *c, user_t *u, bool isnew, char *modes);
-E void generic_chan_lowerts(channel_t *c, user_t *u);
-E void generic_kick(user_t *source, channel_t *c, user_t *u, const char *reason);
-E void generic_msg(const char *from, const char *target, const char *fmt, ...);
-E void generic_msg_global_sts(user_t *from, const char *mask, const char *text);
-E void generic_notice_user_sts(user_t *from, user_t *target, const char *text);
-E void generic_notice_global_sts(user_t *from, const char *mask, const char *text);
-E void generic_notice_channel_sts(user_t *from, channel_t *target, const char *text);
-E void generic_wallchops(user_t *source, channel_t *target, const char *message);
-E void generic_numeric_sts(server_t *from, int numeric, user_t *target, const char *fmt, ...);
-E void generic_kill_id_sts(user_t *killer, const char *id, const char *reason);
-E void generic_part_sts(channel_t *c, user_t *u);
-E void generic_kline_sts(const char *server, const char *user, const char *host, long duration, const char *reason);
-E void generic_unkline_sts(const char *server, const char *user, const char *host);
-E void generic_xline_sts(const char *server, const char *realname, long duration, const char *reason);
-E void generic_unxline_sts(const char *server, const char *realname);
-E void generic_qline_sts(const char *server, const char *mask, long duration, const char *reason);
-E void generic_unqline_sts(const char *server, const char *mask);
-E void generic_topic_sts(channel_t *c, user_t *source, const char *setter, time_t ts, time_t prevts, const char *topic);
-E void generic_mode_sts(char *sender, channel_t *target, char *modes);
-E void generic_ping_sts(void);
-E void generic_on_login(user_t *u, myuser_t *account, const char *wantedhost);
-E bool generic_on_logout(user_t *u, const char *account);
-E void generic_jupe(const char *server, const char *reason);
-E void generic_sethost_sts(user_t *source, user_t *target, const char *host);
-E void generic_fnc_sts(user_t *source, user_t *u, const char *newnick, int type);
-E void generic_holdnick_sts(user_t *source, int duration, const char *nick, myuser_t *account);
-E void generic_svslogin_sts(char *target, char *nick, char *user, char *host, myuser_t *account);
-E void generic_sasl_sts(const char *target, char mode, const char *data);
-E void generic_sasl_mechlist_sts(const char *mechlist);
-E mowgli_node_t *generic_next_matching_ban(channel_t *c, user_t *u, int type, mowgli_node_t *first);
-E mowgli_node_t *generic_next_matching_host_chanacs(mychan_t *mc, user_t *u, mowgli_node_t *first);
-E bool generic_is_valid_host(const char *host);
-E bool generic_is_valid_nick(const char *nick);
-E bool generic_is_valid_username(const char *username);
-E void generic_mlock_sts(channel_t *c);
-E void generic_topiclock_sts(channel_t *c);
-E void generic_quarantine_sts(user_t *source, user_t *victim, long duration, const char *reason);
-E bool generic_is_extban(const char *mask);
-E void generic_dline_sts(const char *server, const char *host, long duration, const char *reason);
-E void generic_undline_sts(const char *server, const char *host);
+extern unsigned int generic_server_login(void);
+extern void generic_introduce_nick(user_t *u);
+extern void generic_invite_sts(user_t *source, user_t *target, channel_t *channel);
+extern void generic_quit_sts(user_t *u, const char *reason);
+extern void generic_wallops_sts(const char *text);
+extern void generic_join_sts(channel_t *c, user_t *u, bool isnew, char *modes);
+extern void generic_chan_lowerts(channel_t *c, user_t *u);
+extern void generic_kick(user_t *source, channel_t *c, user_t *u, const char *reason);
+extern void generic_msg(const char *from, const char *target, const char *fmt, ...);
+extern void generic_msg_global_sts(user_t *from, const char *mask, const char *text);
+extern void generic_notice_user_sts(user_t *from, user_t *target, const char *text);
+extern void generic_notice_global_sts(user_t *from, const char *mask, const char *text);
+extern void generic_notice_channel_sts(user_t *from, channel_t *target, const char *text);
+extern void generic_wallchops(user_t *source, channel_t *target, const char *message);
+extern void generic_numeric_sts(server_t *from, int numeric, user_t *target, const char *fmt, ...);
+extern void generic_kill_id_sts(user_t *killer, const char *id, const char *reason);
+extern void generic_part_sts(channel_t *c, user_t *u);
+extern void generic_kline_sts(const char *server, const char *user, const char *host, long duration, const char *reason);
+extern void generic_unkline_sts(const char *server, const char *user, const char *host);
+extern void generic_xline_sts(const char *server, const char *realname, long duration, const char *reason);
+extern void generic_unxline_sts(const char *server, const char *realname);
+extern void generic_qline_sts(const char *server, const char *mask, long duration, const char *reason);
+extern void generic_unqline_sts(const char *server, const char *mask);
+extern void generic_topic_sts(channel_t *c, user_t *source, const char *setter, time_t ts, time_t prevts, const char *topic);
+extern void generic_mode_sts(char *sender, channel_t *target, char *modes);
+extern void generic_ping_sts(void);
+extern void generic_on_login(user_t *u, myuser_t *account, const char *wantedhost);
+extern bool generic_on_logout(user_t *u, const char *account);
+extern void generic_jupe(const char *server, const char *reason);
+extern void generic_sethost_sts(user_t *source, user_t *target, const char *host);
+extern void generic_fnc_sts(user_t *source, user_t *u, const char *newnick, int type);
+extern void generic_holdnick_sts(user_t *source, int duration, const char *nick, myuser_t *account);
+extern void generic_svslogin_sts(char *target, char *nick, char *user, char *host, myuser_t *account);
+extern void generic_sasl_sts(const char *target, char mode, const char *data);
+extern void generic_sasl_mechlist_sts(const char *mechlist);
+extern mowgli_node_t *generic_next_matching_ban(channel_t *c, user_t *u, int type, mowgli_node_t *first);
+extern mowgli_node_t *generic_next_matching_host_chanacs(mychan_t *mc, user_t *u, mowgli_node_t *first);
+extern bool generic_is_valid_host(const char *host);
+extern bool generic_is_valid_nick(const char *nick);
+extern bool generic_is_valid_username(const char *username);
+extern void generic_mlock_sts(channel_t *c);
+extern void generic_topiclock_sts(channel_t *c);
+extern void generic_quarantine_sts(user_t *source, user_t *victim, long duration, const char *reason);
+extern bool generic_is_extban(const char *mask);
+extern void generic_dline_sts(const char *server, const char *host, long duration, const char *reason);
+extern void generic_undline_sts(const char *server, const char *host);
 
-E struct cmode_ *mode_list;
-E struct extmode *ignore_mode_list;
-E size_t ignore_mode_list_size;
-E struct cmode_ *status_mode_list;
-E struct cmode_ *prefix_mode_list;
-E struct cmode_ *user_mode_list;
+extern struct cmode_ *mode_list;
+extern struct extmode *ignore_mode_list;
+extern size_t ignore_mode_list_size;
+extern struct cmode_ *status_mode_list;
+extern struct cmode_ *prefix_mode_list;
+extern struct cmode_ *user_mode_list;
 
-E ircd_t *ircd;
+extern ircd_t *ircd;
 
 #endif
 

--- a/include/pmodule.h
+++ b/include/pmodule.h
@@ -27,44 +27,44 @@ struct pcommand_ {
 #define MAXPARC		35 /* max # params to protocol command */
 
 /* pmodule.c */
-E mowgli_heap_t *pcommand_heap;
-E mowgli_heap_t *messagetree_heap;
-E mowgli_patricia_t *pcommands;
+extern mowgli_heap_t *pcommand_heap;
+extern mowgli_heap_t *messagetree_heap;
+extern mowgli_patricia_t *pcommands;
 
-E bool pmodule_loaded;
+extern bool pmodule_loaded;
 
-E void pcommand_init(void);
-E void pcommand_add(const char *token,
+extern void pcommand_init(void);
+extern void pcommand_add(const char *token,
 	void (*handler)(sourceinfo_t *si, int parc, char *parv[]),
 	int minparc, int sourcetype);
-E void pcommand_delete(const char *token);
-E pcommand_t *pcommand_find(const char *token);
+extern void pcommand_delete(const char *token);
+extern pcommand_t *pcommand_find(const char *token);
 
 /* ptasks.c */
-E int get_version_string(char *, size_t);
-E void handle_version(user_t *);
-E void handle_admin(user_t *);
-E void handle_info(user_t *);
-E void handle_stats(user_t *, char);
-E void handle_whois(user_t *, const char *);
-E void handle_trace(user_t *, const char *, const char *);
-E void handle_motd(user_t *);
-E void handle_away(user_t *, const char *);
-E void handle_message(sourceinfo_t *, char *, bool, char *);
-E void handle_topic_from(sourceinfo_t *, channel_t *, const char *, time_t, const char *);
-E void handle_kill(sourceinfo_t *, const char *, const char *);
-E server_t *handle_server(sourceinfo_t *, const char *, const char *, int, const char *);
-E void handle_eob(server_t *);
-E bool should_reg_umode(user_t *);
+extern int get_version_string(char *, size_t);
+extern void handle_version(user_t *);
+extern void handle_admin(user_t *);
+extern void handle_info(user_t *);
+extern void handle_stats(user_t *, char);
+extern void handle_whois(user_t *, const char *);
+extern void handle_trace(user_t *, const char *, const char *);
+extern void handle_motd(user_t *);
+extern void handle_away(user_t *, const char *);
+extern void handle_message(sourceinfo_t *, char *, bool, char *);
+extern void handle_topic_from(sourceinfo_t *, channel_t *, const char *, time_t, const char *);
+extern void handle_kill(sourceinfo_t *, const char *, const char *);
+extern server_t *handle_server(sourceinfo_t *, const char *, const char *, int, const char *);
+extern void handle_eob(server_t *);
+extern bool should_reg_umode(user_t *);
 
 /* services.c */
-E void services_init(void);
-E void reintroduce_user(user_t *u);
-E void handle_nickchange(user_t *u);
-E void handle_burstlogin(user_t *u, const char *login, time_t ts);
-E void handle_setlogin(sourceinfo_t *si, user_t *u, const char *login, time_t ts);
-E void handle_certfp(sourceinfo_t *si, user_t *u, const char *certfp);
-E void handle_clearlogin(sourceinfo_t *si, user_t *u);
+extern void services_init(void);
+extern void reintroduce_user(user_t *u);
+extern void handle_nickchange(user_t *u);
+extern void handle_burstlogin(user_t *u, const char *login, time_t ts);
+extern void handle_setlogin(sourceinfo_t *si, user_t *u, const char *login, time_t ts);
+extern void handle_certfp(sourceinfo_t *si, user_t *u, const char *certfp);
+extern void handle_clearlogin(sourceinfo_t *si, user_t *u);
 
 #endif
 

--- a/include/privs.h
+++ b/include/privs.h
@@ -79,47 +79,47 @@ struct soper_ {
 #define SOPER_CONF	0x1 /* oper is listed in atheme.conf */
 
 /* privs.c */
-E mowgli_list_t operclasslist;
-E mowgli_list_t soperlist;
+extern mowgli_list_t operclasslist;
+extern mowgli_list_t soperlist;
 
-E void init_privs(void);
+extern void init_privs(void);
 
-E operclass_t *operclass_add(const char *name, const char *privs, int flags);
-E void operclass_delete(operclass_t *operclass);
-E operclass_t *operclass_find(const char *name);
+extern operclass_t *operclass_add(const char *name, const char *privs, int flags);
+extern void operclass_delete(operclass_t *operclass);
+extern operclass_t *operclass_find(const char *name);
 
-E soper_t *soper_add(const char *name, const char *classname, int flags, const char *password);
-E void soper_delete(soper_t *soper);
-E soper_t *soper_find(myuser_t *myuser);
-E soper_t *soper_find_named(const char *name);
+extern soper_t *soper_add(const char *name, const char *classname, int flags, const char *password);
+extern void soper_delete(soper_t *soper);
+extern soper_t *soper_find(myuser_t *myuser);
+extern soper_t *soper_find_named(const char *name);
 
-E bool is_soper(myuser_t *myuser);
-E bool is_conf_soper(myuser_t *myuser);
+extern bool is_soper(myuser_t *myuser);
+extern bool is_conf_soper(myuser_t *myuser);
 
 /* has_any_privs(): used to determine whether we should give detailed
  * messages about disallowed things
  * warning: do not use this for any kind of real privilege! */
-E bool has_any_privs(sourceinfo_t *);
-E bool has_any_privs_user(user_t *);
+extern bool has_any_privs(sourceinfo_t *);
+extern bool has_any_privs_user(user_t *);
 /* has_priv(): for sources of commands */
-E bool has_priv(sourceinfo_t *, const char *);
+extern bool has_priv(sourceinfo_t *, const char *);
 /* has_priv_user(): for online users */
-E bool has_priv_user(user_t *, const char *);
+extern bool has_priv_user(user_t *, const char *);
 /* has_priv_myuser(): channel succession etc */
-E bool has_priv_myuser(myuser_t *, const char *);
+extern bool has_priv_myuser(myuser_t *, const char *);
 /* has_priv_operclass(): /os specs etc */
-E bool has_priv_operclass(operclass_t *, const char *);
+extern bool has_priv_operclass(operclass_t *, const char *);
 /* has_all_operclass(): checks if source has all privs in operclass */
-E bool has_all_operclass(sourceinfo_t *, operclass_t *);
+extern bool has_all_operclass(sourceinfo_t *, operclass_t *);
 
 /* get_sourceinfo_soper(): get the specific operclass role which is granting
  * privilege authority
  */
-E const soper_t *get_sourceinfo_soper(sourceinfo_t *si);
+extern const soper_t *get_sourceinfo_soper(sourceinfo_t *si);
 /* get_sourceinfo_operclass(): get the specific operclass role which is granting
  * privilege authority
  */
-E const operclass_t *get_sourceinfo_operclass(sourceinfo_t *si);
+extern const operclass_t *get_sourceinfo_operclass(sourceinfo_t *si);
 
 #endif /* PRIVS_H */
 

--- a/include/servers.h
+++ b/include/servers.h
@@ -54,18 +54,18 @@ typedef struct {
 #define ME			(ircd->uses_uid ? me.numeric : me.name)
 
 /* servers.c */
-E mowgli_patricia_t *servlist;
-E mowgli_list_t tldlist;
+extern mowgli_patricia_t *servlist;
+extern mowgli_list_t tldlist;
 
-E void init_servers(void);
+extern void init_servers(void);
 
-E tld_t *tld_add(const char *name);
-E void tld_delete(const char *name);
-E tld_t *tld_find(const char *name);
+extern tld_t *tld_add(const char *name);
+extern void tld_delete(const char *name);
+extern tld_t *tld_find(const char *name);
 
-E server_t *server_add(const char *name, unsigned int hops, server_t *uplink, const char *id, const char *desc);
-E void server_delete(const char *name);
-E server_t *server_find(const char *name);
+extern server_t *server_add(const char *name, unsigned int hops, server_t *uplink, const char *id, const char *desc);
+extern void server_delete(const char *name);
+extern server_t *server_find(const char *name);
 
 #endif
 

--- a/include/services.h
+++ b/include/services.h
@@ -82,64 +82,64 @@ struct nicksvs_
 #define FLOOD_LIGHT 0
 
 /* atheme.c */
-E chansvs_t chansvs;
-E nicksvs_t nicksvs;
+extern chansvs_t chansvs;
+extern nicksvs_t nicksvs;
 
 /* services.c */
-E int authservice_loaded;
-E int use_myuser_access;
-E int use_svsignore;
-E int use_privmsg;
-E int use_account_private;
-E int use_channel_private;
-E int use_limitflags;
+extern int authservice_loaded;
+extern int use_myuser_access;
+extern int use_svsignore;
+extern int use_privmsg;
+extern int use_account_private;
+extern int use_channel_private;
+extern int use_limitflags;
 
-E int ban(user_t *source, channel_t *chan, user_t *target);
-E int remove_banlike(user_t *source, channel_t *chan, int type, user_t *target);
-E int remove_ban_exceptions(user_t *source, channel_t *chan, user_t *target);
+extern int ban(user_t *source, channel_t *chan, user_t *target);
+extern int remove_banlike(user_t *source, channel_t *chan, int type, user_t *target);
+extern int remove_ban_exceptions(user_t *source, channel_t *chan, user_t *target);
 
-E void try_kick_real(user_t *source, channel_t *chan, user_t *target, const char *reason);
-E void (*try_kick)(user_t *source, channel_t *chan, user_t *target, const char *reason);
+extern void try_kick_real(user_t *source, channel_t *chan, user_t *target, const char *reason);
+extern void (*try_kick)(user_t *source, channel_t *chan, user_t *target, const char *reason);
 
-E void kill_user(user_t *source, user_t *victim, const char *fmt, ...) PRINTFLIKE(3, 4);
-E void introduce_enforcer(const char *nick);
-E void join(const char *chan, const char *nick);
-E void joinall(const char *name);
-E void part(const char *chan, const char *nick);
-E void partall(const char *name);
-E void myuser_login(service_t *svs, user_t *u, myuser_t *mu, bool sendaccount);
-E void verbose(mychan_t *mychan, const char *fmt, ...) PRINTFLIKE(2, 3);
-E void (*notice)(const char *from, const char *target, const char *fmt, ...) PRINTFLIKE(3, 4);
-E void change_notify(const char *from, user_t *to, const char *message, ...) PRINTFLIKE(3, 4);
-E bool bad_password(sourceinfo_t *si, myuser_t *mu);
+extern void kill_user(user_t *source, user_t *victim, const char *fmt, ...) PRINTFLIKE(3, 4);
+extern void introduce_enforcer(const char *nick);
+extern void join(const char *chan, const char *nick);
+extern void joinall(const char *name);
+extern void part(const char *chan, const char *nick);
+extern void partall(const char *name);
+extern void myuser_login(service_t *svs, user_t *u, myuser_t *mu, bool sendaccount);
+extern void verbose(mychan_t *mychan, const char *fmt, ...) PRINTFLIKE(2, 3);
+extern void (*notice)(const char *from, const char *target, const char *fmt, ...) PRINTFLIKE(3, 4);
+extern void change_notify(const char *from, user_t *to, const char *message, ...) PRINTFLIKE(3, 4);
+extern bool bad_password(sourceinfo_t *si, myuser_t *mu);
 
-E sourceinfo_t *sourceinfo_create(void);
-E void command_fail(sourceinfo_t *si, cmd_faultcode_t code, const char *fmt, ...) PRINTFLIKE(3, 4);
-E void command_success_nodata(sourceinfo_t *si, const char *fmt, ...) PRINTFLIKE(2, 3);
-E void command_success_string(sourceinfo_t *si, const char *result, const char *fmt, ...) PRINTFLIKE(3, 4);
-E void command_success_table(sourceinfo_t *si, table_t *table);
-E const char *get_source_name(sourceinfo_t *si);
-E const char *get_source_mask(sourceinfo_t *si);
-E const char *get_oper_name(sourceinfo_t *si);
-E const char *get_storage_oper_name(sourceinfo_t *si);
-E const char *get_source_security_label(sourceinfo_t *si);
+extern sourceinfo_t *sourceinfo_create(void);
+extern void command_fail(sourceinfo_t *si, cmd_faultcode_t code, const char *fmt, ...) PRINTFLIKE(3, 4);
+extern void command_success_nodata(sourceinfo_t *si, const char *fmt, ...) PRINTFLIKE(2, 3);
+extern void command_success_string(sourceinfo_t *si, const char *result, const char *fmt, ...) PRINTFLIKE(3, 4);
+extern void command_success_table(sourceinfo_t *si, table_t *table);
+extern const char *get_source_name(sourceinfo_t *si);
+extern const char *get_source_mask(sourceinfo_t *si);
+extern const char *get_oper_name(sourceinfo_t *si);
+extern const char *get_storage_oper_name(sourceinfo_t *si);
+extern const char *get_source_security_label(sourceinfo_t *si);
 
-E void wallops(const char *, ...) PRINTFLIKE(1, 2);
-E void verbose_wallops(const char *, ...) PRINTFLIKE(1, 2);
-E bool check_vhost_validity(sourceinfo_t *si, const char *host);
+extern void wallops(const char *, ...) PRINTFLIKE(1, 2);
+extern void verbose_wallops(const char *, ...) PRINTFLIKE(1, 2);
+extern bool check_vhost_validity(sourceinfo_t *si, const char *host);
 
 /* ptasks.c */
-E void handle_topic(channel_t *, const char *, time_t, const char *);
-E int floodcheck(user_t *, user_t *);
-E void command_add_flood(sourceinfo_t *si, unsigned int amount);
+extern void handle_topic(channel_t *, const char *, time_t, const char *);
+extern int floodcheck(user_t *, user_t *);
+extern void command_add_flood(sourceinfo_t *si, unsigned int amount);
 
 /* ctcp-common.c */
-E void common_ctcp_init(void);
-E unsigned int handle_ctcp_common(sourceinfo_t *si, char *, char *);
+extern void common_ctcp_init(void);
+extern unsigned int handle_ctcp_common(sourceinfo_t *si, char *, char *);
 
 #ifdef HAVE_LIBQRENCODE
 /* qrcode.c */
-E void command_success_qrcode(sourceinfo_t *si, const char *data);
+extern void command_success_qrcode(sourceinfo_t *si, const char *data);
 #endif /* HAVE_LIBQRENCODE */
 
 #endif /* !SERVICES_H */

--- a/include/servtree.h
+++ b/include/servtree.h
@@ -44,27 +44,27 @@ static inline const char *service_get_log_target(const service_t *svs)
 	return svs != NULL ? svs->nick : me.name;
 }
 
-E mowgli_patricia_t *services_name;
-E mowgli_patricia_t *services_nick;
+extern mowgli_patricia_t *services_name;
+extern mowgli_patricia_t *services_nick;
 
-E void servtree_init(void);
-E service_t *service_add(const char *name, void (*handler)(sourceinfo_t *si, int parc, char *parv[]));
-E service_t *service_add_static(const char *name, const char *user, const char *host, const char *real, void (*handler)(sourceinfo_t *si, int parc, char *parv[]), service_t *logtarget);
-E void service_delete(service_t *sptr);
-E service_t *service_find_any(void);
-E service_t *service_find(const char *name);
-E service_t *service_find_nick(const char *nick);
-E char *service_name(char *name);
-E void service_set_chanmsg(service_t *, bool);
-E const char *service_resolve_alias(service_t *sptr, const char *context, const char *cmd);
-E const char *service_set_access(service_t *sptr, const char *cmd, const char *access);
+extern void servtree_init(void);
+extern service_t *service_add(const char *name, void (*handler)(sourceinfo_t *si, int parc, char *parv[]));
+extern service_t *service_add_static(const char *name, const char *user, const char *host, const char *real, void (*handler)(sourceinfo_t *si, int parc, char *parv[]), service_t *logtarget);
+extern void service_delete(service_t *sptr);
+extern service_t *service_find_any(void);
+extern service_t *service_find(const char *name);
+extern service_t *service_find_nick(const char *nick);
+extern char *service_name(char *name);
+extern void service_set_chanmsg(service_t *, bool);
+extern const char *service_resolve_alias(service_t *sptr, const char *context, const char *cmd);
+extern const char *service_set_access(service_t *sptr, const char *cmd, const char *access);
 
-E void service_bind_command(service_t *, command_t *);
-E void service_unbind_command(service_t *, command_t *);
+extern void service_bind_command(service_t *, command_t *);
+extern void service_unbind_command(service_t *, command_t *);
 
-E void service_named_bind_command(const char *, command_t *);
-E void service_named_unbind_command(const char *, command_t *);
-E void servtree_update(void *dummy);
+extern void service_named_bind_command(const char *, command_t *);
+extern void service_named_unbind_command(const char *, command_t *);
+extern void servtree_update(void *dummy);
 
 #endif
 

--- a/include/table.h
+++ b/include/table.h
@@ -28,21 +28,21 @@ typedef struct {
 /*
  * Creates a new table object. Use object_unref() to destroy it.
  */
-E table_t *table_new(const char *fmt, ...) PRINTFLIKE(1, 2);
+extern table_t *table_new(const char *fmt, ...) PRINTFLIKE(1, 2);
 
 /*
  * Renders a table, each line going to callback().
  */
-E void table_render(table_t *t, void (*callback)(const char *line, void *data), void *data);
+extern void table_render(table_t *t, void (*callback)(const char *line, void *data), void *data);
 
 /*
  * Associates a value with a row.
  */
-E void table_cell_associate(table_row_t *r, const char *name, const char *value);
+extern void table_cell_associate(table_row_t *r, const char *name, const char *value);
 
 /*
  * Associates a row with a table.
  */
-E table_row_t *table_row_new(table_t *t);
+extern table_row_t *table_row_new(table_t *t);
 
 #endif

--- a/include/taint.h
+++ b/include/taint.h
@@ -16,7 +16,7 @@ typedef struct {
 	mowgli_node_t node;
 } taint_reason_t;
 
-E mowgli_list_t taint_list;
+extern mowgli_list_t taint_list;
 
 #define IS_TAINTED	MOWGLI_LIST_LENGTH(&taint_list)
 #define TAINT_ON(cond, reason) \

--- a/include/template.h
+++ b/include/template.h
@@ -13,15 +13,15 @@ typedef struct {
 	unsigned int flags;
 } default_template_t;
 
-E const char *getitem(const char *str, const char *name);
-E unsigned int get_template_flags(mychan_t *mc, const char *name);
+extern const char *getitem(const char *str, const char *name);
+extern unsigned int get_template_flags(mychan_t *mc, const char *name);
 
-E void set_global_template_flags(const char *name, unsigned int flags);
-E unsigned int get_global_template_flags(const char *name);
-E void clear_global_template_flags(void);
-E void fix_global_template_flags(void);
+extern void set_global_template_flags(const char *name, unsigned int flags);
+extern unsigned int get_global_template_flags(const char *name);
+extern void clear_global_template_flags(void);
+extern void fix_global_template_flags(void);
 
-E mowgli_patricia_t *global_template_dict;
+extern mowgli_patricia_t *global_template_dict;
 
 #endif /* TEMPLATE_H */
 

--- a/include/tools.h
+++ b/include/tools.h
@@ -11,7 +11,7 @@
 #define ATHEME_TOOLS_H
 
 /* email stuff */
-E int sendemail(user_t *u, myuser_t *mu, const char *type, const char *email, const char *param);
+extern int sendemail(user_t *u, myuser_t *mu, const char *type, const char *email, const char *param);
 
 /* email types (meaning of param argument) */
 #define EMAIL_REGISTER	"register"	/* register an account/nick (verification code) */
@@ -22,14 +22,14 @@ E int sendemail(user_t *u, myuser_t *mu, const char *type, const char *email, co
 
 /* arc4random.c */
 #ifndef HAVE_ARC4RANDOM
-E void arc4random_stir(void);
-E void arc4random_addrandom(unsigned char *dat, int datlen);
-E unsigned int arc4random(void);
+extern void arc4random_stir(void);
+extern void arc4random_addrandom(unsigned char *dat, int datlen);
+extern unsigned int arc4random(void);
 #ifndef HAVE_ARC4RANDOM_BUF
-E void arc4random_buf(void *buf, size_t n);
+extern void arc4random_buf(void *buf, size_t n);
 #endif /* !HAVE_ARC4RANDOM_BUF */
 #ifndef HAVE_ARC4RANDOM_UNIFORM
-E uint32_t arc4random_uniform(uint32_t upper_bound);
+extern uint32_t arc4random_uniform(uint32_t upper_bound);
 #endif /* !HAVE_ARC4RANDOM_UNIFORM */
 #endif /* !HAVE_ARC4RANDOM */
 
@@ -38,13 +38,13 @@ E uint32_t arc4random_uniform(uint32_t upper_bound);
 #  ifdef HAVE_MEMSET_S
 #    define explicit_bzero(p, n) memset_s((p), (n), 0x00, (n))
 #  else /* HAVE_MEMSET_S */
-E void *(* volatile volatile_memset)(void *, int, size_t);
-E void explicit_bzero(void *p, size_t n);
+extern void *(* volatile volatile_memset)(void *, int, size_t);
+extern void explicit_bzero(void *p, size_t n);
 #  endif /* !HAVE_MEMSET_S */
 #endif /* !HAVE_EXPLICIT_BZERO */
 
 /* cidr.c */
-E int valid_ip_or_mask(const char *src);
+extern int valid_ip_or_mask(const char *src);
 
 typedef enum {
 	LOG_ANY = 0,
@@ -70,12 +70,12 @@ struct logfile_ {
 	log_type_t log_type;
 };
 
-E char *log_path; /* contains path to default log. */
-E int log_force;
+extern char *log_path; /* contains path to default log. */
+extern int log_force;
 
-E logfile_t *logfile_new(const char *log_path_, unsigned int log_mask);
-E void logfile_register(logfile_t *lf);
-E void logfile_unregister(logfile_t *lf);
+extern logfile_t *logfile_new(const char *log_path_, unsigned int log_mask);
+extern void logfile_register(logfile_t *lf);
+extern void logfile_unregister(logfile_t *lf);
 
 /* general */
 #define LG_NONE         0x00000001      /* don't log                */
@@ -113,15 +113,15 @@ E void logfile_unregister(logfile_t *lf);
 #define CMDLOG_LOGIN    LG_CMD_LOGIN
 #define CMDLOG_GET      LG_CMD_GET
 
-E void log_open(void);
-E void log_shutdown(void);
-E bool log_debug_enabled(void);
-E void log_master_set_mask(unsigned int mask);
-E logfile_t *logfile_find_mask(unsigned int log_mask);
-E void slog(unsigned int level, const char *fmt, ...) PRINTFLIKE(2, 3);
-E void logcommand(sourceinfo_t *si, int level, const char *fmt, ...) PRINTFLIKE(3, 4);
-E void logcommand_user(service_t *svs, user_t *source, int level, const char *fmt, ...) PRINTFLIKE(4, 5);
-E void logcommand_external(service_t *svs, const char *type, connection_t *source, const char *sourcedesc, myuser_t *login, int level, const char *fmt, ...) PRINTFLIKE(7, 8);
+extern void log_open(void);
+extern void log_shutdown(void);
+extern bool log_debug_enabled(void);
+extern void log_master_set_mask(unsigned int mask);
+extern logfile_t *logfile_find_mask(unsigned int log_mask);
+extern void slog(unsigned int level, const char *fmt, ...) PRINTFLIKE(2, 3);
+extern void logcommand(sourceinfo_t *si, int level, const char *fmt, ...) PRINTFLIKE(3, 4);
+extern void logcommand_user(service_t *svs, user_t *source, int level, const char *fmt, ...) PRINTFLIKE(4, 5);
+extern void logcommand_external(service_t *svs, const char *type, connection_t *source, const char *sourcedesc, myuser_t *login, int level, const char *fmt, ...) PRINTFLIKE(7, 8);
 
 /* function.c */
 
@@ -134,35 +134,35 @@ typedef struct {
 } email_canonicalizer_item_t;
 
 /* misc string stuff */
-E char *random_string(size_t sz);
-E void create_challenge(sourceinfo_t *si, const char *name, int v, char *dest);
-E void tb2sp(char *line);
-E char *replace(char *s, int size, const char *old, const char *new);
-E const char *number_to_string(int num);
-E int validemail(const char *email);
-E stringref canonicalize_email(const char *email);
-E void canonicalize_email_case(char email[EMAILLEN + 1], void *user_data);
-E void register_email_canonicalizer(email_canonicalizer_t func, void *user_data);
-E void unregister_email_canonicalizer(email_canonicalizer_t func, void *user_data);
-E bool email_within_limits(const char *email);
-E bool validhostmask(const char *host);
-E char *pretty_mask(char *mask);
-E bool validtopic(const char *topic);
-E bool has_ctrl_chars(const char *text);
-E char *sbytes(float x);
-E float bytes(float x);
+extern char *random_string(size_t sz);
+extern void create_challenge(sourceinfo_t *si, const char *name, int v, char *dest);
+extern void tb2sp(char *line);
+extern char *replace(char *s, int size, const char *old, const char *new);
+extern const char *number_to_string(int num);
+extern int validemail(const char *email);
+extern stringref canonicalize_email(const char *email);
+extern void canonicalize_email_case(char email[EMAILLEN + 1], void *user_data);
+extern void register_email_canonicalizer(email_canonicalizer_t func, void *user_data);
+extern void unregister_email_canonicalizer(email_canonicalizer_t func, void *user_data);
+extern bool email_within_limits(const char *email);
+extern bool validhostmask(const char *host);
+extern char *pretty_mask(char *mask);
+extern bool validtopic(const char *topic);
+extern bool has_ctrl_chars(const char *text);
+extern char *sbytes(float x);
+extern float bytes(float x);
 
-E unsigned long makekey(void);
-E int srename(const char *old_fn, const char *new_fn);
+extern unsigned long makekey(void);
+extern int srename(const char *old_fn, const char *new_fn);
 
 /* time stuff */
 #if HAVE_GETTIMEOFDAY
-E void s_time(struct timeval *sttime);
-E void e_time(struct timeval sttime, struct timeval *ttime);
-E int tv2ms(struct timeval *tv);
+extern void s_time(struct timeval *sttime);
+extern void e_time(struct timeval sttime, struct timeval *ttime);
+extern int tv2ms(struct timeval *tv);
 #endif
-E char *time_ago(time_t event);
-E char *timediff(time_t seconds);
+extern char *time_ago(time_t event);
+extern char *timediff(time_t seconds);
 
 #ifndef timersub
 #define timersub(tvp, uvp, vvp)                                         \
@@ -177,18 +177,18 @@ E char *timediff(time_t seconds);
 #endif
 
 /* tokenize.c */
-E int sjtoken(char *message, char delimiter, char **parv);
-E int tokenize(char *message, char **parv);
+extern int sjtoken(char *message, char delimiter, char **parv);
+extern int tokenize(char *message, char **parv);
 
 /* ubase64.c */
-E const char *uinttobase64(char *buf, uint64_t v, int64_t count);
-E unsigned int base64touint(const char *buf);
-E void decode_p10_ip(const char *b64, char ipstring[HOSTIPLEN]);
+extern const char *uinttobase64(char *buf, uint64_t v, int64_t count);
+extern unsigned int base64touint(const char *buf);
+extern void decode_p10_ip(const char *b64, char ipstring[HOSTIPLEN]);
 
 /* sharedheap.c */
-E mowgli_heap_t *sharedheap_get(size_t size);
-E void sharedheap_unref(mowgli_heap_t *heap);
-E char *combine_path(const char *parent, const char *child);
+extern mowgli_heap_t *sharedheap_get(size_t size);
+extern void sharedheap_unref(mowgli_heap_t *heap);
+extern char *combine_path(const char *parent, const char *child);
 
 #if !HAVE_VSNPRINTF
 int rpl_vsnprintf(char *, size_t, const char *, va_list);

--- a/include/uplink.h
+++ b/include/uplink.h
@@ -32,27 +32,27 @@ struct uplink_
 #define UPF_ILLEGAL 0x80000000 /* not in conf anymore, delete when disconnected */
 
 /* uplink.c */
-E mowgli_list_t uplinks;
-E uplink_t *curr_uplink;
+extern mowgli_list_t uplinks;
+extern uplink_t *curr_uplink;
 
-E void init_uplinks(void);
-E uplink_t *uplink_add(const char *name, const char *host, const char *send_password, const char *receive_password, const char *vhost, int port);
-E void uplink_delete(uplink_t *u);
-E uplink_t *uplink_find(const char *name);
-E void uplink_connect(void);
+extern void init_uplinks(void);
+extern uplink_t *uplink_add(const char *name, const char *host, const char *send_password, const char *receive_password, const char *vhost, int port);
+extern void uplink_delete(uplink_t *u);
+extern uplink_t *uplink_find(const char *name);
+extern void uplink_connect(void);
 
 /* packet.c */
 /* bursting timer */
 #if HAVE_GETTIMEOFDAY
-E struct timeval burstime;
+extern struct timeval burstime;
 #endif
 
-E void (*parse)(char *line);
-E void irc_handle_connect(connection_t *cptr);
+extern void (*parse)(char *line);
+extern void irc_handle_connect(connection_t *cptr);
 
 /* send.c */
-E int sts(const char *fmt, ...) PRINTFLIKE(1, 2);
-E void io_loop(void);
+extern int sts(const char *fmt, ...) PRINTFLIKE(1, 2);
+extern void io_loop(void);
 
 #endif
 

--- a/include/users.h
+++ b/include/users.h
@@ -70,32 +70,32 @@ typedef struct {
 } hook_user_delete_t;
 
 /* function.c */
-E bool is_ircop(user_t *user);
-E bool is_admin(user_t *user);
-E bool is_internal_client(user_t *user);
-E bool is_autokline_exempt(user_t *user);
-E bool is_service(user_t *user);
+extern bool is_ircop(user_t *user);
+extern bool is_admin(user_t *user);
+extern bool is_internal_client(user_t *user);
+extern bool is_autokline_exempt(user_t *user);
+extern bool is_service(user_t *user);
 
 /* users.c */
-E mowgli_patricia_t *userlist;
-E mowgli_patricia_t *uidlist;
+extern mowgli_patricia_t *userlist;
+extern mowgli_patricia_t *uidlist;
 
-E void init_users(void);
+extern void init_users(void);
 
-E user_t *user_add(const char *nick, const char *user, const char *host, const char *vhost, const char *ip, const char *uid, const char *gecos, server_t *server, time_t ts);
-E void user_delete(user_t *u, const char *comment);
-E user_t *user_find(const char *nick);
-E user_t *user_find_named(const char *nick);
-E void user_changeuid(user_t *u, const char *uid);
-E bool user_changenick(user_t *u, const char *nick, time_t ts);
-E void user_mode(user_t *user, const char *modes);
-E void user_sethost(user_t *source, user_t *target, const char *host);
-E const char *user_get_umodestr(user_t *u);
-E bool user_is_channel_banned(user_t *u, char ban_type);
+extern user_t *user_add(const char *nick, const char *user, const char *host, const char *vhost, const char *ip, const char *uid, const char *gecos, server_t *server, time_t ts);
+extern void user_delete(user_t *u, const char *comment);
+extern user_t *user_find(const char *nick);
+extern user_t *user_find_named(const char *nick);
+extern void user_changeuid(user_t *u, const char *uid);
+extern bool user_changenick(user_t *u, const char *nick, time_t ts);
+extern void user_mode(user_t *user, const char *modes);
+extern void user_sethost(user_t *source, user_t *target, const char *host);
+extern const char *user_get_umodestr(user_t *u);
+extern bool user_is_channel_banned(user_t *u, char ban_type);
 
 /* uid.c */
-E void init_uid(void);
-E const char *uid_get(void);
+extern void init_uid(void);
+extern const char *uid_get(void);
 
 #endif
 

--- a/libathemecore/internal.h
+++ b/libathemecore/internal.h
@@ -10,14 +10,14 @@
 #define INTERNAL_H
 
 /* internal functions */
-E void event_init(void);
-E void hooks_init(void);
-E void init_dlink_nodes(void);
-E void init_netio(void);
-E void init_socket_queues(void);
-E void init_signal_handlers(void);
+extern void event_init(void);
+extern void hooks_init(void);
+extern void init_dlink_nodes(void);
+extern void init_netio(void);
+extern void init_socket_queues(void);
+extern void init_signal_handlers(void);
 
-E void language_init(void);
+extern void language_init(void);
 
 #endif
 

--- a/modules/botserv/main.c
+++ b/modules/botserv/main.c
@@ -32,7 +32,7 @@ service_t *botsvs;
 
 unsigned int min_users = 0;
 
-E mowgli_list_t mychan;
+extern mowgli_list_t mychan;
 
 mowgli_list_t bs_bots;
 

--- a/modules/chanfix/chanfix.h
+++ b/modules/chanfix/chanfix.h
@@ -62,32 +62,32 @@ typedef struct chanfix_persist {
 	mowgli_patricia_t *chanfix_channels;
 } chanfix_persist_record_t;
 
-E service_t *chanfix;
-E mowgli_patricia_t *chanfix_channels;
+extern service_t *chanfix;
+extern mowgli_patricia_t *chanfix_channels;
 
-E void chanfix_gather_init(chanfix_persist_record_t *);
-E void chanfix_gather_deinit(module_unload_intent_t, chanfix_persist_record_t *);
+extern void chanfix_gather_init(chanfix_persist_record_t *);
+extern void chanfix_gather_deinit(module_unload_intent_t, chanfix_persist_record_t *);
 
-E void chanfix_oprecord_update(chanfix_channel_t *chan, user_t *u);
-E void chanfix_oprecord_delete(chanfix_oprecord_t *orec);
-E chanfix_oprecord_t *chanfix_oprecord_create(chanfix_channel_t *chan, user_t *u);
-E chanfix_oprecord_t *chanfix_oprecord_find(chanfix_channel_t *chan, user_t *u);
-E chanfix_channel_t *chanfix_channel_create(const char *name, channel_t *chan);
-E chanfix_channel_t *chanfix_channel_find(const char *name);
-E chanfix_channel_t *chanfix_channel_get(channel_t *chan);
-E void chanfix_gather(void *unused);
-E void chanfix_expire(void *unused);
+extern void chanfix_oprecord_update(chanfix_channel_t *chan, user_t *u);
+extern void chanfix_oprecord_delete(chanfix_oprecord_t *orec);
+extern chanfix_oprecord_t *chanfix_oprecord_create(chanfix_channel_t *chan, user_t *u);
+extern chanfix_oprecord_t *chanfix_oprecord_find(chanfix_channel_t *chan, user_t *u);
+extern chanfix_channel_t *chanfix_channel_create(const char *name, channel_t *chan);
+extern chanfix_channel_t *chanfix_channel_find(const char *name);
+extern chanfix_channel_t *chanfix_channel_get(channel_t *chan);
+extern void chanfix_gather(void *unused);
+extern void chanfix_expire(void *unused);
 
-E bool chanfix_do_autofix;
-E void chanfix_autofix_ev(void *unused);
-E void chanfix_can_register(hook_channel_register_check_t *req);
+extern bool chanfix_do_autofix;
+extern void chanfix_autofix_ev(void *unused);
+extern void chanfix_can_register(hook_channel_register_check_t *req);
 
-E command_t cmd_list;
-E command_t cmd_chanfix;
-E command_t cmd_scores;
-E command_t cmd_info;
-E command_t cmd_help;
-E command_t cmd_mark;
-E command_t cmd_nofix;
+extern command_t cmd_list;
+extern command_t cmd_chanfix;
+extern command_t cmd_scores;
+extern command_t cmd_info;
+extern command_t cmd_help;
+extern command_t cmd_mark;
+extern command_t cmd_nofix;
 
 #endif

--- a/modules/groupserv/main/groupserv_main.h
+++ b/modules/groupserv/main/groupserv_main.h
@@ -8,42 +8,42 @@
 #include "atheme.h"
 #include "groupserv_common.h"
 
-E groupserv_config_t gs_config;
+extern groupserv_config_t gs_config;
 
-E void mygroups_init(void);
-E void mygroups_deinit(void);
-E mygroup_t *mygroup_add(const char *name);
-E mygroup_t *mygroup_add_id(const char *id, const char *name);
-E mygroup_t *mygroup_find(const char *name);
+extern void mygroups_init(void);
+extern void mygroups_deinit(void);
+extern mygroup_t *mygroup_add(const char *name);
+extern mygroup_t *mygroup_add_id(const char *id, const char *name);
+extern mygroup_t *mygroup_find(const char *name);
 
-E groupacs_t *groupacs_add(mygroup_t *mg, myentity_t *mt, unsigned int flags);
-E groupacs_t *groupacs_find(mygroup_t *mg, myentity_t *mt, unsigned int flags, bool allow_recurse);
-E void groupacs_delete(mygroup_t *mg, myentity_t *mt);
+extern groupacs_t *groupacs_add(mygroup_t *mg, myentity_t *mt, unsigned int flags);
+extern groupacs_t *groupacs_find(mygroup_t *mg, myentity_t *mt, unsigned int flags, bool allow_recurse);
+extern void groupacs_delete(mygroup_t *mg, myentity_t *mt);
 
-E bool groupacs_sourceinfo_has_flag(mygroup_t *mg, sourceinfo_t *si, unsigned int flag);
+extern bool groupacs_sourceinfo_has_flag(mygroup_t *mg, sourceinfo_t *si, unsigned int flag);
 
-E void gs_db_init(void);
-E void gs_db_deinit(void);
+extern void gs_db_init(void);
+extern void gs_db_deinit(void);
 
-E void gs_hooks_init(void);
-E void gs_hooks_deinit(void);
+extern void gs_hooks_init(void);
+extern void gs_hooks_deinit(void);
 
-E void mygroup_set_chanacs_validator(myentity_t *mt);
-E unsigned int mygroup_count_flag(mygroup_t *mg, unsigned int flag);
-E unsigned int gs_flags_parser(char *flagstring, bool allow_minus, unsigned int flags);
-E void remove_group_chanacs(mygroup_t *mg);
+extern void mygroup_set_chanacs_validator(myentity_t *mt);
+extern unsigned int mygroup_count_flag(mygroup_t *mg, unsigned int flag);
+extern unsigned int gs_flags_parser(char *flagstring, bool allow_minus, unsigned int flags);
+extern void remove_group_chanacs(mygroup_t *mg);
 
-E mowgli_list_t *myentity_get_membership_list(myentity_t *mt);
-E unsigned int myentity_count_group_flag(myentity_t *mt, unsigned int flagset);
+extern mowgli_list_t *myentity_get_membership_list(myentity_t *mt);
+extern unsigned int myentity_count_group_flag(myentity_t *mt, unsigned int flagset);
 
-E const char *mygroup_founder_names(mygroup_t *mg);
+extern const char *mygroup_founder_names(mygroup_t *mg);
 
 /* services plumbing */
-E service_t *groupsvs;
-E mowgli_list_t gs_cmdtree;
-E mowgli_list_t conf_gs_table;
-E gflags_t ga_flags[];
-E gflags_t mg_flags[];
+extern service_t *groupsvs;
+extern mowgli_list_t gs_cmdtree;
+extern mowgli_list_t conf_gs_table;
+extern gflags_t ga_flags[];
+extern gflags_t mg_flags[];
 
 
 

--- a/modules/transport/jsonrpc/jsonrpclib.h
+++ b/modules/transport/jsonrpc/jsonrpclib.h
@@ -17,15 +17,15 @@ typedef struct {
     char *id;
 } jsonrpc_sourceinfo_t;
 
-E char *jsonrpc_normalizeBuffer(const char *buf);
+extern char *jsonrpc_normalizeBuffer(const char *buf);
 
-E jsonrpc_method_t get_json_method(const char *method_name);
+extern jsonrpc_method_t get_json_method(const char *method_name);
 
-E void jsonrpc_process(char *buffer, void *userdata);
-E void jsonrpc_register_method(const char *method_name, bool (*method)(void *conn, mowgli_list_t *params, char *id));
-E void jsonrpc_unregister_method(const char *method_name);
-E void jsonrpc_send_data(void *conn, char *str);
-E void jsonrpc_success_string(void *conn, const char *str, const char *id);
-E void jsonrpc_failure_string(void *conn, int code, const char *str, const char *id);
+extern void jsonrpc_process(char *buffer, void *userdata);
+extern void jsonrpc_register_method(const char *method_name, bool (*method)(void *conn, mowgli_list_t *params, char *id));
+extern void jsonrpc_unregister_method(const char *method_name);
+extern void jsonrpc_send_data(void *conn, char *str);
+extern void jsonrpc_success_string(void *conn, const char *str, const char *id);
+extern void jsonrpc_failure_string(void *conn, int code, const char *str, const char *id);
 
 #endif

--- a/modules/transport/rfc1459/rfc1459.h
+++ b/modules/transport/rfc1459/rfc1459.h
@@ -9,7 +9,7 @@
 #ifndef RFC1459_H
 #define RFC1459_H
 
-E void irc_parse(char *line);
+extern void irc_parse(char *line);
 
 #endif
 

--- a/modules/transport/xmlrpc/xmlrpclib.h
+++ b/modules/transport/xmlrpc/xmlrpclib.h
@@ -54,27 +54,27 @@
 
 typedef int (*XMLRPCMethodFunc)(void *userdata, int ac, char **av);
 
-E int xmlrpc_getlast_error(void);
-E void xmlrpc_process(char *buffer, void *userdata);
-E int xmlrpc_register_method(const char *name, XMLRPCMethodFunc func);
-E int xmlrpc_unregister_method(const char *method);
+extern int xmlrpc_getlast_error(void);
+extern void xmlrpc_process(char *buffer, void *userdata);
+extern int xmlrpc_register_method(const char *name, XMLRPCMethodFunc func);
+extern int xmlrpc_unregister_method(const char *method);
 
-E char *xmlrpc_array(int argc, ...);
-E char *xmlrpc_double(char *buf, double value);
-E char *xmlrpc_boolean(char *buf, int value);
-E char *xmlrpc_string(char *buf, const char *value);
-E char *xmlrpc_integer(char *buf, int value);
-E char *xmlrpc_time2date(char *buf, time_t t);
+extern char *xmlrpc_array(int argc, ...);
+extern char *xmlrpc_double(char *buf, double value);
+extern char *xmlrpc_boolean(char *buf, int value);
+extern char *xmlrpc_string(char *buf, const char *value);
+extern char *xmlrpc_integer(char *buf, int value);
+extern char *xmlrpc_time2date(char *buf, time_t t);
 
-E int xmlrpc_set_options(int type, const char *value);
-E void xmlrpc_set_buffer(char *(*func)(char *buffer, int len));
-E void xmlrpc_generic_error(int code, const char *string);
-E void xmlrpc_send(int argc, ...);
-E void xmlrpc_send_string(const char *value);
-E int xmlrpc_about(void *userdata, int ac, char **av);
-E void xmlrpc_char_encode(char *outbuffer, const char *s1);
-E char *xmlrpc_decode_string(char *buf);
-E char *xmlrpc_normalizeBuffer(const char *buf);
+extern int xmlrpc_set_options(int type, const char *value);
+extern void xmlrpc_set_buffer(char *(*func)(char *buffer, int len));
+extern void xmlrpc_generic_error(int code, const char *string);
+extern void xmlrpc_send(int argc, ...);
+extern void xmlrpc_send_string(const char *value);
+extern int xmlrpc_about(void *userdata, int ac, char **av);
+extern void xmlrpc_char_encode(char *outbuffer, const char *s1);
+extern char *xmlrpc_decode_string(char *buf);
+extern char *xmlrpc_normalizeBuffer(const char *buf);
 
 #endif
 


### PR DESCRIPTION
This 1-letter macro prevents us from having any variables named 'E',
or using any libraries whose headers declare variables named 'E', or
whose headers declare functions with arguments named 'E'.

As an aside, gcc provides this most excellent diagnostic in this
situation:

```
In file included from digest_fe_mbedtls.c:36:0:
../include/atheme.h:14:11: error: expected ';', ',' or ')' before 'extern'
 #define E extern
           ^
```

... yes, totally useless. Clang provides the much more useful:

```
In file included from digest_fe_mbedtls.c:44:
In file included from .../mbedtls/pkcs5.h:28:
In file included from .../mbedtls/asn1.h:35:
.../mbedtls/bignum.h:674:83: error: expected ')'
int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
    const mbedtls_mpi *E, const mbedtls_mpi *N, mbedtls_mpi *_RR );
                       ^

../include/atheme.h:14:11: note: expanded from macro 'E'
 #define E extern
           ^

.../mbedtls/bignum.h:674:24: note: to match this '('
int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
                       ^
1 error generated.
```