### PR TITLE
nickserv/enforce: blame a channel when denying /ns regain

### DIFF
--- a/include/users.h
+++ b/include/users.h
@@ -87,6 +87,7 @@ void user_mode(struct user *user, const char *modes);
 void user_sethost(struct user *source, struct user *target, const char *host);
 const char *user_get_umodestr(struct user *u);
 bool user_is_channel_banned(struct user *u, char ban_type);
+struct chanuser *find_user_banned_channel(struct user *u, char ban_type);
 
 /* uid.c */
 void init_uid(void);

--- a/libathemecore/users.c
+++ b/libathemecore/users.c
@@ -681,6 +681,34 @@ user_is_channel_banned(struct user *u, char ban_type)
 	return false;
 }
 
+struct chanuser *
+find_user_banned_channel(struct user *u, char ban_type)
+{
+	mowgli_node_t *n;
+
+	return_val_if_fail(u != NULL, false);
+	return_val_if_fail(ban_type != 0, false);
+
+	MOWGLI_ITER_FOREACH(n, u->channels.head)
+	{
+		struct chanuser *cu = n->data;
+
+		/* Assume that any prefix modes allow changing nicks even while banned */
+		if (cu->modes != 0)
+			continue;
+
+		if (next_matching_ban(cu->chan, u, ban_type, cu->chan->bans.head) != NULL)
+		{
+			if (ircd->except_mchar == '\0' || next_matching_ban(cu->chan, u, ircd->except_mchar, cu->chan->bans.head) == NULL)
+				return cu;
+			else
+				continue;
+		}
+	}
+
+	return NULL;
+}
+
 /* vim:cinoptions=>s,e0,n0,f0,{0,}0,^0,=s,ps,t0,c3,+s,(2s,us,)20,*30,gs,hs
  * vim:ts=8
  * vim:sw=8

--- a/modules/nickserv/enforce.c
+++ b/modules/nickserv/enforce.c
@@ -443,9 +443,10 @@ ns_cmd_regain(struct sourceinfo *si, int parc, char *parv[])
 	}
 	if ((si->smu == mn->owner) || verify_password(mn->owner, password))
 	{
-		if (si->su != NULL && (user_is_channel_banned(si->su, 'b') || user_is_channel_banned(si->su, 'q')))
+		struct chanuser *cu = NULL;
+		if (si->su != NULL && ((cu = find_user_banned_channel(si->su, 'b')) || (cu = find_user_banned_channel(si->su, 'q'))))
 		{
-			command_fail(si, fault_noprivs, _("You can not regain your nickname while banned or quieted on a channel."));
+			command_fail(si, fault_noprivs, _("You can not regain your nickname while banned or quieted on a channel: \2%s\2"), cu->chan->name);
 			return;
 		}
 


### PR DESCRIPTION
For parity with IRC:

```
14:38 -!- edk #funk Cannot change nickname while banned/quieted on channel                                                                                                                    │
14:38 -NickServ(NickServ@services.int)- You can not regain your nickname while banned or quieted on a channel: #funk    
```

trying /nick when you see the message is admittedly not very hard, but it's another step (so another obstacle when helping clueless users in #freenode) and it's easy to fix.

this was the only caller of `user_is_channel_banned`, so I don't know if there's a reason to keep that around