### PR TITLE
Tell users about grouping nicks

### DIFF
--- a/help/default/nickserv/register
+++ b/help/default/nickserv/register
@@ -5,6 +5,7 @@ This will allow you to assert some form of identity on
 the network and to be added to access lists. Furthermore,
 &nick& will warn users using your nick without
 identifying and allow you to kill ghosts.
+You can also GROUP other nicknames to this one later on.
 The password is a case-sensitive password that you make
 up. Please write down or memorize your password! You
 will need it later to change settings.


### PR DESCRIPTION
Lots of users register their primary nick then 
also register another account for backup nicks.
Tell them about grouping to avoid this.