### PR TITLE
Remove the last remaining '_t' data types (from the hook system & modules/scripting/perl/)

### DIFF
--- a/include/atheme/account.h
+++ b/include/atheme/account.h
@@ -314,13 +314,6 @@ typedef struct {
 
 typedef struct {
 	struct sourceinfo *     si;
-	const char *            name;
-	struct channel *        chan;
-	int                     approved;       // Write non-zero here to disallow the registration
-} hook_channel_register_check_t;
-
-typedef struct {
-	struct sourceinfo *     si;
 	struct myuser *         mu;
 	struct mynick *         mn;
 } hook_user_req_t;

--- a/include/atheme/account.h
+++ b/include/atheme/account.h
@@ -296,12 +296,6 @@ struct mymemo
 typedef struct {
 	struct sourceinfo *     si;
 	struct myuser *         mu;
-	struct mynick *         mn;
-} hook_user_req_t;
-
-typedef struct {
-	struct sourceinfo *     si;
-	struct myuser *         mu;
 	bool                    allowed;
 } hook_user_login_check_t;
 

--- a/include/atheme/account.h
+++ b/include/atheme/account.h
@@ -295,12 +295,6 @@ struct mymemo
 /* account related hooks */
 typedef struct {
 	struct sourceinfo *     si;
-	struct myuser *         mu;
-	bool                    allowed;
-} hook_user_login_check_t;
-
-typedef struct {
-	struct sourceinfo *     si;
 	struct user *           u;
 	const bool              relogin;
 	bool                    allowed;

--- a/include/atheme/account.h
+++ b/include/atheme/account.h
@@ -298,12 +298,6 @@ typedef struct {
 	const char *    oldname;
 } hook_user_rename_t;
 
-typedef struct {
-	struct sourceinfo *     si;
-	struct myuser *         mu;
-	int                     allowed;
-} hook_user_needforce_t;
-
 /* pmodule.c XXX */
 extern bool backend_loaded;
 

--- a/include/atheme/account.h
+++ b/include/atheme/account.h
@@ -300,11 +300,6 @@ typedef struct {
 
 typedef struct {
 	struct sourceinfo *     si;
-	const char *            nick;
-} hook_info_noexist_req_t;
-
-typedef struct {
-	struct sourceinfo *     si;
 	struct myuser *         mu;
 	int                     allowed;
 } hook_user_needforce_t;

--- a/include/atheme/account.h
+++ b/include/atheme/account.h
@@ -326,12 +326,6 @@ typedef struct {
 } hook_nick_enforce_t;
 
 typedef struct {
-	struct myuser * target;
-	const char *    name;
-	char *          value;
-} hook_metadata_change_t;
-
-typedef struct {
 	struct sourceinfo * si;
 	struct myuser *     mu;
 	struct mynick *     mn;

--- a/include/atheme/account.h
+++ b/include/atheme/account.h
@@ -304,15 +304,6 @@ typedef struct {
 } hook_channel_succession_req_t;
 
 typedef struct {
-	union {
-		struct mychan * mc;
-		struct myuser * mu;
-		struct mynick * mn;
-	}                       data;
-	int                     do_expire;      // Write zero here to disallow expiry
-} hook_expiry_req_t;
-
-typedef struct {
 	struct sourceinfo *     si;
 	struct myuser *         mu;
 	struct mynick *         mn;

--- a/include/atheme/account.h
+++ b/include/atheme/account.h
@@ -294,11 +294,6 @@ struct mymemo
 
 /* account related hooks */
 typedef struct {
-	struct mychan * mc;
-	struct myuser * mu;
-} hook_channel_succession_req_t;
-
-typedef struct {
 	struct sourceinfo *     si;
 	struct myuser *         mu;
 	struct mynick *         mn;

--- a/include/atheme/account.h
+++ b/include/atheme/account.h
@@ -299,15 +299,6 @@ typedef struct {
 } hook_channel_req_t;
 
 typedef struct {
-	struct chanacs *        ca;
-	struct sourceinfo *     si;
-	struct myentity *       parent;
-	unsigned int            oldlevel;
-	unsigned int            newlevel;
-	int                     approved;
-} hook_channel_acl_req_t;
-
-typedef struct {
 	struct mychan * mc;
 	struct myuser * mu;
 } hook_channel_succession_req_t;

--- a/include/atheme/account.h
+++ b/include/atheme/account.h
@@ -294,11 +294,6 @@ struct mymemo
 
 /* account related hooks */
 typedef struct {
-	struct mychan *         mc;
-	struct sourceinfo *     si;
-} hook_channel_req_t;
-
-typedef struct {
 	struct mychan * mc;
 	struct myuser * mu;
 } hook_channel_succession_req_t;

--- a/include/atheme/account.h
+++ b/include/atheme/account.h
@@ -313,11 +313,6 @@ typedef struct {
 } hook_user_logout_check_t;
 
 typedef struct {
-	struct user *   u;
-	struct mynick * mn;
-} hook_nick_enforce_t;
-
-typedef struct {
 	struct sourceinfo * si;
 	struct myuser *     mu;
 	struct mynick *     mn;

--- a/include/atheme/account.h
+++ b/include/atheme/account.h
@@ -301,14 +301,6 @@ typedef struct {
 
 typedef struct {
 	struct sourceinfo *     si;
-	const char *            account;        // or nick
-	const char *            email;
-	const char *            password;
-	int                     approved;       // Write non-zero here to disallow the registration
-} hook_user_register_check_t;
-
-typedef struct {
-	struct sourceinfo *     si;
 	struct myuser *         mu;
 	bool                    allowed;
 } hook_user_login_check_t;

--- a/include/atheme/account.h
+++ b/include/atheme/account.h
@@ -292,12 +292,6 @@ struct mymemo
 #define MEMO_READ          0x00000001U
 #define MEMO_CHANNEL       0x00000002U
 
-/* account related hooks */
-typedef struct {
-	struct myuser * mu;
-	const char *    oldname;
-} hook_user_rename_t;
-
 /* pmodule.c XXX */
 extern bool backend_loaded;
 

--- a/include/atheme/account.h
+++ b/include/atheme/account.h
@@ -294,13 +294,6 @@ struct mymemo
 
 /* account related hooks */
 typedef struct {
-	struct sourceinfo *     si;
-	struct user *           u;
-	const bool              relogin;
-	bool                    allowed;
-} hook_user_logout_check_t;
-
-typedef struct {
 	struct sourceinfo * si;
 	struct myuser *     mu;
 	struct mynick *     mn;

--- a/include/atheme/account.h
+++ b/include/atheme/account.h
@@ -294,13 +294,6 @@ struct mymemo
 
 /* account related hooks */
 typedef struct {
-	struct sourceinfo * si;
-	struct myuser *     mu;
-	struct mynick *     mn;
-	bool                allowed;
-} hook_user_rename_check_t;
-
-typedef struct {
 	struct myuser * mu;
 	const char *    oldname;
 } hook_user_rename_t;

--- a/include/atheme/channels.h
+++ b/include/atheme/channels.h
@@ -95,18 +95,6 @@ struct extmode
 	bool  (*check)(const char *, struct channel *, struct mychan *, struct user *, struct myuser *);
 };
 
-/* channel related hooks */
-typedef struct {
-
-	/* Write NULL here if you kicked the user. When kicking the last user, you must join a service first,
-	 * otherwise the channel may be destroyed and crashes may occur. The service may not part until you
-	 * return; chanserv provides MC_INHABIT to help with this. This also prevents kick/rejoin floods. If
-	 * this is NULL, a previous function kicked the user
-	 */
-	struct chanuser *       cu;
-
-} hook_channel_joinpart_t;
-
 typedef struct {
 	struct user *   u;
 	struct channel *c;

--- a/include/atheme/channels.h
+++ b/include/atheme/channels.h
@@ -114,16 +114,6 @@ typedef struct {
 } hook_cmessage_data_t;
 
 typedef struct {
-	struct user *   u;              // Online user that changed the topic
-	struct server * s;              // Server that restored a topic
-	struct channel *c;              // Channel still has old topic
-	const char *    setter;         // Stored setter string, can be nick, nick!user@host or server
-	time_t          ts;             // Time the topic was changed
-	const char *    topic;          // New topic
-	int             approved;       // Write non-zero here to cancel the change
-} hook_channel_topic_check_t;
-
-typedef struct {
 	struct user *   u;
 	struct channel *c;
 } hook_channel_mode_t;

--- a/include/atheme/channels.h
+++ b/include/atheme/channels.h
@@ -96,11 +96,6 @@ struct extmode
 };
 
 typedef struct {
-	struct user *   u;
-	struct channel *c;
-} hook_channel_mode_t;
-
-typedef struct {
 	struct chanuser *       cu;
 	const char              mchar;
 	const unsigned int      mvalue;

--- a/include/atheme/channels.h
+++ b/include/atheme/channels.h
@@ -98,12 +98,6 @@ struct extmode
 typedef struct {
 	struct user *   u;
 	struct channel *c;
-	char *          msg;
-} hook_cmessage_data_t;
-
-typedef struct {
-	struct user *   u;
-	struct channel *c;
 } hook_channel_mode_t;
 
 typedef struct {

--- a/include/atheme/channels.h
+++ b/include/atheme/channels.h
@@ -95,12 +95,6 @@ struct extmode
 	bool  (*check)(const char *, struct channel *, struct mychan *, struct user *, struct myuser *);
 };
 
-typedef struct {
-	struct chanuser *       cu;
-	const char              mchar;
-	const unsigned int      mvalue;
-} hook_channel_mode_change_t;
-
 /* cmode.c */
 char *flags_to_string(unsigned int flags);
 int mode_to_flag(char c);

--- a/include/atheme/entity.h
+++ b/include/atheme/entity.h
@@ -73,10 +73,4 @@ unsigned int myentity_count_channels_with_flagset(struct myentity *mt, unsigned 
 bool myentity_can_register_channel(struct myentity *mt);
 bool myentity_allow_foundership(struct myentity *mt);
 
-typedef struct {
-	struct myentity *       entity;
-	const char *            name;
-	bool                    approval;
-} hook_myentity_req_t;
-
 #endif /* !ATHEME_INC_ENTITY_H */

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -81,6 +81,17 @@ struct hook_channel_topic_check
 	int             approved;       // Write non-zero here to cancel the change
 };
 
+struct hook_expiry_req
+{
+	union {
+		struct mychan * mc;
+		struct myuser * mu;
+		struct mynick * mn;
+	}                       data;
+
+	int                     do_expire;  // Write zero here to disallow expiry
+};
+
 struct hook_server_delete
 {
 	struct server * s;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -69,6 +69,12 @@ struct hook_server_delete
 	/* space for reason etc here */
 };
 
+struct hook_user_delete_info
+{
+	struct user * const u;
+	const char *        comment;
+};
+
 struct hook_user_nick
 {
 	struct user *    u;             // User in question. Write NULL here if you delete the user

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -152,6 +152,15 @@ struct hook_user_nick
 	const char *     oldnick;       // Previous nick for nick changes. u->nick is the new nick
 };
 
+struct hook_user_register_check
+{
+	struct sourceinfo * si;
+	const char *        account;    // or nick
+	const char *        email;
+	const char *        password;
+	int                 approved;   // Write non-zero here to disallow the registration
+};
+
 void hook_del_hook(const char *, hook_fn);
 void hook_add_hook(const char *, hook_fn);
 void hook_add_hook_first(const char *, hook_fn);

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -15,7 +15,6 @@
 #include <atheme/structures.h>
 
 // Types necessary for the hook system (and/or for Perl scripts)
-typedef struct mychan mychan_t;
 typedef struct myentity myentity_t;
 typedef struct mygroup mygroup_t;
 typedef struct mynick mynick_t;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -22,6 +22,16 @@ struct hook
 	mowgli_list_t   hooks;
 };
 
+struct hook_channel_acl_req
+{
+	struct chanacs *    ca;
+	struct sourceinfo * si;
+	struct myentity *   parent;
+	unsigned int        oldlevel;
+	unsigned int        newlevel;
+	int                 approved;
+};
+
 struct hook_channel_joinpart
 {
 	/* Write NULL here if you kicked the user. When kicking the last user, you must join a service first,

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -15,7 +15,6 @@
 #include <atheme/structures.h>
 
 // Types necessary for the hook system (and/or for Perl scripts)
-typedef struct sourceinfo sourceinfo_t;
 typedef struct user user_t;
 
 

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -15,7 +15,6 @@
 #include <atheme/structures.h>
 
 // Types necessary for the hook system (and/or for Perl scripts)
-typedef struct mynick mynick_t;
 typedef struct myuser myuser_t;
 typedef struct sasl_message sasl_message_t;
 typedef struct server server_t;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -112,6 +112,12 @@ struct hook_host_request
 	const char *        target;
 };
 
+struct hook_info_noexist_req
+{
+	struct sourceinfo * si;
+	const char *        nick;
+};
+
 struct hook_metadata_change
 {
 	struct myuser * target;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -112,6 +112,13 @@ struct hook_host_request
 	const char *        target;
 };
 
+struct hook_metadata_change
+{
+	struct myuser * target;
+	const char *    name;
+	char *          value;
+};
+
 struct hook_server_delete
 {
 	struct server * s;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -152,6 +152,13 @@ struct hook_user_delete_info
 	const char *        comment;
 };
 
+struct hook_user_login_check
+{
+	struct sourceinfo * si;
+	struct myuser *     mu;
+	bool                allowed;
+};
+
 struct hook_user_nick
 {
 	struct user *    u;             // User in question. Write NULL here if you delete the user

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -15,7 +15,6 @@
 #include <atheme/structures.h>
 
 // Types necessary for the hook system (and/or for Perl scripts)
-typedef struct database_handle database_handle_t;
 typedef struct mychan mychan_t;
 typedef struct myentity myentity_t;
 typedef struct mygroup mygroup_t;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -167,6 +167,13 @@ struct hook_user_register_check
 	int                 approved;   // Write non-zero here to disallow the registration
 };
 
+struct hook_user_req
+{
+	struct sourceinfo * si;
+	struct myuser *     mu;
+	struct mynick *     mn;
+};
+
 void hook_del_hook(const char *, hook_fn);
 void hook_add_hook(const char *, hook_fn);
 void hook_add_hook_first(const char *, hook_fn);

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -15,8 +15,6 @@
 #include <atheme/structures.h>
 
 // Types necessary for the hook system (and/or for Perl scripts)
-typedef struct server server_t;
-typedef struct service service_t;
 typedef struct sourceinfo sourceinfo_t;
 typedef struct user user_t;
 

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -22,6 +22,16 @@ struct hook
 	mowgli_list_t   hooks;
 };
 
+struct hook_channel_joinpart
+{
+	/* Write NULL here if you kicked the user. When kicking the last user, you must join a service first,
+	 * otherwise the channel may be destroyed and crashes may occur. The service may not part until you
+	 * return; chanserv provides MC_INHABIT to help with this. This also prevents kick/rejoin floods. If
+	 * this is NULL, a previous function kicked the user.
+	 */
+	struct chanuser *   cu;
+};
+
 struct hook_channel_topic_check
 {
 	struct user *   u;              // Online user that changed the topic

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -195,6 +195,12 @@ struct hook_user_register_check
 	int                 approved;   // Write non-zero here to disallow the registration
 };
 
+struct hook_user_rename
+{
+	struct myuser * mu;
+	const char *    oldname;
+};
+
 struct hook_user_rename_check
 {
 	struct sourceinfo * si;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -106,7 +106,7 @@ struct hook_expiry_req
 
 struct hook_host_request
 {
-        const char *        host;
+	const char *        host;
 	struct sourceinfo * si;
 	int                 approved;
 	const char *        target;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -159,6 +159,14 @@ struct hook_user_login_check
 	bool                allowed;
 };
 
+struct hook_user_logout_check
+{
+	struct sourceinfo * si;
+	struct user *       u;
+	const bool          relogin;
+	bool                allowed;
+};
+
 struct hook_user_nick
 {
 	struct user *    u;             // User in question. Write NULL here if you delete the user

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -69,6 +69,12 @@ struct hook_server_delete
 	/* space for reason etc here */
 };
 
+struct hook_user_nick
+{
+	struct user *    u;             // User in question. Write NULL here if you delete the user
+	const char *     oldnick;       // Previous nick for nick changes. u->nick is the new nick
+};
+
 void hook_del_hook(const char *, hook_fn);
 void hook_add_hook(const char *, hook_fn);
 void hook_add_hook_first(const char *, hook_fn);

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -22,6 +22,17 @@ struct hook
 	mowgli_list_t   hooks;
 };
 
+struct hook_channel_topic_check
+{
+	struct user *   u;              // Online user that changed the topic
+	struct server * s;              // Server that restored a topic
+	struct channel *c;              // Channel still has old topic
+	const char *    setter;         // Stored setter string, can be nick, nick!user@host or server
+	time_t          ts;             // Time the topic was changed
+	const char *    topic;          // New topic
+	int             approved;       // Write non-zero here to cancel the change
+};
+
 void hook_del_hook(const char *, hook_fn);
 void hook_add_hook(const char *, hook_fn);
 void hook_add_hook_first(const char *, hook_fn);

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -134,6 +134,12 @@ struct hook_myentity_req
 	bool                approval;
 };
 
+struct hook_nick_enforce
+{
+	struct user *   u;
+	struct mynick * mn;
+};
+
 struct hook_server_delete
 {
 	struct server * s;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -15,7 +15,6 @@
 #include <atheme/structures.h>
 
 // Types necessary for the hook system (and/or for Perl scripts)
-typedef struct myuser myuser_t;
 typedef struct sasl_message sasl_message_t;
 typedef struct server server_t;
 typedef struct service service_t;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -70,6 +70,12 @@ struct hook_channel_register_check
 	int                 approved;   // Write non-zero here to disallow the registration
 };
 
+struct hook_channel_req
+{
+	struct mychan *     mc;
+	struct sourceinfo * si;
+};
+
 struct hook_channel_topic_check
 {
 	struct user *   u;              // Online user that changed the topic

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -15,7 +15,6 @@
 #include <atheme/structures.h>
 
 // Types necessary for the hook system (and/or for Perl scripts)
-typedef struct myentity myentity_t;
 typedef struct mygroup mygroup_t;
 typedef struct mynick mynick_t;
 typedef struct myuser myuser_t;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -32,6 +32,13 @@ struct hook_channel_joinpart
 	struct chanuser *   cu;
 };
 
+struct hook_channel_message
+{
+	struct user *   u;              // Online user that sent the message
+	struct channel *c;              // Channel the message was sent to
+	char *          msg;            // The message itself
+};
+
 struct hook_channel_topic_check
 {
 	struct user *   u;              // Online user that changed the topic

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -15,7 +15,6 @@
 #include <atheme/structures.h>
 
 // Types necessary for the hook system (and/or for Perl scripts)
-typedef struct channel channel_t;
 typedef struct chanuser chanuser_t;
 typedef struct database_handle database_handle_t;
 typedef struct mychan mychan_t;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -173,6 +173,13 @@ struct hook_user_logout_check
 	bool                allowed;
 };
 
+struct hook_user_needforce
+{
+	struct sourceinfo * si;
+	struct myuser *     mu;
+	int                 allowed;
+};
+
 struct hook_user_nick
 {
 	struct user *    u;             // User in question. Write NULL here if you delete the user

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -39,6 +39,12 @@ struct hook_channel_message
 	char *          msg;            // The message itself
 };
 
+struct hook_channel_mode
+{
+	struct user *   u;
+	struct channel *c;
+};
+
 struct hook_channel_topic_check
 {
 	struct user *   u;              // Online user that changed the topic

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -15,7 +15,6 @@
 #include <atheme/structures.h>
 
 // Types necessary for the hook system (and/or for Perl scripts)
-typedef struct chanuser chanuser_t;
 typedef struct database_handle database_handle_t;
 typedef struct mychan mychan_t;
 typedef struct myentity myentity_t;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -45,6 +45,13 @@ struct hook_channel_mode
 	struct channel *c;
 };
 
+struct hook_channel_mode_change
+{
+	struct chanuser *   cu;
+	const char          mchar;
+	const unsigned int  mvalue;
+};
+
 struct hook_channel_topic_check
 {
 	struct user *   u;              // Online user that changed the topic

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -62,6 +62,14 @@ struct hook_channel_mode_change
 	const unsigned int  mvalue;
 };
 
+struct hook_channel_register_check
+{
+	struct sourceinfo * si;
+	const char *        name;
+	struct channel *    chan;
+	int                 approved;   // Write non-zero here to disallow the registration
+};
+
 struct hook_channel_topic_check
 {
 	struct user *   u;              // Online user that changed the topic

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -119,6 +119,14 @@ struct hook_metadata_change
 	char *          value;
 };
 
+struct hook_module_load
+{
+	const char *    name;       // The module name we're searching for
+	const char *    path;       // The likely path name, which may be ignored
+	struct module * module;     // If a module is loaded, set this to point to it
+	int             handled;
+};
+
 struct hook_server_delete
 {
 	struct server * s;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -63,6 +63,12 @@ struct hook_channel_topic_check
 	int             approved;       // Write non-zero here to cancel the change
 };
 
+struct hook_server_delete
+{
+	struct server * s;
+	/* space for reason etc here */
+};
+
 void hook_del_hook(const char *, hook_fn);
 void hook_add_hook(const char *, hook_fn);
 void hook_add_hook_first(const char *, hook_fn);

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -14,11 +14,6 @@
 #include <atheme/stdheaders.h>
 #include <atheme/structures.h>
 
-// Types necessary for the hook system (and/or for Perl scripts)
-typedef struct user user_t;
-
-
-
 typedef void (*hook_fn)(void *data);
 
 struct hook

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -15,7 +15,6 @@
 #include <atheme/structures.h>
 
 // Types necessary for the hook system (and/or for Perl scripts)
-typedef struct sasl_message sasl_message_t;
 typedef struct server server_t;
 typedef struct service service_t;
 typedef struct sourceinfo sourceinfo_t;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -15,7 +15,6 @@
 #include <atheme/structures.h>
 
 // Types necessary for the hook system (and/or for Perl scripts)
-typedef struct chanacs chanacs_t;
 typedef struct channel channel_t;
 typedef struct chanuser chanuser_t;
 typedef struct database_handle database_handle_t;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -182,6 +182,14 @@ struct hook_user_register_check
 	int                 approved;   // Write non-zero here to disallow the registration
 };
 
+struct hook_user_rename_check
+{
+	struct sourceinfo * si;
+	struct myuser *     mu;
+	struct mynick *     mn;
+	bool                allowed;
+};
+
 struct hook_user_req
 {
 	struct sourceinfo * si;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -104,6 +104,14 @@ struct hook_expiry_req
 	int                     do_expire;  // Write zero here to disallow expiry
 };
 
+struct hook_host_request
+{
+        const char *        host;
+	struct sourceinfo * si;
+	int                 approved;
+	const char *        target;
+};
+
 struct hook_server_delete
 {
 	struct server * s;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -127,6 +127,13 @@ struct hook_module_load
 	int             handled;
 };
 
+struct hook_myentity_req
+{
+	struct myentity *   entity;
+	const char *        name;
+	bool                approval;
+};
+
 struct hook_server_delete
 {
 	struct server * s;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -146,6 +146,13 @@ struct hook_nick_enforce
 	struct mynick * mn;
 };
 
+struct hook_sasl_may_impersonate
+{
+	struct myuser * source_mu;
+	struct myuser * target_mu;
+	bool            allowed;
+};
+
 struct hook_server_delete
 {
 	struct server * s;

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -76,6 +76,12 @@ struct hook_channel_req
 	struct sourceinfo * si;
 };
 
+struct hook_channel_succession_req
+{
+	struct mychan * mc;
+	struct myuser * mu;
+};
+
 struct hook_channel_topic_check
 {
 	struct user *   u;              // Online user that changed the topic

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -15,7 +15,6 @@
 #include <atheme/structures.h>
 
 // Types necessary for the hook system (and/or for Perl scripts)
-typedef struct mygroup mygroup_t;
 typedef struct mynick mynick_t;
 typedef struct myuser myuser_t;
 typedef struct sasl_message sasl_message_t;

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -25,9 +25,9 @@
 config_purge                    void
 config_ready                    void
 db_saved                        void
-db_write                        database_handle_t *
+db_write                        struct database_handle *
 # XXX: for groupserv.  remove when we have proper dependency resolution in opensex.
-db_write_pre_ca                 database_handle_t *
+db_write_pre_ca                 struct database_handle *
 shutdown                        void
 
 # (ircd)

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -56,7 +56,7 @@ user_oper                       user_t *
 channel_acl_change              hook_channel_acl_req_t *
 channel_can_register            hook_channel_register_check_t *
 channel_check_expire            hook_expiry_req_t *
-channel_drop                    mychan_t *
+channel_drop                    struct mychan *
 channel_info                    hook_channel_req_t *
 channel_pick_successor          hook_channel_succession_req_t *
 channel_register                hook_channel_req_t *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -32,7 +32,7 @@ shutdown                        void
 
 # (ircd)
 channel_add                     struct channel *
-channel_can_change_topic        hook_channel_topic_check_t *
+channel_can_change_topic        struct hook_channel_topic_check *
 channel_delete                  struct channel *
 channel_join                    hook_channel_joinpart_t *
 channel_message                 hook_cmessage_data_t *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -37,7 +37,7 @@ channel_delete                  struct channel *
 channel_join                    struct hook_channel_joinpart *
 channel_message                 struct hook_channel_message *
 channel_mode                    struct hook_channel_mode *
-channel_mode_change             hook_channel_mode_change_t *
+channel_mode_change             struct hook_channel_mode_change *
 channel_part                    struct hook_channel_joinpart *
 channel_topic                   struct channel *
 channel_tschange                struct channel *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -78,7 +78,7 @@ nick_ungroup                    struct hook_user_req *
 operserv_info                   struct sourceinfo *
 service_introduce               struct service *
 user_can_login                  struct hook_user_login_check *
-user_can_logout                 hook_user_logout_check_t *
+user_can_logout                 struct hook_user_logout_check *
 user_can_register               struct hook_user_register_check *
 user_can_rename                 hook_user_rename_check_t *
 user_check_expire               struct hook_expiry_req *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -44,12 +44,12 @@ channel_tschange                struct channel *
 server_add                      struct server *
 server_delete                   struct hook_server_delete *
 server_eob                      struct server *
-user_add                        hook_user_nick_t *
+user_add                        struct hook_user_nick *
 user_away                       struct user *
 user_delete                     struct user *
 user_delete_info                hook_user_delete_t *
 user_deoper                     struct user *
-user_nickchange                 hook_user_nick_t *
+user_nickchange                 struct hook_user_nick *
 user_oper                       struct user *
 
 # (services)

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -64,7 +64,7 @@ channel_succession              struct hook_channel_succession_req *
 grant_channel_access            struct user *
 group_drop                      struct mygroup *
 group_register                  struct mygroup *
-host_request                    hook_host_request_t *
+host_request                    struct hook_host_request *
 metadata_change                 hook_metadata_change_t *
 module_load                     hook_module_load_t *
 myentity_find                   hook_myentity_req_t *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -88,7 +88,7 @@ user_info                       struct hook_user_req *
 user_info_noexist               struct hook_info_noexist *
 user_needforce                  struct hook_user_needforce *
 user_register                   struct myuser *
-user_rename                     hook_user_rename_t *
+user_rename                     struct hook_user_rename *
 user_sethost                    struct user *
 user_verify_register            struct hook_user_req *
 

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -93,5 +93,5 @@ user_sethost                    user_t *
 user_verify_register            hook_user_req_t *
 
 # (sasl)
-sasl_input                      sasl_message_t *
+sasl_input                      struct sasl_message *
 sasl_may_impersonate            hook_sasl_may_impersonate_t *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -73,8 +73,8 @@ nick_can_register               struct hook_user_register_check *
 nick_check                      struct user *
 nick_check_expire               struct hook_expiry_req *
 nick_enforce                    struct hook_nick_enforce *
-nick_group                      hook_user_req_t *
-nick_ungroup                    hook_user_req_t *
+nick_group                      struct hook_user_req *
+nick_ungroup                    struct hook_user_req *
 operserv_info                   struct sourceinfo *
 service_introduce               struct service *
 user_can_login                  hook_user_login_check_t *
@@ -84,13 +84,13 @@ user_can_rename                 hook_user_rename_check_t *
 user_check_expire               struct hook_expiry_req *
 user_drop                       struct myuser *
 user_identify                   struct user *
-user_info                       hook_user_req_t *
+user_info                       struct hook_user_req *
 user_info_noexist               hook_info_noexist_req_t *
 user_needforce                  hook_user_needforce_t *
 user_register                   struct myuser *
 user_rename                     hook_user_rename_t *
 user_sethost                    struct user *
-user_verify_register            hook_user_req_t *
+user_verify_register            struct hook_user_req *
 
 # (sasl)
 sasl_input                      struct sasl_message *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -66,7 +66,7 @@ group_drop                      struct mygroup *
 group_register                  struct mygroup *
 host_request                    struct hook_host_request *
 metadata_change                 struct hook_metadata_change *
-module_load                     hook_module_load_t *
+module_load                     struct hook_module_load *
 myentity_find                   hook_myentity_req_t *
 myuser_delete                   struct myuser *
 nick_can_register               hook_user_register_check_t *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -80,7 +80,7 @@ service_introduce               struct service *
 user_can_login                  struct hook_user_login_check *
 user_can_logout                 struct hook_user_logout_check *
 user_can_register               struct hook_user_register_check *
-user_can_rename                 hook_user_rename_check_t *
+user_can_rename                 struct hook_user_rename_check *
 user_check_expire               struct hook_expiry_req *
 user_drop                       struct myuser *
 user_identify                   struct user *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -36,7 +36,7 @@ channel_can_change_topic        struct hook_channel_topic_check *
 channel_delete                  struct channel *
 channel_join                    struct hook_channel_joinpart *
 channel_message                 struct hook_channel_message *
-channel_mode                    hook_channel_mode_t *
+channel_mode                    struct hook_channel_mode *
 channel_mode_change             hook_channel_mode_change_t *
 channel_part                    struct hook_channel_joinpart *
 channel_topic                   struct channel *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -67,7 +67,7 @@ group_register                  struct mygroup *
 host_request                    struct hook_host_request *
 metadata_change                 struct hook_metadata_change *
 module_load                     struct hook_module_load *
-myentity_find                   hook_myentity_req_t *
+myentity_find                   struct hook_myentity_req *
 myuser_delete                   struct myuser *
 nick_can_register               hook_user_register_check_t *
 nick_check                      struct user *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -86,7 +86,7 @@ user_drop                       struct myuser *
 user_identify                   struct user *
 user_info                       struct hook_user_req *
 user_info_noexist               struct hook_info_noexist *
-user_needforce                  hook_user_needforce_t *
+user_needforce                  struct hook_user_needforce *
 user_register                   struct myuser *
 user_rename                     hook_user_rename_t *
 user_sethost                    struct user *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -54,7 +54,7 @@ user_oper                       struct user *
 
 # (services)
 channel_acl_change              struct hook_channel_acl_req *
-channel_can_register            hook_channel_register_check_t *
+channel_can_register            struct hook_channel_register_check *
 channel_check_expire            hook_expiry_req_t *
 channel_drop                    struct mychan *
 channel_info                    hook_channel_req_t *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -57,9 +57,9 @@ channel_acl_change              struct hook_channel_acl_req *
 channel_can_register            struct hook_channel_register_check *
 channel_check_expire            struct hook_expiry_req *
 channel_drop                    struct mychan *
-channel_info                    hook_channel_req_t *
+channel_info                    struct hook_channel_req *
 channel_pick_successor          hook_channel_succession_req_t *
-channel_register                hook_channel_req_t *
+channel_register                struct hook_channel_req *
 channel_succession              hook_channel_succession_req_t *
 grant_channel_access            struct user *
 group_drop                      struct mygroup *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -77,7 +77,7 @@ nick_group                      struct hook_user_req *
 nick_ungroup                    struct hook_user_req *
 operserv_info                   struct sourceinfo *
 service_introduce               struct service *
-user_can_login                  hook_user_login_check_t *
+user_can_login                  struct hook_user_login_check *
 user_can_logout                 hook_user_logout_check_t *
 user_can_register               struct hook_user_register_check *
 user_can_rename                 hook_user_rename_check_t *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -58,9 +58,9 @@ channel_can_register            struct hook_channel_register_check *
 channel_check_expire            struct hook_expiry_req *
 channel_drop                    struct mychan *
 channel_info                    struct hook_channel_req *
-channel_pick_successor          hook_channel_succession_req_t *
+channel_pick_successor          struct hook_channel_succession_req *
 channel_register                struct hook_channel_req *
-channel_succession              hook_channel_succession_req_t *
+channel_succession              struct hook_channel_succession_req *
 grant_channel_access            struct user *
 group_drop                      struct mygroup *
 group_register                  struct mygroup *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -65,7 +65,7 @@ grant_channel_access            struct user *
 group_drop                      struct mygroup *
 group_register                  struct mygroup *
 host_request                    struct hook_host_request *
-metadata_change                 hook_metadata_change_t *
+metadata_change                 struct hook_metadata_change *
 module_load                     hook_module_load_t *
 myentity_find                   hook_myentity_req_t *
 myuser_delete                   struct myuser *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -72,7 +72,7 @@ myuser_delete                   struct myuser *
 nick_can_register               struct hook_user_register_check *
 nick_check                      struct user *
 nick_check_expire               struct hook_expiry_req *
-nick_enforce                    hook_nick_enforce_t *
+nick_enforce                    struct hook_nick_enforce *
 nick_group                      hook_user_req_t *
 nick_ungroup                    hook_user_req_t *
 operserv_info                   struct sourceinfo *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -34,11 +34,11 @@ shutdown                        void
 channel_add                     struct channel *
 channel_can_change_topic        struct hook_channel_topic_check *
 channel_delete                  struct channel *
-channel_join                    hook_channel_joinpart_t *
+channel_join                    struct hook_channel_joinpart *
 channel_message                 hook_cmessage_data_t *
 channel_mode                    hook_channel_mode_t *
 channel_mode_change             hook_channel_mode_change_t *
-channel_part                    hook_channel_joinpart_t *
+channel_part                    struct hook_channel_joinpart *
 channel_topic                   struct channel *
 channel_tschange                struct channel *
 server_add                      struct server *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -68,7 +68,7 @@ host_request                    hook_host_request_t *
 metadata_change                 hook_metadata_change_t *
 module_load                     hook_module_load_t *
 myentity_find                   hook_myentity_req_t *
-myuser_delete                   myuser_t *
+myuser_delete                   struct myuser *
 nick_can_register               hook_user_register_check_t *
 nick_check                      user_t *
 nick_check_expire               hook_expiry_req_t *
@@ -82,12 +82,12 @@ user_can_logout                 hook_user_logout_check_t *
 user_can_register               hook_user_register_check_t *
 user_can_rename                 hook_user_rename_check_t *
 user_check_expire               hook_expiry_req_t *
-user_drop                       myuser_t *
+user_drop                       struct myuser *
 user_identify                   user_t *
 user_info                       hook_user_req_t *
 user_info_noexist               hook_info_noexist_req_t *
 user_needforce                  hook_user_needforce_t *
-user_register                   myuser_t *
+user_register                   struct myuser *
 user_rename                     hook_user_rename_t *
 user_sethost                    user_t *
 user_verify_register            hook_user_req_t *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -53,7 +53,7 @@ user_nickchange                 struct hook_user_nick *
 user_oper                       struct user *
 
 # (services)
-channel_acl_change              hook_channel_acl_req_t *
+channel_acl_change              struct hook_channel_acl_req *
 channel_can_register            hook_channel_register_check_t *
 channel_check_expire            hook_expiry_req_t *
 channel_drop                    struct mychan *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -69,7 +69,7 @@ metadata_change                 struct hook_metadata_change *
 module_load                     struct hook_module_load *
 myentity_find                   struct hook_myentity_req *
 myuser_delete                   struct myuser *
-nick_can_register               hook_user_register_check_t *
+nick_can_register               struct hook_user_register_check *
 nick_check                      struct user *
 nick_check_expire               struct hook_expiry_req *
 nick_enforce                    hook_nick_enforce_t *
@@ -79,7 +79,7 @@ operserv_info                   struct sourceinfo *
 service_introduce               struct service *
 user_can_login                  hook_user_login_check_t *
 user_can_logout                 hook_user_logout_check_t *
-user_can_register               hook_user_register_check_t *
+user_can_register               struct hook_user_register_check *
 user_can_rename                 hook_user_rename_check_t *
 user_check_expire               struct hook_expiry_req *
 user_drop                       struct myuser *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -94,4 +94,4 @@ user_verify_register            struct hook_user_req *
 
 # (sasl)
 sasl_input                      struct sasl_message *
-sasl_may_impersonate            hook_sasl_may_impersonate_t *
+sasl_may_impersonate            struct hook_sasl_may_impersonate *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -55,7 +55,7 @@ user_oper                       struct user *
 # (services)
 channel_acl_change              struct hook_channel_acl_req *
 channel_can_register            struct hook_channel_register_check *
-channel_check_expire            hook_expiry_req_t *
+channel_check_expire            struct hook_expiry_req *
 channel_drop                    struct mychan *
 channel_info                    hook_channel_req_t *
 channel_pick_successor          hook_channel_succession_req_t *
@@ -71,7 +71,7 @@ myentity_find                   hook_myentity_req_t *
 myuser_delete                   struct myuser *
 nick_can_register               hook_user_register_check_t *
 nick_check                      struct user *
-nick_check_expire               hook_expiry_req_t *
+nick_check_expire               struct hook_expiry_req *
 nick_enforce                    hook_nick_enforce_t *
 nick_group                      hook_user_req_t *
 nick_ungroup                    hook_user_req_t *
@@ -81,7 +81,7 @@ user_can_login                  hook_user_login_check_t *
 user_can_logout                 hook_user_logout_check_t *
 user_can_register               hook_user_register_check_t *
 user_can_rename                 hook_user_rename_check_t *
-user_check_expire               hook_expiry_req_t *
+user_check_expire               struct hook_expiry_req *
 user_drop                       struct myuser *
 user_identify                   struct user *
 user_info                       hook_user_req_t *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -31,16 +31,16 @@ db_write_pre_ca                 database_handle_t *
 shutdown                        void
 
 # (ircd)
-channel_add                     channel_t *
+channel_add                     struct channel *
 channel_can_change_topic        hook_channel_topic_check_t *
-channel_delete                  channel_t *
+channel_delete                  struct channel *
 channel_join                    hook_channel_joinpart_t *
 channel_message                 hook_cmessage_data_t *
 channel_mode                    hook_channel_mode_t *
 channel_mode_change             hook_channel_mode_change_t *
 channel_part                    hook_channel_joinpart_t *
-channel_topic                   channel_t *
-channel_tschange                channel_t *
+channel_topic                   struct channel *
+channel_tschange                struct channel *
 server_add                      server_t *
 server_delete                   hook_server_delete_t *
 server_eob                      server_t *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -75,7 +75,7 @@ nick_check_expire               hook_expiry_req_t *
 nick_enforce                    hook_nick_enforce_t *
 nick_group                      hook_user_req_t *
 nick_ungroup                    hook_user_req_t *
-operserv_info                   sourceinfo_t *
+operserv_info                   struct sourceinfo *
 service_introduce               struct service *
 user_can_login                  hook_user_login_check_t *
 user_can_logout                 hook_user_logout_check_t *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -85,7 +85,7 @@ user_check_expire               struct hook_expiry_req *
 user_drop                       struct myuser *
 user_identify                   struct user *
 user_info                       struct hook_user_req *
-user_info_noexist               hook_info_noexist_req_t *
+user_info_noexist               struct hook_info_noexist *
 user_needforce                  hook_user_needforce_t *
 user_register                   struct myuser *
 user_rename                     hook_user_rename_t *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -47,7 +47,7 @@ server_eob                      struct server *
 user_add                        struct hook_user_nick *
 user_away                       struct user *
 user_delete                     struct user *
-user_delete_info                hook_user_delete_t *
+user_delete_info                struct hook_user_delete_info *
 user_deoper                     struct user *
 user_nickchange                 struct hook_user_nick *
 user_oper                       struct user *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -42,7 +42,7 @@ channel_part                    struct hook_channel_joinpart *
 channel_topic                   struct channel *
 channel_tschange                struct channel *
 server_add                      struct server *
-server_delete                   hook_server_delete_t *
+server_delete                   struct hook_server_delete *
 server_eob                      struct server *
 user_add                        hook_user_nick_t *
 user_away                       struct user *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -85,7 +85,7 @@ user_check_expire               struct hook_expiry_req *
 user_drop                       struct myuser *
 user_identify                   struct user *
 user_info                       struct hook_user_req *
-user_info_noexist               struct hook_info_noexist *
+user_info_noexist               struct hook_info_noexist_req *
 user_needforce                  struct hook_user_needforce *
 user_register                   struct myuser *
 user_rename                     struct hook_user_rename *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -41,9 +41,9 @@ channel_mode_change             hook_channel_mode_change_t *
 channel_part                    hook_channel_joinpart_t *
 channel_topic                   struct channel *
 channel_tschange                struct channel *
-server_add                      server_t *
+server_add                      struct server *
 server_delete                   hook_server_delete_t *
-server_eob                      server_t *
+server_eob                      struct server *
 user_add                        hook_user_nick_t *
 user_away                       user_t *
 user_delete                     user_t *
@@ -76,7 +76,7 @@ nick_enforce                    hook_nick_enforce_t *
 nick_group                      hook_user_req_t *
 nick_ungroup                    hook_user_req_t *
 operserv_info                   sourceinfo_t *
-service_introduce               service_t *
+service_introduce               struct service *
 user_can_login                  hook_user_login_check_t *
 user_can_logout                 hook_user_logout_check_t *
 user_can_register               hook_user_register_check_t *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -35,7 +35,7 @@ channel_add                     struct channel *
 channel_can_change_topic        struct hook_channel_topic_check *
 channel_delete                  struct channel *
 channel_join                    struct hook_channel_joinpart *
-channel_message                 hook_cmessage_data_t *
+channel_message                 struct hook_channel_message *
 channel_mode                    hook_channel_mode_t *
 channel_mode_change             hook_channel_mode_change_t *
 channel_part                    struct hook_channel_joinpart *

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -45,12 +45,12 @@ server_add                      struct server *
 server_delete                   hook_server_delete_t *
 server_eob                      struct server *
 user_add                        hook_user_nick_t *
-user_away                       user_t *
-user_delete                     user_t *
+user_away                       struct user *
+user_delete                     struct user *
 user_delete_info                hook_user_delete_t *
-user_deoper                     user_t *
+user_deoper                     struct user *
 user_nickchange                 hook_user_nick_t *
-user_oper                       user_t *
+user_oper                       struct user *
 
 # (services)
 channel_acl_change              hook_channel_acl_req_t *
@@ -61,7 +61,7 @@ channel_info                    hook_channel_req_t *
 channel_pick_successor          hook_channel_succession_req_t *
 channel_register                hook_channel_req_t *
 channel_succession              hook_channel_succession_req_t *
-grant_channel_access            user_t *
+grant_channel_access            struct user *
 group_drop                      struct mygroup *
 group_register                  struct mygroup *
 host_request                    hook_host_request_t *
@@ -70,7 +70,7 @@ module_load                     hook_module_load_t *
 myentity_find                   hook_myentity_req_t *
 myuser_delete                   struct myuser *
 nick_can_register               hook_user_register_check_t *
-nick_check                      user_t *
+nick_check                      struct user *
 nick_check_expire               hook_expiry_req_t *
 nick_enforce                    hook_nick_enforce_t *
 nick_group                      hook_user_req_t *
@@ -83,13 +83,13 @@ user_can_register               hook_user_register_check_t *
 user_can_rename                 hook_user_rename_check_t *
 user_check_expire               hook_expiry_req_t *
 user_drop                       struct myuser *
-user_identify                   user_t *
+user_identify                   struct user *
 user_info                       hook_user_req_t *
 user_info_noexist               hook_info_noexist_req_t *
 user_needforce                  hook_user_needforce_t *
 user_register                   struct myuser *
 user_rename                     hook_user_rename_t *
-user_sethost                    user_t *
+user_sethost                    struct user *
 user_verify_register            hook_user_req_t *
 
 # (sasl)

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -62,8 +62,8 @@ channel_pick_successor          hook_channel_succession_req_t *
 channel_register                hook_channel_req_t *
 channel_succession              hook_channel_succession_req_t *
 grant_channel_access            user_t *
-group_drop                      mygroup_t *
-group_register                  mygroup_t *
+group_drop                      struct mygroup *
+group_register                  struct mygroup *
 host_request                    hook_host_request_t *
 metadata_change                 hook_metadata_change_t *
 module_load                     hook_module_load_t *

--- a/include/atheme/module.h
+++ b/include/atheme/module.h
@@ -67,17 +67,6 @@ struct v4_moduleheader
 	const char *                    version;
 };
 
-/* name is the module name we're searching for.
- * path is the likely full path name, which may be ignored.
- * If it is found, set module to the loaded struct module pointer
- */
-typedef struct {
-	const char *    name;
-	const char *    path;
-	struct module * module;
-	int             handled;
-} hook_module_load_t;
-
 struct module_dependency
 {
 	char *                          name;

--- a/include/atheme/sasl.h
+++ b/include/atheme/sasl.h
@@ -130,12 +130,4 @@ struct sasl_core_functions
 	sasl_authxid_can_login_fn   authzid_can_login;
 };
 
-typedef struct {
-
-	struct myuser * source_mu;
-	struct myuser * target_mu;
-	bool            allowed;
-
-} hook_sasl_may_impersonate_t;
-
 #endif /* !ATHEME_INC_SASL_H */

--- a/include/atheme/servers.h
+++ b/include/atheme/servers.h
@@ -42,12 +42,6 @@ struct tld
 	char *  name;
 };
 
-/* server related hooks */
-typedef struct {
-	struct server * s;
-	/* space for reason etc here */
-} hook_server_delete_t;
-
 #define SERVER_NAME(serv)	(((serv)->sid && ircd->uses_uid) ? (serv)->sid : (serv)->name)
 #define ME			(ircd->uses_uid ? me.numeric : me.name)
 

--- a/include/atheme/users.h
+++ b/include/atheme/users.h
@@ -61,11 +61,6 @@ struct user
 #define CLIENT_NAME(user)	((user)->uid != NULL ? (user)->uid : (user)->nick)
 
 typedef struct {
-	struct user *    u;             // User in question. Write NULL here if you delete the user
-	const char *     oldnick;       // Previous nick for nick changes. u->nick is the new nick
-} hook_user_nick_t;
-
-typedef struct {
 	struct user * const     u;
 	const char *            comment;
 } hook_user_delete_t;

--- a/include/atheme/users.h
+++ b/include/atheme/users.h
@@ -60,11 +60,6 @@ struct user
 
 #define CLIENT_NAME(user)	((user)->uid != NULL ? (user)->uid : (user)->nick)
 
-typedef struct {
-	struct user * const     u;
-	const char *            comment;
-} hook_user_delete_t;
-
 /* function.c */
 bool is_internal_client(struct user *user);
 bool is_autokline_exempt(struct user *user);

--- a/libathemecore/account.c
+++ b/libathemecore/account.c
@@ -233,11 +233,7 @@ myuser_delete(struct myuser *mu)
 
 			/* CA_FOUNDER | CA_FLAGS is the minimum required for full control; let chanserv take care of assigning the rest via founder_flags */
 			chanacs_change_simple(mc, entity(successor), NULL, CA_FOUNDER | CA_FLAGS, 0, NULL);
-			hook_call_channel_succession((
-					&(hook_channel_succession_req_t){
-						.mc = mc,
-						.mu = successor
-					}));
+			hook_call_channel_succession((&(struct hook_channel_succession_req){ .mc = mc, .mu = successor }));
 
 			if (chansvs.me != NULL)
 				myuser_notice(chansvs.nick, successor, "You are now founder on \2%s\2 (as \2%s\2).", mc->name, entity(successor)->name);
@@ -1169,7 +1165,7 @@ struct myuser *
 mychan_pick_successor(struct mychan *mc)
 {
 	struct myuser *mu;
-	hook_channel_succession_req_t req;
+	struct hook_channel_succession_req req;
 
 	return_val_if_fail(mc != NULL, NULL);
 

--- a/libathemecore/account.c
+++ b/libathemecore/account.c
@@ -2021,7 +2021,7 @@ chanacs_change_simple(struct mychan *mychan, struct myentity *mt, const char *ho
 static int
 expire_myuser_cb(struct myentity *mt, void *unused)
 {
-	hook_expiry_req_t req;
+	struct hook_expiry_req req;
 	struct myuser *mu = user(mt);
 
 	return_val_if_fail(isuser(mt), 0);
@@ -2074,7 +2074,7 @@ expire_check(void *arg)
 	struct mychan *mc;
 	struct user *u;
 	mowgli_patricia_iteration_state_t state;
-	hook_expiry_req_t req;
+	struct hook_expiry_req req;
 
 	/* Let them know about this and the likely subsequent db_save()
 	 * right away -- jilles */

--- a/libathemecore/account.c
+++ b/libathemecore/account.c
@@ -345,7 +345,7 @@ myuser_rename(struct myuser *mu, const char *name)
 {
 	mowgli_node_t *n, *tn;
 	struct user *u;
-	hook_user_rename_t data;
+	struct hook_user_rename data;
 	stringref newname;
 	char nb[NICKLEN + 1];
 

--- a/libathemecore/account.c
+++ b/libathemecore/account.c
@@ -1915,7 +1915,7 @@ bool
 chanacs_change(struct mychan *mychan, struct myentity *mt, const char *hostmask, unsigned int *addflags, unsigned int *removeflags, unsigned int restrictflags, struct myentity *setter)
 {
 	struct chanacs *ca;
-	hook_channel_acl_req_t req;
+	struct hook_channel_acl_req req;
 
 	/* wrt the second assert: only one of mu or hostmask can be not-NULL --nenolod */
 	return_val_if_fail(mychan != NULL, false);

--- a/libathemecore/channels.c
+++ b/libathemecore/channels.c
@@ -345,7 +345,7 @@ chanuser_add(struct channel *chan, const char *nick)
 	struct chanuser *cu, *tcu;
 	unsigned int flags = 0;
 	int i = 0;
-	hook_channel_joinpart_t hdata;
+	struct hook_channel_joinpart hdata;
 
 	return_val_if_fail(chan != NULL, NULL);
 	return_val_if_fail(chan->name != NULL, NULL);
@@ -436,7 +436,7 @@ void
 chanuser_delete(struct channel *chan, struct user *user)
 {
 	struct chanuser *cu;
-	hook_channel_joinpart_t hdata;
+	struct hook_channel_joinpart hdata;
 
 	return_if_fail(chan != NULL);
 	return_if_fail(user != NULL);

--- a/libathemecore/cmode.c
+++ b/libathemecore/cmode.c
@@ -94,7 +94,7 @@ channel_mode(struct user *source, struct channel *chan, int parc, char *parv[])
 	struct user *target;
 	struct chanuser *cu = NULL;
 	struct user *first_deopped_service = NULL;
-	hook_channel_mode_t hookmsg;
+	struct hook_channel_mode hookmsg;
 
 	if ((!pos) || (*pos == '\0'))
 		return;

--- a/libathemecore/cmode.c
+++ b/libathemecore/cmode.c
@@ -320,7 +320,7 @@ channel_mode(struct user *source, struct channel *chan, int parc, char *parv[])
 					/* see if they did something we have to undo */
 					if (source == NULL && cu->user->server != me.me)
 					{
-						hook_channel_mode_change_t hookmsg_chg = {
+						struct hook_channel_mode_change hookmsg_chg = {
 							.cu = cu,
 							.mchar = status_mode_list[i].mode,
 							.mvalue = status_mode_list[i].value

--- a/libathemecore/entity.c
+++ b/libathemecore/entity.c
@@ -93,7 +93,7 @@ struct myentity *
 myentity_find(const char *name)
 {
 	struct myentity *ent;
-	hook_myentity_req_t req;
+	struct hook_myentity_req req;
 
 	return_val_if_fail(name != NULL, NULL);
 

--- a/libathemecore/module.c
+++ b/libathemecore/module.c
@@ -60,7 +60,7 @@ module_load(const char *filespec)
 	struct module *m;
 	char pathbuf[BUFSIZE], errbuf[BUFSIZE];
 	const char *pathname;
-	hook_module_load_t hdata;
+	struct hook_module_load hdata;
 
 	/* / or C:\... */
 	if (*filespec == '/' || *(filespec + 1) == ':')

--- a/libathemecore/ptasks.c
+++ b/libathemecore/ptasks.c
@@ -663,7 +663,7 @@ handle_message(struct sourceinfo *si, char *target, bool is_notice, char *messag
 void
 handle_topic_from(struct sourceinfo *si, struct channel *c, const char *setter, time_t ts, const char *topic)
 {
-	hook_channel_topic_check_t hdata;
+	struct hook_channel_topic_check hdata;
 
 	if (topic != NULL && topic[0] == '\0')
 		topic = NULL;

--- a/libathemecore/ptasks.c
+++ b/libathemecore/ptasks.c
@@ -497,7 +497,7 @@ static void
 handle_channel_message(struct sourceinfo *si, char *target, bool is_notice, char *message)
 {
 	char *vec[3];
-	hook_cmessage_data_t cdata;
+	struct hook_channel_message cdata;
 	mowgli_node_t *n, *tn;
 	mowgli_list_t l = { NULL, NULL, 0 };
 	struct service *svs;

--- a/libathemecore/servers.c
+++ b/libathemecore/servers.c
@@ -202,7 +202,7 @@ server_delete_serv(struct server *s)
 				s->name, s->uplink != NULL ? s->uplink->name : "<none>",
 				s->users);
 
-	hook_call_server_delete((&(hook_server_delete_t){ .s = s }));
+	hook_call_server_delete((&(struct hook_server_delete){ .s = s }));
 
 	/* first go through it's users and kill all of them */
 	MOWGLI_ITER_FOREACH_SAFE(n, tn, s->userlist.head)

--- a/libathemecore/services.c
+++ b/libathemecore/services.c
@@ -609,7 +609,7 @@ handle_certfp(struct sourceinfo *si, struct user *u, const char *certfp)
 	struct myuser *mu;
 	struct mycertfp *mcfp;
 	struct service *svs;
-	hook_user_login_check_t req;
+	struct hook_user_login_check req;
 
 	sfree(u->certfp);
 	u->certfp = sstrdup(certfp);

--- a/libathemecore/services.c
+++ b/libathemecore/services.c
@@ -401,7 +401,7 @@ handle_nickchange(struct user *const restrict u)
 	(void) hook_call_nick_check(u);
 }
 
-bool ircd_logout_or_kill(user_t *u, const char *login)
+bool ircd_logout_or_kill(struct user *u, const char *login)
 {
 	hook_user_logout_check_t req = {
 		.si      = NULL,

--- a/libathemecore/services.c
+++ b/libathemecore/services.c
@@ -403,7 +403,7 @@ handle_nickchange(struct user *const restrict u)
 
 bool ircd_logout_or_kill(struct user *u, const char *login)
 {
-	hook_user_logout_check_t req = {
+	struct hook_user_logout_check req = {
 		.si      = NULL,
 		.u       = u,
 		.allowed = true,

--- a/libathemecore/users.c
+++ b/libathemecore/users.c
@@ -225,8 +225,7 @@ user_delete(struct user *u, const char *comment)
 
 	slog(LG_DEBUG, "user_delete(): removing user: %s -> %s (%s)", u->nick, u->server->name, comment);
 
-	hook_call_user_delete_info((&(hook_user_delete_t){ .u = u,
-				.comment = comment}));
+	hook_call_user_delete_info((&(struct hook_user_delete_info){.u = u, .comment = comment}));
 	hook_call_user_delete(u);
 
 	u->server->users--;

--- a/libathemecore/users.c
+++ b/libathemecore/users.c
@@ -87,7 +87,7 @@ user_add(const char *nick, const char *user, const char *host,
 	struct server *server, time_t ts)
 {
 	struct user *u, *u2;
-	hook_user_nick_t hdata;
+	struct hook_user_nick hdata;
 
 	slog(LG_DEBUG, "user_add(): %s (%s@%s) -> %s", nick, user, host, server->name);
 
@@ -404,7 +404,7 @@ user_changenick(struct user *u, const char *nick, time_t ts)
 	struct user *u2;
 	char oldnick[NICKLEN + 1];
 	bool doenforcer = false;
-	hook_user_nick_t hdata;
+	struct hook_user_nick hdata;
 
 	return_val_if_fail(u != NULL, false);
 	return_val_if_fail(nick != NULL, false);

--- a/modules/botserv/main.c
+++ b/modules/botserv/main.c
@@ -920,7 +920,7 @@ on_shutdown(void *unused)
 }
 
 static void
-bs_join(hook_channel_joinpart_t *hdata)
+bs_join(struct hook_channel_joinpart *hdata)
 {
 	struct chanuser *cu = hdata->cu;
 	struct channel *chan;
@@ -964,7 +964,7 @@ bs_join(hook_channel_joinpart_t *hdata)
 }
 
 static void
-bs_part(hook_channel_joinpart_t *hdata)
+bs_part(struct hook_channel_joinpart *hdata)
 {
 	struct chanuser *cu;
 	struct mychan *mc;

--- a/modules/chanfix/chanfix.h
+++ b/modules/chanfix/chanfix.h
@@ -90,7 +90,7 @@ void chanfix_expire(void *unused);
 
 extern bool chanfix_do_autofix;
 void chanfix_autofix_ev(void *unused);
-void chanfix_can_register(hook_channel_register_check_t *req);
+void chanfix_can_register(struct hook_channel_register_check *req);
 
 extern struct command cmd_list;
 extern struct command cmd_chanfix;

--- a/modules/chanfix/fix.c
+++ b/modules/chanfix/fix.c
@@ -817,7 +817,7 @@ chanfix_cmd_help(struct sourceinfo *si, int parc, char *parv[])
 }
 
 void
-chanfix_can_register(hook_channel_register_check_t *req)
+chanfix_can_register(struct hook_channel_register_check *req)
 {
 	struct chanfix_channel *chan;
 	struct chanfix_oprecord *orec;

--- a/modules/chanserv/access.c
+++ b/modules/chanserv/access.c
@@ -327,7 +327,7 @@ update_role_entry(struct sourceinfo *si, struct mychan *mc, const char *role, un
 	mowgli_node_t *n, *tn;
 	struct chanacs *ca;
 	unsigned int changes = 0;
-	hook_channel_acl_req_t req;
+	struct hook_channel_acl_req req;
 
 	flagstr = bitmask_to_flags2(flags, 0);
 	oldflags = get_template_flags(mc, role);
@@ -641,7 +641,7 @@ cs_cmd_access_del(struct sourceinfo *si, int parc, char *parv[])
 	struct chanacs *ca;
 	struct myentity *mt;
 	struct mychan *mc;
-	hook_channel_acl_req_t req;
+	struct hook_channel_acl_req req;
 	unsigned int restrictflags;
 	const char *channel = parv[0];
 	const char *target = parv[1];
@@ -747,7 +747,7 @@ cs_cmd_access_add(struct sourceinfo *si, int parc, char *parv[])
 	struct chanacs *ca;
 	struct myentity *mt = NULL;
 	struct mychan *mc;
-	hook_channel_acl_req_t req;
+	struct hook_channel_acl_req req;
 	unsigned int oldflags, restrictflags;
 	unsigned int newflags, addflags, removeflags;
 	const char *channel = parv[0];
@@ -896,7 +896,7 @@ cs_cmd_access_set(struct sourceinfo *si, int parc, char *parv[])
 	struct chanacs *ca;
 	struct myentity *mt = NULL;
 	struct mychan *mc;
-	hook_channel_acl_req_t req;
+	struct hook_channel_acl_req req;
 	unsigned int oldflags, restrictflags;
 	unsigned int newflags, addflags, removeflags;
 	const char *channel = parv[0];

--- a/modules/chanserv/akick.c
+++ b/modules/chanserv/akick.c
@@ -196,7 +196,7 @@ cs_cmd_akick_add(struct sourceinfo *si, int parc, char *parv[])
 {
 	struct myentity *mt;
 	struct mychan *mc;
-	hook_channel_acl_req_t req;
+	struct hook_channel_acl_req req;
 	struct chanacs *ca, *ca2;
 	char *chan = parv[0];
 	long duration;
@@ -469,7 +469,7 @@ cs_cmd_akick_del(struct sourceinfo *si, int parc, char *parv[])
 {
 	struct myentity *mt;
 	struct mychan *mc;
-	hook_channel_acl_req_t req;
+	struct hook_channel_acl_req req;
 	struct chanacs *ca;
 	mowgli_node_t *n, *tn;
 	char *chan = parv[0];

--- a/modules/chanserv/antiflood.c
+++ b/modules/chanserv/antiflood.c
@@ -328,7 +328,7 @@ antiflood_unenforce_timer_cb(void *unused)
 }
 
 static void
-on_channel_message(hook_cmessage_data_t *data)
+on_channel_message(struct hook_channel_message *data)
 {
 	struct chanuser *cu;
 	struct mychan *mc;

--- a/modules/chanserv/close.c
+++ b/modules/chanserv/close.c
@@ -10,7 +10,7 @@
 #include <atheme.h>
 
 static void
-close_check_join(hook_channel_joinpart_t *data)
+close_check_join(struct hook_channel_joinpart *data)
 {
 	struct mychan *mc;
 	struct chanuser *cu = data->cu;

--- a/modules/chanserv/fflags.c
+++ b/modules/chanserv/fflags.c
@@ -20,7 +20,7 @@ cs_cmd_fflags(struct sourceinfo *si, int parc, char *parv[])
 	struct myentity *mt;
 	unsigned int addflags, removeflags;
 	struct chanacs *ca;
-	hook_channel_acl_req_t req;
+	struct hook_channel_acl_req req;
 
 	if (parc < 3)
 	{

--- a/modules/chanserv/flags.c
+++ b/modules/chanserv/flags.c
@@ -148,7 +148,7 @@ do_list(struct sourceinfo *si, struct mychan *mc, unsigned int flags)
 }
 
 static void
-check_registration_keywords(hook_user_register_check_t *hdata)
+check_registration_keywords(struct hook_user_register_check *hdata)
 {
 	if (hdata->approved || !anope_flags_compat)
 	{

--- a/modules/chanserv/flags.c
+++ b/modules/chanserv/flags.c
@@ -173,7 +173,7 @@ cs_cmd_flags(struct sourceinfo *si, int parc, char *parv[])
 	char *flagstr = parv[2];
 	const char *str1;
 	unsigned int addflags, removeflags, restrictflags;
-	hook_channel_acl_req_t req;
+	struct hook_channel_acl_req req;
 	struct mychan *mc;
 
 	if (parc < 1)

--- a/modules/chanserv/info.c
+++ b/modules/chanserv/info.c
@@ -21,7 +21,7 @@ cs_cmd_info(struct sourceinfo *si, int parc, char *parv[])
 	struct myuser *mu;
 	struct metadata *md;
 	mowgli_patricia_iteration_state_t state;
-	hook_channel_req_t req;
+	struct hook_channel_req req;
 	bool hide_info, hide_acl;
 
 	if (!name)

--- a/modules/chanserv/main.c
+++ b/modules/chanserv/main.c
@@ -839,7 +839,7 @@ cs_leave_empty(void *unused)
 }
 
 static void
-cs_bounce_mode_change(hook_channel_mode_change_t *data)
+cs_bounce_mode_change(struct hook_channel_mode_change *data)
 {
 	struct mychan *mc;
 	struct chanuser *cu;

--- a/modules/chanserv/main.c
+++ b/modules/chanserv/main.c
@@ -255,7 +255,7 @@ c_ci_templates(mowgli_config_file_entry_t *ce)
 }
 
 static void
-cs_join(hook_channel_joinpart_t *hdata)
+cs_join(struct hook_channel_joinpart *hdata)
 {
 	struct chanuser *cu = hdata->cu;
 	struct user *u;
@@ -506,7 +506,7 @@ cs_join(hook_channel_joinpart_t *hdata)
 }
 
 static void
-cs_part(hook_channel_joinpart_t *hdata)
+cs_part(struct hook_channel_joinpart *hdata)
 {
 	struct chanuser *cu;
 	struct mychan *mc;

--- a/modules/chanserv/main.c
+++ b/modules/chanserv/main.c
@@ -646,7 +646,7 @@ cs_keeptopic_topicset(struct channel *c)
 /* Called when a topic change is received from the network, before altering
  * our internal structures */
 static void
-cs_topiccheck(hook_channel_topic_check_t *data)
+cs_topiccheck(struct hook_channel_topic_check *data)
 {
 	struct mychan *mc;
 	unsigned int accessfl = 0;

--- a/modules/chanserv/main.c
+++ b/modules/chanserv/main.c
@@ -597,7 +597,7 @@ cs_register(struct hook_channel_req *hdata)
 }
 
 static void
-cs_succession(hook_channel_succession_req_t *data)
+cs_succession(struct hook_channel_succession_req *data)
 {
 	chanacs_change_simple(data->mc, entity(data->mu), NULL, custom_founder_check(), 0, NULL);
 }

--- a/modules/chanserv/main.c
+++ b/modules/chanserv/main.c
@@ -578,7 +578,7 @@ get_changets_user(struct mychan *mc)
 }
 
 static void
-cs_register(hook_channel_req_t *hdata)
+cs_register(struct hook_channel_req *hdata)
 {
 	struct mychan *mc;
 

--- a/modules/chanserv/moderate.c
+++ b/modules/chanserv/moderate.c
@@ -187,7 +187,7 @@ cs_cmd_activate(struct sourceinfo *si, int parc, char *parv[])
 	struct user *u;
 	struct channel *c;
 	char str[BUFSIZE];
-	hook_channel_req_t hdata;
+	struct hook_channel_req hdata;
 	struct sourceinfo baked_si;
 	unsigned int fl;
 

--- a/modules/chanserv/moderate.c
+++ b/modules/chanserv/moderate.c
@@ -152,7 +152,7 @@ send_group_memo(struct sourceinfo *si, const char *memo, ...)
 
 // deny chanserv registrations but turn them into a request
 static void
-can_register(hook_channel_register_check_t *req)
+can_register(struct hook_channel_register_check *req)
 {
 	struct reg_request *cs;
 

--- a/modules/chanserv/register.c
+++ b/modules/chanserv/register.c
@@ -21,7 +21,7 @@ cs_cmd_register(struct sourceinfo *si, int parc, char *parv[])
 	struct mychan *mc;
 	char *name = parv[0];
 	char str[21];
-	hook_channel_register_check_t hdatac;
+	struct hook_channel_register_check hdatac;
 	hook_channel_req_t hdata;
 	unsigned int fl;
 

--- a/modules/chanserv/register.c
+++ b/modules/chanserv/register.c
@@ -22,7 +22,7 @@ cs_cmd_register(struct sourceinfo *si, int parc, char *parv[])
 	char *name = parv[0];
 	char str[21];
 	struct hook_channel_register_check hdatac;
-	hook_channel_req_t hdata;
+	struct hook_channel_req hdata;
 	unsigned int fl;
 
 	/* This command is not useful on registered channels, ignore it if

--- a/modules/chanserv/successor_acl.c
+++ b/modules/chanserv/successor_acl.c
@@ -12,7 +12,7 @@
 static unsigned int successor_flag = 0;
 
 static void
-channel_pick_successor_hook(hook_channel_succession_req_t *req)
+channel_pick_successor_hook(struct hook_channel_succession_req *req)
 {
 	return_if_fail(req != NULL);
 	return_if_fail(req->mc != NULL);
@@ -27,7 +27,7 @@ channel_pick_successor_hook(hook_channel_succession_req_t *req)
 }
 
 static void
-channel_succession_hook(hook_channel_succession_req_t *req)
+channel_succession_hook(struct hook_channel_succession_req *req)
 {
 	return_if_fail(req != NULL);
 	return_if_fail(req->mc != NULL);

--- a/modules/chanserv/sync.c
+++ b/modules/chanserv/sync.c
@@ -275,7 +275,7 @@ sync_myuser(struct myuser *mu)
 }
 
 static void
-sync_channel_acl_change(hook_channel_acl_req_t *hookdata)
+sync_channel_acl_change(struct hook_channel_acl_req *hookdata)
 {
 	struct mychan *mc;
 

--- a/modules/chanserv/xop.c
+++ b/modules/chanserv/xop.c
@@ -16,7 +16,7 @@ cs_xop_do_add(struct sourceinfo *si, struct mychan *mc, struct myentity *mt, cha
 	struct chanacs *ca;
 	unsigned int addflags = level, removeflags = ~level;
 	bool isnew;
-	hook_channel_acl_req_t req;
+	struct hook_channel_acl_req req;
 
 	if (!mt)
 	{
@@ -151,7 +151,7 @@ static void
 cs_xop_do_del(struct sourceinfo *si, struct mychan *mc, struct myentity *mt, char *target, unsigned int level, const char *leveldesc)
 {
 	struct chanacs *ca;
-	hook_channel_acl_req_t req;
+	struct hook_channel_acl_req req;
 
 	// let's finally make this sane.. --w00t
 	if (!mt)

--- a/modules/exttarget/main.c
+++ b/modules/exttarget/main.c
@@ -12,7 +12,7 @@
 mowgli_patricia_t *exttarget_tree = NULL;
 
 static void
-exttarget_find(hook_myentity_req_t *req)
+exttarget_find(struct hook_myentity_req *req)
 {
 	char buf[BUFSIZE];
 	char *i, *j;

--- a/modules/groupserv/fflags.c
+++ b/modules/groupserv/fflags.c
@@ -93,7 +93,7 @@ gs_cmd_fflags(struct sourceinfo *si, int parc, char *parv[])
 			mt->name, gflags_tostr(ga_flags, ga->flags), entity(mg)->name,
 			bitmask_to_flags(ca->level), ca->mychan->name);
 
-		hook_call_channel_acl_change(&(hook_channel_acl_req_t){ .ca = ca });
+		hook_call_channel_acl_change(&(struct hook_channel_acl_req){ .ca = ca });
 	}
 
 	command_success_nodata(si, _("\2%s\2 now has flags \2%s\2 on \2%s\2."), mt->name, gflags_tostr(ga_flags, ga->flags), entity(mg)->name);

--- a/modules/groupserv/flags.c
+++ b/modules/groupserv/flags.c
@@ -195,7 +195,7 @@ no_founder:
 			mt->name, gflags_tostr(ga_flags, ga->flags), entity(mg)->name,
 			bitmask_to_flags(ca->level), ca->mychan->name);
 
-		hook_call_channel_acl_change(&(hook_channel_acl_req_t){ .ca = ca });
+		hook_call_channel_acl_change(&(struct hook_channel_acl_req){ .ca = ca });
 	}
 
 	command_success_nodata(si, _("\2%s\2 now has flags \2%s\2 on \2%s\2."), mt->name, gflags_tostr(ga_flags, ga->flags), entity(mg)->name);

--- a/modules/groupserv/main/hooks.c
+++ b/modules/groupserv/main/hooks.c
@@ -150,7 +150,7 @@ user_info_hook(struct hook_user_req *req)
 }
 
 static void
-sasl_may_impersonate_hook(hook_sasl_may_impersonate_t *req)
+sasl_may_impersonate_hook(struct hook_sasl_may_impersonate *req)
 {
 	char priv[BUFSIZE];
 	mowgli_list_t *l;

--- a/modules/groupserv/main/hooks.c
+++ b/modules/groupserv/main/hooks.c
@@ -119,7 +119,7 @@ grant_channel_access_hook(struct user *u)
 }
 
 static void
-user_info_hook(hook_user_req_t *req)
+user_info_hook(struct hook_user_req *req)
 {
 	static char buf[BUFSIZE];
 	mowgli_node_t *n;

--- a/modules/hostserv/hostserv.h
+++ b/modules/hostserv/hostserv.h
@@ -10,13 +10,6 @@
 
 #include <atheme.h>
 
-typedef struct {
-        const char *host;
-	struct sourceinfo *si;
-	int approved;
-	const char *target;
-} hook_host_request_t;
-
 /*
  * do_sethost(struct user *u, char *host)
  *

--- a/modules/hostserv/request.c
+++ b/modules/hostserv/request.c
@@ -63,7 +63,7 @@ db_h_hr(struct database_handle *db, const char *type)
 }
 
 static void
-nick_drop_request(hook_user_req_t *hdata)
+nick_drop_request(struct hook_user_req *hdata)
 {
 	mowgli_node_t *m;
 	struct hsrequest *l;

--- a/modules/hostserv/request.c
+++ b/modules/hostserv/request.c
@@ -188,7 +188,7 @@ hs_cmd_request(struct sourceinfo *si, int parc, char *parv[])
 	struct metadata *md, *md_timestamp, *md_assigner;
 	mowgli_node_t *n;
 	struct hsrequest *l;
-	hook_host_request_t hdata;
+	struct hook_host_request hdata;
 	int matches = 0;
 
 	if (!host)

--- a/modules/infoserv/main.c
+++ b/modules/infoserv/main.c
@@ -129,7 +129,7 @@ db_h_lio(struct database_handle *db, const char *type)
 }
 
 static void
-display_info(hook_user_nick_t *data)
+display_info(struct hook_user_nick *data)
 {
 	struct user *u;
 	mowgli_node_t *n;

--- a/modules/nickserv/access.c
+++ b/modules/nickserv/access.c
@@ -139,7 +139,7 @@ myuser_access_delete_enforce(struct myuser *mu, char *mask)
 	mowgli_node_t *n, *tn;
 	struct mynick *mn;
 	struct user *u;
-	hook_nick_enforce_t hdata;
+	struct hook_nick_enforce hdata;
 
 	// find users who get access via the access list
 	MOWGLI_ITER_FOREACH(n, mu->nicks.head)

--- a/modules/nickserv/badmail.c
+++ b/modules/nickserv/badmail.c
@@ -54,7 +54,7 @@ db_h_be(struct database_handle *db, const char *type)
 }
 
 static void
-check_registration(hook_user_register_check_t *hdata)
+check_registration(struct hook_user_register_check *hdata)
 {
 	mowgli_node_t *n;
 	struct badmail *l;

--- a/modules/nickserv/enforce.c
+++ b/modules/nickserv/enforce.c
@@ -137,7 +137,7 @@ enforce_timeout_check(void *arg)
 }
 
 static void
-check_enforce(hook_nick_enforce_t *hdata)
+check_enforce(struct hook_nick_enforce *hdata)
 {
 	struct enforce_timeout *timeout, *timeout2;
 	mowgli_node_t *n;
@@ -225,7 +225,7 @@ check_enforce_all(struct myuser *mu)
 		u = user_find(mn->nick);
 		if (u != NULL && u->myuser != mn->owner &&
 				!myuser_access_verify(u, mn->owner))
-			check_enforce(&(hook_nick_enforce_t){ .u = u, .mn = mn });
+			check_enforce(&(struct hook_nick_enforce){ .u = u, .mn = mn });
 	}
 }
 

--- a/modules/nickserv/enforce.c
+++ b/modules/nickserv/enforce.c
@@ -587,7 +587,7 @@ show_enforce(hook_user_req_t *hdata)
 }
 
 static void
-check_registration(hook_user_register_check_t *hdata)
+check_registration(struct hook_user_register_check *hdata)
 {
 	int prefixlen;
 

--- a/modules/nickserv/enforce.c
+++ b/modules/nickserv/enforce.c
@@ -580,7 +580,7 @@ enforce_remove_enforcers(void *arg)
 }
 
 static void
-show_enforce(hook_user_req_t *hdata)
+show_enforce(struct hook_user_req *hdata)
 {
 	if (metadata_find(hdata->mu, "private:doenforce"))
 		command_success_nodata(hdata->si, _("%s has enabled nick protection"), entity(hdata->mu)->name);

--- a/modules/nickserv/group.c
+++ b/modules/nickserv/group.c
@@ -14,7 +14,7 @@ ns_cmd_group(struct sourceinfo *si, int parc, char *parv[])
 {
 	struct mynick *mn;
 	hook_user_req_t hdata;
-	hook_user_register_check_t hdata_reg;
+	struct hook_user_register_check hdata_reg;
 
 	if (si->su == NULL)
 	{

--- a/modules/nickserv/group.c
+++ b/modules/nickserv/group.c
@@ -13,7 +13,7 @@ static void
 ns_cmd_group(struct sourceinfo *si, int parc, char *parv[])
 {
 	struct mynick *mn;
-	hook_user_req_t hdata;
+	struct hook_user_req hdata;
 	struct hook_user_register_check hdata_reg;
 
 	if (si->su == NULL)
@@ -80,7 +80,7 @@ ns_cmd_ungroup(struct sourceinfo *si, int parc, char *parv[])
 {
 	struct mynick *mn;
 	const char *target;
-	hook_user_req_t hdata;
+	struct hook_user_req hdata;
 
 	if (parc >= 1)
 		target = parv[0];
@@ -121,7 +121,7 @@ ns_cmd_fungroup(struct sourceinfo *si, int parc, char *parv[])
 {
 	struct mynick *mn, *mn2 = NULL;
 	struct myuser *mu;
-	hook_user_req_t hdata;
+	struct hook_user_req hdata;
 
 	if (parc < 1)
 	{

--- a/modules/nickserv/identify.c
+++ b/modules/nickserv/identify.c
@@ -69,13 +69,16 @@ ns_cmd_login(struct sourceinfo *si, int parc, char *parv[])
 		.mu      = mu,
 		.allowed = true,
 	};
-	hook_user_logout_check_t logout_req = {
+
+	struct hook_user_logout_check logout_req = {
 		.si      = si,
 		.u       = u,
 		.allowed = true,
 		.relogin = true,
 	};
+
 	hook_call_user_can_login(&login_req);
+
 	if (login_req.allowed && u->myuser)
 		hook_call_user_can_logout(&logout_req);
 

--- a/modules/nickserv/identify.c
+++ b/modules/nickserv/identify.c
@@ -64,7 +64,7 @@ ns_cmd_login(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	hook_user_login_check_t login_req = {
+	struct hook_user_login_check login_req = {
 		.si      = si,
 		.mu      = mu,
 		.allowed = true,

--- a/modules/nickserv/info.c
+++ b/modules/nickserv/info.c
@@ -33,7 +33,7 @@ ns_cmd_info(struct sourceinfo *si, int parc, char *parv[])
 	time_t vhost_time;
 	bool has_user_auspex;
 	bool hide_info;
-	hook_user_req_t req;
+	struct hook_user_req req;
 	hook_info_noexist_req_t noexist_req;
 
 	// On IRC, default the name to something. Not currently documented.

--- a/modules/nickserv/info.c
+++ b/modules/nickserv/info.c
@@ -34,7 +34,7 @@ ns_cmd_info(struct sourceinfo *si, int parc, char *parv[])
 	bool has_user_auspex;
 	bool hide_info;
 	struct hook_user_req req;
-	hook_info_noexist_req_t noexist_req;
+	struct hook_info_noexist_req noexist_req;
 
 	// On IRC, default the name to something. Not currently documented.
 	if (!name && si->su)

--- a/modules/nickserv/info_lastquit.c
+++ b/modules/nickserv/info_lastquit.c
@@ -10,7 +10,7 @@
 #include <atheme.h>
 
 static void
-user_delete_info_hook(hook_user_delete_t *hdata)
+user_delete_info_hook(struct hook_user_delete_info *hdata)
 {
 	if (hdata->u->myuser == NULL)
 		return;

--- a/modules/nickserv/info_lastquit.c
+++ b/modules/nickserv/info_lastquit.c
@@ -19,7 +19,7 @@ user_delete_info_hook(struct hook_user_delete_info *hdata)
 }
 
 static void
-info_hook(hook_user_req_t *hdata)
+info_hook(struct hook_user_req *hdata)
 {
 	struct metadata *md;
 

--- a/modules/nickserv/logout.c
+++ b/modules/nickserv/logout.c
@@ -47,7 +47,7 @@ ns_cmd_logout(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	hook_user_logout_check_t req = {
+	struct hook_user_logout_check req = {
 		.si      = si,
 		.u       = u,
 		.allowed = true,

--- a/modules/nickserv/main.c
+++ b/modules/nickserv/main.c
@@ -32,7 +32,7 @@ static void
 nickserv_handle_nickchange(struct user *u)
 {
 	struct mynick *mn;
-	hook_nick_enforce_t hdata;
+	struct hook_nick_enforce hdata;
 
 	if (nicksvs.me == NULL || nicksvs.no_nick_ownership)
 		return;

--- a/modules/nickserv/multimark.c
+++ b/modules/nickserv/multimark.c
@@ -353,7 +353,7 @@ migrate_all(struct sourceinfo *si)
 }
 
 static void
-nick_ungroup_hook(hook_user_req_t *hdata)
+nick_ungroup_hook(struct hook_user_req *hdata)
 {
 	struct myuser *mu = hdata->mu;
 	mowgli_list_t *l = multimark_list(mu);
@@ -460,7 +460,7 @@ account_register_hook(struct myuser *mu)
 }
 
 static void
-nick_group_hook(hook_user_req_t *hdata)
+nick_group_hook(struct hook_user_req *hdata)
 {
 	struct myuser *smu = hdata->si->smu;
 	mowgli_list_t *l;
@@ -516,7 +516,7 @@ nick_group_hook(hook_user_req_t *hdata)
 }
 
 static void
-show_multimark(hook_user_req_t *hdata)
+show_multimark(struct hook_user_req *hdata)
 {
 	mowgli_list_t *l;
 

--- a/modules/nickserv/multimark.c
+++ b/modules/nickserv/multimark.c
@@ -711,7 +711,7 @@ show_multimark_noexist(struct hook_info_noexist_req *hdata)
 }
 
 static void
-multimark_needforce(hook_user_needforce_t *hdata)
+multimark_needforce(struct hook_user_needforce *hdata)
 {
 	struct myuser *mu;
 	bool marked;

--- a/modules/nickserv/multimark.c
+++ b/modules/nickserv/multimark.c
@@ -647,7 +647,7 @@ show_multimark(struct hook_user_req *hdata)
 }
 
 static void
-show_multimark_noexist(hook_info_noexist_req_t *hdata)
+show_multimark_noexist(struct hook_info_noexist_req *hdata)
 {
 	const char *nick = hdata->nick;
 

--- a/modules/nickserv/pwquality.c
+++ b/modules/nickserv/pwquality.c
@@ -125,7 +125,7 @@ pwquality_config_check(void)
 }
 
 static void
-pwquality_register_hook(hook_user_register_check_t *const restrict hdata)
+pwquality_register_hook(struct hook_user_register_check *const restrict hdata)
 {
 	return_if_fail(hdata != NULL);
 	return_if_fail(hdata->si != NULL);

--- a/modules/nickserv/register.c
+++ b/modules/nickserv/register.c
@@ -23,7 +23,7 @@ ns_cmd_register(struct sourceinfo *si, int parc, char *parv[])
 	const char *email;
 	char lau[BUFSIZE], lao[BUFSIZE];
 	struct hook_user_register_check hdata;
-	hook_user_req_t req;
+	struct hook_user_req req;
 
 	if (si->smu)
 	{

--- a/modules/nickserv/register.c
+++ b/modules/nickserv/register.c
@@ -22,7 +22,7 @@ ns_cmd_register(struct sourceinfo *si, int parc, char *parv[])
 	const char *pass;
 	const char *email;
 	char lau[BUFSIZE], lao[BUFSIZE];
-	hook_user_register_check_t hdata;
+	struct hook_user_register_check hdata;
 	hook_user_req_t req;
 
 	if (si->smu)

--- a/modules/nickserv/restrict.c
+++ b/modules/nickserv/restrict.c
@@ -36,7 +36,7 @@ restricted_match(const struct mynick *mn, const void *arg)
 }
 
 static void
-info_hook(hook_user_req_t *hdata)
+info_hook(struct hook_user_req *hdata)
 {
 	struct metadata *md;
 

--- a/modules/nickserv/sendpass.c
+++ b/modules/nickserv/sendpass.c
@@ -27,7 +27,7 @@ ns_cmd_sendpass(struct sourceinfo *si, int parc, char *parv[])
 	enum specialoperation op = op_none;
 	bool ismarked = false;
 	char cmdtext[NICKLEN + 20];
-	hook_user_needforce_t needforce_hdata;
+	struct hook_user_needforce needforce_hdata;
 
 	if (!name)
 	{

--- a/modules/nickserv/set_accountname.c
+++ b/modules/nickserv/set_accountname.c
@@ -18,7 +18,7 @@ ns_cmd_set_accountname(struct sourceinfo *si, int parc, char *parv[])
 {
 	char *newname = parv[0];
 	struct mynick *mn;
-	hook_user_rename_check_t req;
+	struct hook_user_rename_check req;
 
 	if (!newname)
 	{

--- a/modules/nickserv/set_property.c
+++ b/modules/nickserv/set_property.c
@@ -21,7 +21,7 @@ ns_cmd_set_property(struct sourceinfo *si, int parc, char *parv[])
 	unsigned int count;
 	mowgli_patricia_iteration_state_t state;
 	struct metadata *md;
-	hook_metadata_change_t mdchange;
+	struct hook_metadata_change mdchange;
 
 	if (!property)
 	{

--- a/modules/nickserv/setpass.c
+++ b/modules/nickserv/setpass.c
@@ -100,7 +100,7 @@ clear_setpass_key(struct user *u)
 }
 
 static void
-show_setpass(hook_user_req_t *hdata)
+show_setpass(struct hook_user_req *hdata)
 {
 	if (has_priv(hdata->si, PRIV_USER_AUSPEX))
 	{

--- a/modules/nickserv/vacation.c
+++ b/modules/nickserv/vacation.c
@@ -50,7 +50,7 @@ user_identify_hook(struct user *u)
 }
 
 static void
-user_expiry_hook(hook_expiry_req_t *req)
+user_expiry_hook(struct hook_expiry_req *req)
 {
 	struct myuser *mu = req->data.mu;
 
@@ -62,7 +62,7 @@ user_expiry_hook(hook_expiry_req_t *req)
 }
 
 static void
-nick_expiry_hook(hook_expiry_req_t *req)
+nick_expiry_hook(struct hook_expiry_req *req)
 {
 	struct mynick *mn = req->data.mn;
 	struct myuser *mu = mn->owner;

--- a/modules/nickserv/vacation.c
+++ b/modules/nickserv/vacation.c
@@ -75,7 +75,7 @@ nick_expiry_hook(struct hook_expiry_req *req)
 }
 
 static void
-info_hook(hook_user_req_t *hdata)
+info_hook(struct hook_user_req *hdata)
 {
 	if (metadata_find(hdata->mu, "private:vacation"))
 		command_success_nodata(hdata->si, _("%s is on vacation and has an extended expiry time"),

--- a/modules/nickserv/verify.c
+++ b/modules/nickserv/verify.c
@@ -18,7 +18,7 @@ ns_cmd_verify(struct sourceinfo *si, int parc, char *parv[])
 	char *op = parv[0];
 	char *nick = parv[1];
 	char *key = parv[2];
-	hook_user_req_t req;
+	struct hook_user_req req;
 
 	if (!op || !nick || !key)
 	{
@@ -137,7 +137,7 @@ ns_cmd_fverify(struct sourceinfo *si, int parc, char *parv[])
 	mowgli_node_t *n;
 	char *op = parv[0];
 	char *nick = parv[1];
-	hook_user_req_t req;
+	struct hook_user_req req;
 
 	if (!op || !nick)
 	{

--- a/modules/nickserv/vhost.c
+++ b/modules/nickserv/vhost.c
@@ -44,7 +44,7 @@ ns_cmd_vhost(struct sourceinfo *si, int parc, char *parv[])
 	bool force = false, ismarked = false;
 	char cmdtext[NICKLEN + HOSTLEN + 20];
 	char timestring[16];
-	hook_user_needforce_t needforce_hdata;
+	struct hook_user_needforce needforce_hdata;
 
 	if (!target)
 	{

--- a/modules/nickserv/waitreg.c
+++ b/modules/nickserv/waitreg.c
@@ -25,7 +25,7 @@ waitreg_infohook(struct sourceinfo *const restrict si)
 }
 
 static void
-waitreg_registerhook(hook_user_register_check_t *const restrict hdata)
+waitreg_registerhook(struct hook_user_register_check *const restrict hdata)
 {
 	if (! waitreg_time)
 		return;

--- a/modules/operserv/akill.c
+++ b/modules/operserv/akill.c
@@ -14,7 +14,7 @@
 static mowgli_patricia_t *os_akill_cmds = NULL;
 
 static void
-os_akill_newuser(hook_user_nick_t *data)
+os_akill_newuser(struct hook_user_nick *data)
 {
 	struct user *u = data->u;
 	struct kline *k;

--- a/modules/operserv/clones.c
+++ b/modules/operserv/clones.c
@@ -694,7 +694,7 @@ os_cmd_clones_listexempt(struct sourceinfo *si, int parc, char *parv[])
 }
 
 static void
-clones_newuser(hook_user_nick_t *data)
+clones_newuser(struct hook_user_nick *data)
 {
 	struct user *u = data->u;
 	unsigned int i;
@@ -976,7 +976,7 @@ mod_init(struct module *const restrict m)
 	struct user *u;
 	mowgli_patricia_iteration_state_t state;
 	MOWGLI_PATRICIA_FOREACH(u, &state, userlist)
-		(void) clones_newuser(&(hook_user_nick_t){ .u = u });
+		(void) clones_newuser(&(struct hook_user_nick){ .u = u });
 
 	m->mflags |= MODFLAG_DBHANDLER;
 }

--- a/modules/operserv/rwatch.c
+++ b/modules/operserv/rwatch.c
@@ -437,7 +437,7 @@ os_cmd_rwatch_set(struct sourceinfo *si, int parc, char *parv[])
 }
 
 static void
-rwatch_newuser(hook_user_nick_t *data)
+rwatch_newuser(struct hook_user_nick *data)
 {
 	struct user *u = data->u;
 	char usermask[NICKLEN + 1 + USERLEN + 1 + HOSTLEN + 1 + GECOSLEN + 1];
@@ -502,7 +502,7 @@ rwatch_newuser(hook_user_nick_t *data)
 }
 
 static void
-rwatch_nickchange(hook_user_nick_t *data)
+rwatch_nickchange(struct hook_user_nick *data)
 {
 	struct user *u = data->u;
 	char usermask[NICKLEN + 1 + USERLEN + 1 + HOSTLEN + 1 + GECOSLEN + 1];

--- a/modules/operserv/sgline.c
+++ b/modules/operserv/sgline.c
@@ -14,7 +14,7 @@
 static mowgli_patricia_t *os_sgline_cmds = NULL;
 
 static void
-os_sgline_newuser(hook_user_nick_t *data)
+os_sgline_newuser(struct hook_user_nick *data)
 {
 	struct user *u = data->u;
 	struct xline *x;

--- a/modules/operserv/sqline.c
+++ b/modules/operserv/sqline.c
@@ -14,7 +14,7 @@
 static mowgli_patricia_t *os_sqline_cmds = NULL;
 
 static void
-os_sqline_newuser(hook_user_nick_t *data)
+os_sqline_newuser(struct hook_user_nick *data)
 {
 	struct user *u = data->u;
 	struct qline *q;

--- a/modules/operserv/sqline.c
+++ b/modules/operserv/sqline.c
@@ -36,7 +36,7 @@ os_sqline_newuser(hook_user_nick_t *data)
 }
 
 static void
-os_sqline_chanjoin(hook_channel_joinpart_t *hdata)
+os_sqline_chanjoin(struct hook_channel_joinpart *hdata)
 {
 	struct chanuser *cu = hdata->cu;
 	struct qline *q;

--- a/modules/protocol/bahamut.c
+++ b/modules/protocol/bahamut.c
@@ -917,7 +917,7 @@ m_capab(struct sourceinfo *si, int parc, char *parv[])
 }
 
 static void
-nick_group(hook_user_req_t *hdata)
+nick_group(struct hook_user_req *hdata)
 {
 	struct user *u;
 
@@ -927,7 +927,7 @@ nick_group(hook_user_req_t *hdata)
 }
 
 static void
-nick_ungroup(hook_user_req_t *hdata)
+nick_ungroup(struct hook_user_req *hdata)
 {
 	struct user *u;
 

--- a/modules/protocol/ircd-seven.c
+++ b/modules/protocol/ircd-seven.c
@@ -290,7 +290,7 @@ nick_ungroup(struct hook_user_req *hdata)
 }
 
 static void
-user_can_logout(hook_user_logout_check_t *hdata)
+user_can_logout(struct hook_user_logout_check *hdata)
 {
 	if (hdata->u && (hdata->u->flags & UF_NOLOGOUT) && !hdata->relogin)
 		hdata->allowed = false;

--- a/modules/protocol/ircd-seven.c
+++ b/modules/protocol/ircd-seven.c
@@ -270,7 +270,7 @@ seven_is_ircop(struct user *u)
 }
 
 static void
-nick_group(hook_user_req_t *hdata)
+nick_group(struct hook_user_req *hdata)
 {
 	struct user *u;
 
@@ -280,7 +280,7 @@ nick_group(hook_user_req_t *hdata)
 }
 
 static void
-nick_ungroup(hook_user_req_t *hdata)
+nick_ungroup(struct hook_user_req *hdata)
 {
 	struct user *u;
 

--- a/modules/protocol/ngircd.c
+++ b/modules/protocol/ngircd.c
@@ -856,7 +856,7 @@ m_metadata(struct sourceinfo *si, int parc, char *parv[])
 }
 
 static void
-nick_group(hook_user_req_t *hdata)
+nick_group(struct hook_user_req *hdata)
 {
 	struct user *u;
 
@@ -866,7 +866,7 @@ nick_group(hook_user_req_t *hdata)
 }
 
 static void
-nick_ungroup(hook_user_req_t *hdata)
+nick_ungroup(struct hook_user_req *hdata)
 {
 	struct user *u;
 

--- a/modules/protocol/unreal.c
+++ b/modules/protocol/unreal.c
@@ -1527,7 +1527,7 @@ m_motd(struct sourceinfo *si, int parc, char *parv[])
 }
 
 static void
-nick_group(hook_user_req_t *hdata)
+nick_group(struct hook_user_req *hdata)
 {
 	struct user *u;
 
@@ -1538,7 +1538,7 @@ nick_group(hook_user_req_t *hdata)
 }
 
 static void
-nick_ungroup(hook_user_req_t *hdata)
+nick_ungroup(struct hook_user_req *hdata)
 {
 	struct user *u;
 

--- a/modules/protocol/unreal4.c
+++ b/modules/protocol/unreal4.c
@@ -1537,7 +1537,7 @@ m_md(struct sourceinfo *si, int parc, char *parv[])
 }
 
 static void
-nick_group(hook_user_req_t *hdata)
+nick_group(struct hook_user_req *hdata)
 {
 	struct user *u;
 
@@ -1548,7 +1548,7 @@ nick_group(hook_user_req_t *hdata)
 }
 
 static void
-nick_ungroup(hook_user_req_t *hdata)
+nick_ungroup(struct hook_user_req *hdata)
 {
 	struct user *u;
 

--- a/modules/proxyscan/dnsbl.c
+++ b/modules/proxyscan/dnsbl.c
@@ -515,7 +515,7 @@ dnsbl_action_config_handler(mowgli_config_file_entry_t *ce)
 }
 
 static void
-check_dnsbls(hook_user_nick_t *data)
+check_dnsbls(struct hook_user_nick *data)
 {
 	struct user *u = data->u;
 	mowgli_node_t *n;

--- a/modules/saslserv/main.c
+++ b/modules/saslserv/main.c
@@ -982,7 +982,7 @@ sasl_authxid_can_login(struct sasl_session *const restrict p, const char *const 
 		// We have already executed the user_can_login hook for this user
 		return true;
 
-	hook_user_login_check_t req = {
+	struct hook_user_login_check req = {
 
 		.si         = p->si,
 		.mu         = mu,

--- a/modules/saslserv/main.c
+++ b/modules/saslserv/main.c
@@ -226,7 +226,7 @@ sasl_may_impersonate(struct myuser *const source_mu, struct myuser *const target
 		return true;
 
 	// Allow modules to check too
-	hook_sasl_may_impersonate_t req = {
+	struct hook_sasl_may_impersonate req = {
 
 		.source_mu = source_mu,
 		.target_mu = target_mu,

--- a/modules/saslserv/main.c
+++ b/modules/saslserv/main.c
@@ -745,7 +745,7 @@ sasl_input_startauth(const struct sasl_message *const restrict smsg, struct sasl
 		(void) slog(LG_DEBUG, "%s: user %s ('%s') is logged in as '%s' -- executing user_can_logout hooks",
 		                      MOWGLI_FUNC_NAME, p->uid, u->nick, entity(u->myuser)->name);
 
-		hook_user_logout_check_t req = {
+		struct hook_user_logout_check req = {
 			.si      = p->si,
 			.u       = u,
 			.allowed = true,

--- a/modules/saslserv/main.c
+++ b/modules/saslserv/main.c
@@ -872,7 +872,7 @@ sasl_input(struct sasl_message *const restrict smsg)
 }
 
 static void
-sasl_user_add(hook_user_nick_t *const restrict data)
+sasl_user_add(struct hook_user_nick *const restrict data)
 {
 	// If the user has been killed, don't do anything.
 	struct user *const u = data->u;

--- a/modules/scripting/perl/api/Atheme.xs
+++ b/modules/scripting/perl/api/Atheme.xs
@@ -1,6 +1,6 @@
 #include "atheme_perl.h"
 
-typedef sourceinfo_t *Atheme_Sourceinfo;
+typedef struct sourceinfo *Atheme_Sourceinfo;
 typedef struct perl_command *Atheme_Command;
 typedef struct service *Atheme_Service;
 typedef struct user *Atheme_User;

--- a/modules/scripting/perl/api/Atheme.xs
+++ b/modules/scripting/perl/api/Atheme.xs
@@ -2,7 +2,7 @@
 
 typedef sourceinfo_t *Atheme_Sourceinfo;
 typedef struct perl_command *Atheme_Command;
-typedef service_t *Atheme_Service;
+typedef struct service *Atheme_Service;
 typedef struct user *Atheme_User;
 typedef struct atheme_object *Atheme_Object;
 typedef struct atheme_object *Atheme_Object_MetadataHash;

--- a/modules/scripting/perl/api/Atheme.xs
+++ b/modules/scripting/perl/api/Atheme.xs
@@ -9,7 +9,7 @@ typedef struct atheme_object *Atheme_Object_MetadataHash;
 typedef myentity_t *Atheme_Entity;
 typedef struct myuser *Atheme_Account;
 typedef struct channel *Atheme_Channel;
-typedef chanuser_t *Atheme_ChanUser;
+typedef struct chanuser *Atheme_ChanUser;
 typedef struct mychan *Atheme_ChannelRegistration;
 typedef struct chanacs *Atheme_ChanAcs;
 typedef struct mynick *Atheme_NickRegistration;

--- a/modules/scripting/perl/api/Atheme.xs
+++ b/modules/scripting/perl/api/Atheme.xs
@@ -11,7 +11,7 @@ typedef struct myuser *Atheme_Account;
 typedef channel_t *Atheme_Channel;
 typedef chanuser_t *Atheme_ChanUser;
 typedef struct mychan *Atheme_ChannelRegistration;
-typedef chanacs_t *Atheme_ChanAcs;
+typedef struct chanacs *Atheme_ChanAcs;
 typedef struct mynick *Atheme_NickRegistration;
 typedef struct server *Atheme_Server;
 

--- a/modules/scripting/perl/api/Atheme.xs
+++ b/modules/scripting/perl/api/Atheme.xs
@@ -8,7 +8,7 @@ typedef struct atheme_object *Atheme_Object;
 typedef struct atheme_object *Atheme_Object_MetadataHash;
 typedef myentity_t *Atheme_Entity;
 typedef struct myuser *Atheme_Account;
-typedef channel_t *Atheme_Channel;
+typedef struct channel *Atheme_Channel;
 typedef chanuser_t *Atheme_ChanUser;
 typedef struct mychan *Atheme_ChannelRegistration;
 typedef struct chanacs *Atheme_ChanAcs;

--- a/modules/scripting/perl/api/Atheme.xs
+++ b/modules/scripting/perl/api/Atheme.xs
@@ -6,7 +6,7 @@ typedef service_t *Atheme_Service;
 typedef struct user *Atheme_User;
 typedef struct atheme_object *Atheme_Object;
 typedef struct atheme_object *Atheme_Object_MetadataHash;
-typedef myentity_t *Atheme_Entity;
+typedef struct myentity *Atheme_Entity;
 typedef struct myuser *Atheme_Account;
 typedef struct channel *Atheme_Channel;
 typedef struct chanuser *Atheme_ChanUser;

--- a/modules/scripting/perl/api/channel.xs
+++ b/modules/scripting/perl/api/channel.xs
@@ -33,7 +33,7 @@ register (Atheme_Channel self, Atheme_Sourceinfo si, Atheme_Account user)
 CODE:
     char *name = self->name;
     struct mychan *mc = mychan_add(name);
-    hook_channel_req_t hdata;
+    struct hook_channel_req hdata;
 
     if (mc == NULL) {
         Perl_croak (aTHX_ "Failed to create channel registration for %s", name);

--- a/modules/scripting/perl/api/channelregistration.xs
+++ b/modules/scripting/perl/api/channelregistration.xs
@@ -44,7 +44,7 @@ transfer (Atheme_ChannelRegistration self, Atheme_Sourceinfo si, Atheme_Entity u
 CODE:
 	mowgli_node_t *n;
 
-	chanacs_t *ca;
+	struct chanacs *ca;
 
     MOWGLI_ITER_FOREACH(n, self->chanacs.head)
 	{

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -17,7 +17,7 @@ my @unsupported_types = ( 'struct database_handle', 'struct sasl_message',
 
 # Types that need special handling. Define the dispatch for these, but the handler
 # functions themselves are hand-written.
-my @special_types = ( 'hook_expiry_req_t' );
+my @special_types = ( 'struct hook_expiry_req' );
 
 # XXX: Duplication here with the typedefs in Atheme.xs.
 my %perl_api_types = (

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -91,7 +91,7 @@ my %hook_structs = (
 		u => [ 'struct user', 'user' ],
 		mn => [ 'struct mynick', 'nick' ],
 	},
-	hook_metadata_change_t => {
+	'struct hook_metadata_change' => {
 		target => 'struct myuser',
 		name => 'const char *',
 		value => 'char *',

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -100,7 +100,7 @@ my %hook_structs = (
 		mu => [ 'struct myuser', 'account' ],
 		oldname => 'const char *',
 	},
-	hook_server_delete_t => {
+	'struct hook_server_delete' => {
 		s => [ 'struct server', 'server' ],
 	},
 	hook_user_nick_t => {

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -47,7 +47,7 @@ my %hook_structs = (
 	'struct hook_channel_joinpart' => {
 		cu => [ 'struct chanuser', '+chanuser' ]
 	},
-	hook_cmessage_data_t => {
+	'struct hook_channel_message' => {
 		u => [ 'struct user', 'user' ],
 		c => [ 'struct channel', 'channel' ],
 		msg => [ 'char *', 'message' ],

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -11,7 +11,7 @@ my %arg_types;
 # XXX: Types we haven't exposed to perl yet. Remove these if they do become supported.
 # THIS LIST IS NOT A SUBSTITUTE FOR ACTUALLY DEFINING HOOK STRUCTURES. IT IS FOR STRUCTURES
 # WITH MEMBERS THAT WE CAN'T SUPPORT YET.
-my @unsupported_types = ( 'struct database_handle', 'sasl_message_t',
+my @unsupported_types = ( 'struct database_handle', 'struct sasl_message',
     'hook_module_load_t', 'hook_myentity_req_t', 'hook_host_request_t',
     'hook_channel_acl_req_t', 'hook_email_canonicalize_t', 'struct mygroup' );
 

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -13,7 +13,8 @@ my %arg_types;
 # WITH MEMBERS THAT WE CAN'T SUPPORT YET.
 my @unsupported_types = ( 'struct database_handle', 'struct sasl_message',
     'struct hook_module_load', 'struct hook_myentity_req', 'struct hook_host_request',
-    'struct hook_channel_acl_req', 'hook_email_canonicalize_t', 'struct mygroup' );
+    'struct hook_channel_acl_req', 'hook_email_canonicalize_t', 'struct mygroup',
+    'struct hook_user_login_check' );
 
 # Types that need special handling. Define the dispatch for these, but the handler
 # functions themselves are hand-written.

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -11,7 +11,7 @@ my %arg_types;
 # XXX: Types we haven't exposed to perl yet. Remove these if they do become supported.
 # THIS LIST IS NOT A SUBSTITUTE FOR ACTUALLY DEFINING HOOK STRUCTURES. IT IS FOR STRUCTURES
 # WITH MEMBERS THAT WE CAN'T SUPPORT YET.
-my @unsupported_types = ( 'database_handle_t', 'sasl_message_t',
+my @unsupported_types = ( 'struct database_handle', 'sasl_message_t',
     'hook_module_load_t', 'hook_myentity_req_t', 'hook_host_request_t',
     'hook_channel_acl_req_t', 'hook_email_canonicalize_t', 'mygroup_t' );
 

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -12,7 +12,6 @@ my %arg_types;
 # THIS LIST IS NOT A SUBSTITUTE FOR ACTUALLY DEFINING HOOK STRUCTURES. IT IS FOR STRUCTURES
 # WITH MEMBERS THAT WE CAN'T SUPPORT YET.
 my @unsupported_types = (
-	'hook_email_canonicalize_t',
 	'struct database_handle',
 	'struct hook_channel_acl_req',
 	'struct hook_host_request',

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -13,7 +13,7 @@ my %arg_types;
 # WITH MEMBERS THAT WE CAN'T SUPPORT YET.
 my @unsupported_types = ( 'struct database_handle', 'sasl_message_t',
     'hook_module_load_t', 'hook_myentity_req_t', 'hook_host_request_t',
-    'hook_channel_acl_req_t', 'hook_email_canonicalize_t', 'mygroup_t' );
+    'hook_channel_acl_req_t', 'hook_email_canonicalize_t', 'struct mygroup' );
 
 # Types that need special handling. Define the dispatch for these, but the handler
 # functions themselves are hand-written.

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -122,7 +122,7 @@ my %hook_structs = (
 		u => [ 'struct user', 'user' ],
 		comment => 'const char *',
 	},
-	hook_sasl_may_impersonate_t => {
+	'struct hook_sasl_may_impersonate' => {
 		source_mu => [ 'struct myuser', 'source' ],
 		target_mu => [ 'struct myuser', 'target' ],
 		allowed => [ 'int', '+allowed' ]

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -65,7 +65,7 @@ my %hook_structs = (
 		mc => [ 'struct mychan', 'channel' ],
 		si => [ 'struct sourceinfo', 'source' ],
 	},
-	hook_channel_succession_req_t => {
+	'struct hook_channel_succession_req' => {
 		mc => [ 'struct mychan', 'channel' ],
 		mu => [ 'struct myuser', '+account' ],
 	},

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -103,7 +103,7 @@ my %hook_structs = (
 	'struct hook_server_delete' => {
 		s => [ 'struct server', 'server' ],
 	},
-	hook_user_nick_t => {
+	'struct hook_user_nick' => {
 		u => [ 'struct user', '+user' ],
 		oldnick => 'const char *',
 	},

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -80,7 +80,7 @@ my %hook_structs = (
 		mu => [ 'struct myuser', 'account' ],
 		mn => [ 'struct mynick', 'nick' ],
 	},
-	hook_user_register_check_t => {
+	'struct hook_user_register_check' => {
 		si => [ 'struct sourceinfo', 'source' ],
 		account => 'const char *',
 		email => 'const char *',

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -55,112 +55,112 @@ my %perl_api_types = (
 my %hook_structs = (
 
 	'struct hook_channel_joinpart' => {
-		cu => [ 'struct chanuser', '+chanuser' ]
+		'cu'            => [ 'struct chanuser', '+chanuser' ],
 	},
 
 	'struct hook_channel_message' => {
-		u => [ 'struct user', 'user' ],
-		c => [ 'struct channel', 'channel' ],
-		msg => [ 'char *', 'message' ],
+		'u'             => [ 'struct user', 'user' ],
+		'c'             => [ 'struct channel', 'channel' ],
+		'msg'           => [ 'char *', 'message' ],
 	},
 
 	'struct hook_channel_mode' => {
-		u => [ 'struct user', 'user' ],
-		c => [ 'struct channel', 'channel' ],
+		'u'             => [ 'struct user', 'user' ],
+		'c'             => [ 'struct channel', 'channel' ],
 	},
 
 	'struct hook_channel_mode_change' => {
-		cu => [ 'struct chanuser', 'chanuser' ],
-		mchar => 'int',
-		mvalue => 'int',
+		'cu'            => [ 'struct chanuser', 'chanuser' ],
+		'mchar'         => 'int',
+		'mvalue'        => 'int',
 	},
 
 	'struct hook_channel_register_check' => {
-		si => [ 'struct sourceinfo', 'source' ],
-		name => 'const char *',
-		chan => [ 'struct channel', 'channel' ],
-		approved => [ 'int', '+approved' ],
+		'si'            => [ 'struct sourceinfo', 'source' ],
+		'name'          => 'const char *',
+		'chan'          => [ 'struct channel', 'channel' ],
+		'approved'      => [ 'int', '+approved' ],
 	},
 
 	'struct hook_channel_req' => {
-		mc => [ 'struct mychan', 'channel' ],
-		si => [ 'struct sourceinfo', 'source' ],
+		'mc'            => [ 'struct mychan', 'channel' ],
+		'si'            => [ 'struct sourceinfo', 'source' ],
 	},
 
 	'struct hook_channel_succession_req' => {
-		mc => [ 'struct mychan', 'channel' ],
-		mu => [ 'struct myuser', '+account' ],
+		'mc'            => [ 'struct mychan', 'channel' ],
+		'mu'            => [ 'struct myuser', '+account' ],
 	},
 
 	'struct hook_channel_topic_check' => {
-		u => [ 'struct user', 'user' ],
-		s => [ 'struct server', 'server' ],
-		c => [ 'struct channel', 'channel' ],
-		setter => 'char *',
-		ts => 'time_t',
-		topic => [ 'char *', 'topic' ],
-		approved => [ 'int', '+approved' ],
+		'u'             => [ 'struct user', 'user' ],
+		's'             => [ 'struct server', 'server' ],
+		'c'             => [ 'struct channel', 'channel' ],
+		'setter'        => 'char *',
+		'ts'            => 'time_t',
+		'topic'         => [ 'char *', 'topic' ],
+		'approved'      => [ 'int', '+approved' ],
 	},
 
 	'struct hook_info_noexist_req' => {
-		si => [ 'struct sourceinfo', 'source' ],
-		nick => 'const char *'
+		'si'            => [ 'struct sourceinfo', 'source' ],
+		'nick'          => 'const char *',
 	},
 
 	'struct hook_metadata_change' => {
-		target => 'struct myuser',
-		name => 'const char *',
-		value => 'char *',
+		'target'        => 'struct myuser',
+		'name'          => 'const char *',
+		'value'         => 'char *',
 	},
 
 	'struct hook_nick_enforce' => {
-		u => [ 'struct user', 'user' ],
-		mn => [ 'struct mynick', 'nick' ],
+		'u'             => [ 'struct user', 'user' ],
+		'mn'            => [ 'struct mynick', 'nick' ],
 	},
 
 	'struct hook_sasl_may_impersonate' => {
-		source_mu => [ 'struct myuser', 'source' ],
-		target_mu => [ 'struct myuser', 'target' ],
-		allowed => [ 'int', '+allowed' ]
+		'source_mu'     => [ 'struct myuser', 'source' ],
+		'target_mu'     => [ 'struct myuser', 'target' ],
+		'allowed'       => [ 'int', '+allowed' ],
 	},
 
 	'struct hook_server_delete' => {
-		s => [ 'struct server', 'server' ],
+		's'             => [ 'struct server', 'server' ],
 	},
 
 	'struct hook_user_delete_info' => {
-		u => [ 'struct user', 'user' ],
-		comment => 'const char *',
+		'u'             => [ 'struct user', 'user' ],
+		'comment'       => 'const char *',
 	},
 
 	'struct hook_user_needforce' => {
-		si => [ 'struct sourceinfo', 'source' ],
-		mu => [ 'struct myuser', 'account' ],
-		allowed => [ 'int', '+allowed' ]
+		'si'            => [ 'struct sourceinfo', 'source' ],
+		'mu'            => [ 'struct myuser', 'account' ],
+		'allowed'       => [ 'int', '+allowed' ],
 	},
 
 	'struct hook_user_nick' => {
-		u => [ 'struct user', '+user' ],
-		oldnick => 'const char *',
+		'u'             => [ 'struct user', '+user' ],
+		'oldnick'       => 'const char *',
 	},
 
 	'struct hook_user_register_check' => {
-		si => [ 'struct sourceinfo', 'source' ],
-		account => 'const char *',
-		email => 'const char *',
-		password => 'const char *',
-		approved => [ 'int', '+approved' ]
+		'si'            => [ 'struct sourceinfo', 'source' ],
+		'account'       => 'const char *',
+		'email'         => 'const char *',
+		'password'      => 'const char *',
+		'approved'      => [ 'int', '+approved' ],
 	},
 
 	'struct hook_user_rename' => {
-		mu => [ 'struct myuser', 'account' ],
-		oldname => 'const char *',
+		'mu'            => [ 'struct myuser', 'account' ],
+		'oldname'       => 'const char *',
 	},
 
 	'struct hook_user_req' => {
-		si => [ 'struct sourceinfo', 'source' ],
-		mu => [ 'struct myuser', 'account' ],
-		mn => [ 'struct mynick', 'nick' ],
+		'si'            => [ 'struct sourceinfo', 'source' ],
+		'mu'            => [ 'struct myuser', 'account' ],
+		'mn'            => [ 'struct mynick', 'nick' ],
 	},
 );
 

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -25,8 +25,8 @@ my %perl_api_types = (
 	user_t => 'Atheme::User',
 	'struct channel' => 'Atheme::Channel',
 	'struct chanuser' => 'Atheme::ChanUser',
-	server_t => 'Atheme::Server',
-	service_t => 'Atheme::Service',
+	'struct server' => 'Atheme::Server',
+	'struct service' => 'Atheme::Service',
 	'struct myuser' => 'Atheme::Account',
 	'struct mynick' => 'Atheme::NickRegistration',
 	'struct mychan' => 'Atheme::ChannelRegistration',
@@ -54,7 +54,7 @@ my %hook_structs = (
 	},
 	hook_channel_topic_check_t => {
 		u => [ 'user_t', 'user' ],
-		s => [ 'server_t', 'server' ],
+		s => [ 'struct server', 'server' ],
 		c => [ 'struct channel', 'channel' ],
 		setter => 'char *',
 		ts => 'time_t',
@@ -101,7 +101,7 @@ my %hook_structs = (
 		oldname => 'const char *',
 	},
 	hook_server_delete_t => {
-		s => [ 'server_t', 'server' ],
+		s => [ 'struct server', 'server' ],
 	},
 	hook_user_nick_t => {
 		u => [ 'user_t', '+user' ],

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -29,7 +29,7 @@ my %perl_api_types = (
 	service_t => 'Atheme::Service',
 	myuser_t => 'Atheme::Account',
 	mynick_t => 'Atheme::NickRegistration',
-	mychan_t => 'Atheme::ChannelRegistration',
+	'struct mychan' => 'Atheme::ChannelRegistration',
 	'struct chanacs' => 'Atheme::ChanAcs',
 
 	'char *' => [ sub { "sv_setpv($_[0], $_[1]);" }, sub { die "Don't know how to unmarshal a read-write string"; } ],
@@ -62,11 +62,11 @@ my %hook_structs = (
 		approved => [ 'int', '+approved' ],
 	},
 	hook_channel_req_t => {
-		mc => [ 'mychan_t', 'channel' ],
+		mc => [ 'struct mychan', 'channel' ],
 		si => [ 'sourceinfo_t', 'source' ],
 	},
 	hook_channel_succession_req_t => {
-		mc => [ 'mychan_t', 'channel' ],
+		mc => [ 'struct mychan', 'channel' ],
 		mu => [ 'myuser_t', '+account' ],
 	},
 	hook_channel_register_check_t => {

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -107,7 +107,7 @@ my %hook_structs = (
 		u => [ 'struct user', '+user' ],
 		oldnick => 'const char *',
 	},
-	hook_channel_mode_t => {
+	'struct hook_channel_mode' => {
 		u => [ 'struct user', 'user' ],
 		c => [ 'struct channel', 'channel' ],
 	},

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -12,7 +12,7 @@ my %arg_types;
 # THIS LIST IS NOT A SUBSTITUTE FOR ACTUALLY DEFINING HOOK STRUCTURES. IT IS FOR STRUCTURES
 # WITH MEMBERS THAT WE CAN'T SUPPORT YET.
 my @unsupported_types = ( 'struct database_handle', 'struct sasl_message',
-    'hook_module_load_t', 'hook_myentity_req_t', 'hook_host_request_t',
+    'hook_module_load_t', 'hook_myentity_req_t', 'struct hook_host_request',
     'struct hook_channel_acl_req', 'hook_email_canonicalize_t', 'struct mygroup' );
 
 # Types that need special handling. Define the dispatch for these, but the handler

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -98,7 +98,7 @@ my %hook_structs = (
 		name => 'const char *',
 		value => 'char *',
 	},
-	hook_user_rename_t => {
+	'struct hook_user_rename' => {
 		mu => [ 'struct myuser', 'account' ],
 		oldname => 'const char *',
 	},

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -30,7 +30,7 @@ my %perl_api_types = (
 	myuser_t => 'Atheme::Account',
 	mynick_t => 'Atheme::NickRegistration',
 	mychan_t => 'Atheme::ChannelRegistration',
-	chanacs_t => 'Atheme::ChanAcs',
+	'struct chanacs' => 'Atheme::ChanAcs',
 
 	'char *' => [ sub { "sv_setpv($_[0], $_[1]);" }, sub { die "Don't know how to unmarshal a read-write string"; } ],
 	'const char *' => [ sub { "sv_setpv($_[0], $_[1]);" }, sub { die "Don't know how to unmarshal a read-write string"; } ],

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -21,7 +21,7 @@ my @special_types = ( 'hook_expiry_req_t' );
 
 # XXX: Duplication here with the typedefs in Atheme.xs.
 my %perl_api_types = (
-	sourceinfo_t => 'Atheme::Sourceinfo',
+	'struct sourceinfo' => 'Atheme::Sourceinfo',
 	user_t => 'Atheme::User',
 	'struct channel' => 'Atheme::Channel',
 	'struct chanuser' => 'Atheme::ChanUser',
@@ -63,25 +63,25 @@ my %hook_structs = (
 	},
 	hook_channel_req_t => {
 		mc => [ 'struct mychan', 'channel' ],
-		si => [ 'sourceinfo_t', 'source' ],
+		si => [ 'struct sourceinfo', 'source' ],
 	},
 	hook_channel_succession_req_t => {
 		mc => [ 'struct mychan', 'channel' ],
 		mu => [ 'struct myuser', '+account' ],
 	},
 	hook_channel_register_check_t => {
-		si => [ 'sourceinfo_t', 'source' ],
+		si => [ 'struct sourceinfo', 'source' ],
 		name => 'const char *',
 		chan => [ 'struct channel', 'channel' ],
 		approved => [ 'int', '+approved' ],
 	},
 	hook_user_req_t => {
-		si => [ 'sourceinfo_t', 'source' ],
+		si => [ 'struct sourceinfo', 'source' ],
 		mu => [ 'struct myuser', 'account' ],
 		mn => [ 'struct mynick', 'nick' ],
 	},
 	hook_user_register_check_t => {
-		si => [ 'sourceinfo_t', 'source' ],
+		si => [ 'struct sourceinfo', 'source' ],
 		account => 'const char *',
 		email => 'const char *',
 		password => 'const char *',
@@ -126,11 +126,11 @@ my %hook_structs = (
 		allowed => [ 'int', '+allowed' ]
 	},
 	hook_info_noexist_req_t => {
-		si => [ 'sourceinfo_t', 'source' ],
+		si => [ 'struct sourceinfo', 'source' ],
 		nick => 'const char *'
 	},
 	hook_user_needforce_t => {
-		si => [ 'sourceinfo_t', 'source' ],
+		si => [ 'struct sourceinfo', 'source' ],
 		mu => [ 'struct myuser', 'account' ],
 		allowed => [ 'int', '+allowed' ]
 	},

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -127,7 +127,7 @@ my %hook_structs = (
 		target_mu => [ 'struct myuser', 'target' ],
 		allowed => [ 'int', '+allowed' ]
 	},
-	hook_info_noexist_req_t => {
+	'struct hook_info_noexist_req' => {
 		si => [ 'struct sourceinfo', 'source' ],
 		nick => 'const char *'
 	},

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -116,7 +116,7 @@ my %hook_structs = (
 		mchar => 'int',
 		mvalue => 'int',
 	},
-	hook_user_delete_t => {
+	'struct hook_user_delete_info' => {
 		u => [ 'struct user', 'user' ],
 		comment => 'const char *',
 	},

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -61,7 +61,7 @@ my %hook_structs = (
 		topic => [ 'char *', 'topic' ],
 		approved => [ 'int', '+approved' ],
 	},
-	hook_channel_req_t => {
+	'struct hook_channel_req' => {
 		mc => [ 'struct mychan', 'channel' ],
 		si => [ 'struct sourceinfo', 'source' ],
 	},

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -96,9 +96,9 @@ my %hook_structs = (
 		'u'             => [ 'struct user', 'user' ],
 		's'             => [ 'struct server', 'server' ],
 		'c'             => [ 'struct channel', 'channel' ],
-		'setter'        => 'char *',
+		'setter'        => 'const char *',
 		'ts'            => 'time_t',
-		'topic'         => [ 'char *', 'topic' ],
+		'topic'         => [ 'const char *', 'topic' ],
 		'approved'      => [ 'int', '+approved' ],
 	},
 

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -52,7 +52,7 @@ my %hook_structs = (
 		c => [ 'struct channel', 'channel' ],
 		msg => [ 'char *', 'message' ],
 	},
-	hook_channel_topic_check_t => {
+	'struct hook_channel_topic_check' => {
 		u => [ 'struct user', 'user' ],
 		s => [ 'struct server', 'server' ],
 		c => [ 'struct channel', 'channel' ],

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -87,7 +87,7 @@ my %hook_structs = (
 		password => 'const char *',
 		approved => [ 'int', '+approved' ]
 	},
-	hook_nick_enforce_t => {
+	'struct hook_nick_enforce' => {
 		u => [ 'struct user', 'user' ],
 		mn => [ 'struct mynick', 'nick' ],
 	},

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -12,7 +12,7 @@ my %arg_types;
 # THIS LIST IS NOT A SUBSTITUTE FOR ACTUALLY DEFINING HOOK STRUCTURES. IT IS FOR STRUCTURES
 # WITH MEMBERS THAT WE CAN'T SUPPORT YET.
 my @unsupported_types = ( 'struct database_handle', 'struct sasl_message',
-    'struct hook_module_load', 'hook_myentity_req_t', 'struct hook_host_request',
+    'struct hook_module_load', 'struct hook_myentity_req', 'struct hook_host_request',
     'struct hook_channel_acl_req', 'hook_email_canonicalize_t', 'struct mygroup' );
 
 # Types that need special handling. Define the dispatch for these, but the handler

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -12,7 +12,7 @@ my %arg_types;
 # THIS LIST IS NOT A SUBSTITUTE FOR ACTUALLY DEFINING HOOK STRUCTURES. IT IS FOR STRUCTURES
 # WITH MEMBERS THAT WE CAN'T SUPPORT YET.
 my @unsupported_types = ( 'struct database_handle', 'struct sasl_message',
-    'hook_module_load_t', 'hook_myentity_req_t', 'struct hook_host_request',
+    'struct hook_module_load', 'hook_myentity_req_t', 'struct hook_host_request',
     'struct hook_channel_acl_req', 'hook_email_canonicalize_t', 'struct mygroup' );
 
 # Types that need special handling. Define the dispatch for these, but the handler

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -28,7 +28,7 @@ my %perl_api_types = (
 	server_t => 'Atheme::Server',
 	service_t => 'Atheme::Service',
 	myuser_t => 'Atheme::Account',
-	mynick_t => 'Atheme::NickRegistration',
+	'struct mynick' => 'Atheme::NickRegistration',
 	'struct mychan' => 'Atheme::ChannelRegistration',
 	'struct chanacs' => 'Atheme::ChanAcs',
 
@@ -78,7 +78,7 @@ my %hook_structs = (
 	hook_user_req_t => {
 		si => [ 'sourceinfo_t', 'source' ],
 		mu => [ 'myuser_t', 'account' ],
-		mn => [ 'mynick_t', 'nick' ],
+		mn => [ 'struct mynick', 'nick' ],
 	},
 	hook_user_register_check_t => {
 		si => [ 'sourceinfo_t', 'source' ],
@@ -89,7 +89,7 @@ my %hook_structs = (
 	},
 	hook_nick_enforce_t => {
 		u => [ 'user_t', 'user' ],
-		mn => [ 'mynick_t', 'nick' ],
+		mn => [ 'struct mynick', 'nick' ],
 	},
 	hook_metadata_change_t => {
 		target => 'myuser_t',

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -44,7 +44,7 @@ my %perl_api_types = (
 # or an arrayref of [type, name], if the name on the perl side is to be different from the
 # member name in the structure. Prefix name with '+' if this value may be modified by the hook.
 my %hook_structs = (
-	hook_channel_joinpart_t => {
+	'struct hook_channel_joinpart' => {
 		cu => [ 'struct chanuser', '+chanuser' ]
 	},
 	hook_cmessage_data_t => {

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -69,7 +69,7 @@ my %hook_structs = (
 		mc => [ 'struct mychan', 'channel' ],
 		mu => [ 'struct myuser', '+account' ],
 	},
-	hook_channel_register_check_t => {
+	'struct hook_channel_register_check' => {
 		si => [ 'struct sourceinfo', 'source' ],
 		name => 'const char *',
 		chan => [ 'struct channel', 'channel' ],

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -14,7 +14,7 @@ my %arg_types;
 my @unsupported_types = ( 'struct database_handle', 'struct sasl_message',
     'struct hook_module_load', 'struct hook_myentity_req', 'struct hook_host_request',
     'struct hook_channel_acl_req', 'hook_email_canonicalize_t', 'struct mygroup',
-    'struct hook_user_login_check' );
+    'struct hook_user_login_check', 'struct hook_user_logout_check' );
 
 # Types that need special handling. Define the dispatch for these, but the handler
 # functions themselves are hand-written.

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -24,7 +24,7 @@ my %perl_api_types = (
 	sourceinfo_t => 'Atheme::Sourceinfo',
 	user_t => 'Atheme::User',
 	'struct channel' => 'Atheme::Channel',
-	chanuser_t => 'Atheme::ChanUser',
+	'struct chanuser' => 'Atheme::ChanUser',
 	server_t => 'Atheme::Server',
 	service_t => 'Atheme::Service',
 	myuser_t => 'Atheme::Account',
@@ -45,7 +45,7 @@ my %perl_api_types = (
 # member name in the structure. Prefix name with '+' if this value may be modified by the hook.
 my %hook_structs = (
 	hook_channel_joinpart_t => {
-		cu => [ 'chanuser_t', '+chanuser' ]
+		cu => [ 'struct chanuser', '+chanuser' ]
 	},
 	hook_cmessage_data_t => {
 		u => [ 'user_t', 'user' ],
@@ -112,7 +112,7 @@ my %hook_structs = (
 		c => [ 'struct channel', 'channel' ],
 	},
 	hook_channel_mode_change_t => {
-		cu => [ 'chanuser_t', 'chanuser' ],
+		cu => [ 'struct chanuser', 'chanuser' ],
 		mchar => 'int',
 		mvalue => 'int',
 	},

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -27,7 +27,7 @@ my %perl_api_types = (
 	'struct chanuser' => 'Atheme::ChanUser',
 	server_t => 'Atheme::Server',
 	service_t => 'Atheme::Service',
-	myuser_t => 'Atheme::Account',
+	'struct myuser' => 'Atheme::Account',
 	'struct mynick' => 'Atheme::NickRegistration',
 	'struct mychan' => 'Atheme::ChannelRegistration',
 	'struct chanacs' => 'Atheme::ChanAcs',
@@ -67,7 +67,7 @@ my %hook_structs = (
 	},
 	hook_channel_succession_req_t => {
 		mc => [ 'struct mychan', 'channel' ],
-		mu => [ 'myuser_t', '+account' ],
+		mu => [ 'struct myuser', '+account' ],
 	},
 	hook_channel_register_check_t => {
 		si => [ 'sourceinfo_t', 'source' ],
@@ -77,7 +77,7 @@ my %hook_structs = (
 	},
 	hook_user_req_t => {
 		si => [ 'sourceinfo_t', 'source' ],
-		mu => [ 'myuser_t', 'account' ],
+		mu => [ 'struct myuser', 'account' ],
 		mn => [ 'struct mynick', 'nick' ],
 	},
 	hook_user_register_check_t => {
@@ -92,12 +92,12 @@ my %hook_structs = (
 		mn => [ 'struct mynick', 'nick' ],
 	},
 	hook_metadata_change_t => {
-		target => 'myuser_t',
+		target => 'struct myuser',
 		name => 'const char *',
 		value => 'char *',
 	},
 	hook_user_rename_t => {
-		mu => [ 'myuser_t', 'account' ],
+		mu => [ 'struct myuser', 'account' ],
 		oldname => 'const char *',
 	},
 	hook_server_delete_t => {
@@ -121,8 +121,8 @@ my %hook_structs = (
 		comment => 'const char *',
 	},
 	hook_sasl_may_impersonate_t => {
-		source_mu => [ 'myuser_t', 'source' ],
-		target_mu => [ 'myuser_t', 'target' ],
+		source_mu => [ 'struct myuser', 'source' ],
+		target_mu => [ 'struct myuser', 'target' ],
 		allowed => [ 'int', '+allowed' ]
 	},
 	hook_info_noexist_req_t => {
@@ -131,7 +131,7 @@ my %hook_structs = (
 	},
 	hook_user_needforce_t => {
 		si => [ 'sourceinfo_t', 'source' ],
-		mu => [ 'myuser_t', 'account' ],
+		mu => [ 'struct myuser', 'account' ],
 		allowed => [ 'int', '+allowed' ]
 	},
 );

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -14,7 +14,8 @@ my %arg_types;
 my @unsupported_types = ( 'struct database_handle', 'struct sasl_message',
     'struct hook_module_load', 'struct hook_myentity_req', 'struct hook_host_request',
     'struct hook_channel_acl_req', 'hook_email_canonicalize_t', 'struct mygroup',
-    'struct hook_user_login_check', 'struct hook_user_logout_check' );
+    'struct hook_user_login_check', 'struct hook_user_logout_check',
+    'struct hook_user_rename_check' );
 
 # Types that need special handling. Define the dispatch for these, but the handler
 # functions themselves are hand-written.

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -111,7 +111,7 @@ my %hook_structs = (
 		u => [ 'struct user', 'user' ],
 		c => [ 'struct channel', 'channel' ],
 	},
-	hook_channel_mode_change_t => {
+	'struct hook_channel_mode_change' => {
 		cu => [ 'struct chanuser', 'chanuser' ],
 		mchar => 'int',
 		mvalue => 'int',

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -13,7 +13,7 @@ my %arg_types;
 # WITH MEMBERS THAT WE CAN'T SUPPORT YET.
 my @unsupported_types = ( 'struct database_handle', 'struct sasl_message',
     'hook_module_load_t', 'hook_myentity_req_t', 'hook_host_request_t',
-    'hook_channel_acl_req_t', 'hook_email_canonicalize_t', 'struct mygroup' );
+    'struct hook_channel_acl_req', 'hook_email_canonicalize_t', 'struct mygroup' );
 
 # Types that need special handling. Define the dispatch for these, but the handler
 # functions themselves are hand-written.

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -22,7 +22,7 @@ my @special_types = ( 'hook_expiry_req_t' );
 # XXX: Duplication here with the typedefs in Atheme.xs.
 my %perl_api_types = (
 	'struct sourceinfo' => 'Atheme::Sourceinfo',
-	user_t => 'Atheme::User',
+	'struct user' => 'Atheme::User',
 	'struct channel' => 'Atheme::Channel',
 	'struct chanuser' => 'Atheme::ChanUser',
 	'struct server' => 'Atheme::Server',
@@ -48,12 +48,12 @@ my %hook_structs = (
 		cu => [ 'struct chanuser', '+chanuser' ]
 	},
 	hook_cmessage_data_t => {
-		u => [ 'user_t', 'user' ],
+		u => [ 'struct user', 'user' ],
 		c => [ 'struct channel', 'channel' ],
 		msg => [ 'char *', 'message' ],
 	},
 	hook_channel_topic_check_t => {
-		u => [ 'user_t', 'user' ],
+		u => [ 'struct user', 'user' ],
 		s => [ 'struct server', 'server' ],
 		c => [ 'struct channel', 'channel' ],
 		setter => 'char *',
@@ -88,7 +88,7 @@ my %hook_structs = (
 		approved => [ 'int', '+approved' ]
 	},
 	hook_nick_enforce_t => {
-		u => [ 'user_t', 'user' ],
+		u => [ 'struct user', 'user' ],
 		mn => [ 'struct mynick', 'nick' ],
 	},
 	hook_metadata_change_t => {
@@ -104,11 +104,11 @@ my %hook_structs = (
 		s => [ 'struct server', 'server' ],
 	},
 	hook_user_nick_t => {
-		u => [ 'user_t', '+user' ],
+		u => [ 'struct user', '+user' ],
 		oldnick => 'const char *',
 	},
 	hook_channel_mode_t => {
-		u => [ 'user_t', 'user' ],
+		u => [ 'struct user', 'user' ],
 		c => [ 'struct channel', 'channel' ],
 	},
 	hook_channel_mode_change_t => {
@@ -117,7 +117,7 @@ my %hook_structs = (
 		mvalue => 'int',
 	},
 	hook_user_delete_t => {
-		u => [ 'user_t', 'user' ],
+		u => [ 'struct user', 'user' ],
 		comment => 'const char *',
 	},
 	hook_sasl_may_impersonate_t => {

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -23,7 +23,7 @@ my @special_types = ( 'hook_expiry_req_t' );
 my %perl_api_types = (
 	sourceinfo_t => 'Atheme::Sourceinfo',
 	user_t => 'Atheme::User',
-	channel_t => 'Atheme::Channel',
+	'struct channel' => 'Atheme::Channel',
 	chanuser_t => 'Atheme::ChanUser',
 	server_t => 'Atheme::Server',
 	service_t => 'Atheme::Service',
@@ -49,13 +49,13 @@ my %hook_structs = (
 	},
 	hook_cmessage_data_t => {
 		u => [ 'user_t', 'user' ],
-		c => [ 'channel_t', 'channel' ],
+		c => [ 'struct channel', 'channel' ],
 		msg => [ 'char *', 'message' ],
 	},
 	hook_channel_topic_check_t => {
 		u => [ 'user_t', 'user' ],
 		s => [ 'server_t', 'server' ],
-		c => [ 'channel_t', 'channel' ],
+		c => [ 'struct channel', 'channel' ],
 		setter => 'char *',
 		ts => 'time_t',
 		topic => [ 'char *', 'topic' ],
@@ -72,7 +72,7 @@ my %hook_structs = (
 	hook_channel_register_check_t => {
 		si => [ 'sourceinfo_t', 'source' ],
 		name => 'const char *',
-		chan => [ 'channel_t', 'channel' ],
+		chan => [ 'struct channel', 'channel' ],
 		approved => [ 'int', '+approved' ],
 	},
 	hook_user_req_t => {
@@ -109,7 +109,7 @@ my %hook_structs = (
 	},
 	hook_channel_mode_t => {
 		u => [ 'user_t', 'user' ],
-		c => [ 'channel_t', 'channel' ],
+		c => [ 'struct channel', 'channel' ],
 	},
 	hook_channel_mode_change_t => {
 		cu => [ 'chanuser_t', 'chanuser' ],

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -131,7 +131,7 @@ my %hook_structs = (
 		si => [ 'struct sourceinfo', 'source' ],
 		nick => 'const char *'
 	},
-	hook_user_needforce_t => {
+	'struct hook_user_needforce' => {
 		si => [ 'struct sourceinfo', 'source' ],
 		mu => [ 'struct myuser', 'account' ],
 		allowed => [ 'int', '+allowed' ]

--- a/modules/scripting/perl/api/make_perl_hooks.pl
+++ b/modules/scripting/perl/api/make_perl_hooks.pl
@@ -75,7 +75,7 @@ my %hook_structs = (
 		chan => [ 'struct channel', 'channel' ],
 		approved => [ 'int', '+approved' ],
 	},
-	hook_user_req_t => {
+	'struct hook_user_req' => {
 		si => [ 'struct sourceinfo', 'source' ],
 		mu => [ 'struct myuser', 'account' ],
 		mn => [ 'struct mynick', 'nick' ],

--- a/modules/scripting/perl/api/perl_hooks_extra.h
+++ b/modules/scripting/perl/api/perl_hooks_extra.h
@@ -24,7 +24,7 @@ static void perl_hook_marshal_void(perl_hook_marshal_direction_t dir, void * dat
  * used (and hence the package to which to bless it) dependent on the hook that's
  * being called.
  */
-static void perl_hook_marshal_hook_expiry_req_t(perl_hook_marshal_direction_t dir, hook_expiry_req_t * data, SV **psv,
+static void perl_hook_marshal_struct_hook_expiry_req(perl_hook_marshal_direction_t dir, struct hook_expiry_req * data, SV **psv,
 		const char * argname, const char * packagename)
 {
 	if (dir == PERL_HOOK_TO_PERL)
@@ -54,10 +54,10 @@ static void perl_hook_marshal_hook_expiry_req_t(perl_hook_marshal_direction_t di
  * structure but need to populate it in different ways.
  */
 
-static void perl_hook_expiry_check(hook_expiry_req_t * data, const char *hookname, const char *packagename, const char * argname)
+static void perl_hook_expiry_check(struct hook_expiry_req * data, const char *hookname, const char *packagename, const char * argname)
 {
 	SV *arg;
-	perl_hook_marshal_hook_expiry_req_t(PERL_HOOK_TO_PERL, data, &arg, packagename, argname);
+	perl_hook_marshal_struct_hook_expiry_req(PERL_HOOK_TO_PERL, data, &arg, packagename, argname);
 
 	dSP;
 	ENTER;
@@ -73,24 +73,24 @@ static void perl_hook_expiry_check(hook_expiry_req_t * data, const char *hooknam
 	FREETMPS;
 	LEAVE;
 
-	perl_hook_marshal_hook_expiry_req_t(PERL_HOOK_FROM_PERL, data, &arg, NULL, NULL);
+	perl_hook_marshal_struct_hook_expiry_req(PERL_HOOK_FROM_PERL, data, &arg, NULL, NULL);
 	SvREFCNT_dec(arg);
 	invalidate_object_references();
 }
 
 
 
-static void perl_hook_user_check_expire(hook_expiry_req_t * data)
+static void perl_hook_user_check_expire(struct hook_expiry_req * data)
 {
 	perl_hook_expiry_check(data, "user_check_expire", "Atheme::Account", "account");
 }
 
-static void perl_hook_nick_check_expire(hook_expiry_req_t * data)
+static void perl_hook_nick_check_expire(struct hook_expiry_req * data)
 {
 	perl_hook_expiry_check(data, "nick_check_expire", "Atheme::NickRegistration", "nick");
 }
 
-static void perl_hook_channel_check_expire(hook_expiry_req_t * data)
+static void perl_hook_channel_check_expire(struct hook_expiry_req * data)
 {
 	perl_hook_expiry_check(data, "channel_check_expire", "Atheme::ChannelRegistration", "channel");
 }

--- a/modules/scripting/perl/perl_module.c
+++ b/modules/scripting/perl/perl_module.c
@@ -319,7 +319,7 @@ do_script_list(struct sourceinfo *si)
 
 // Connect all of the above to OperServ.
 static void
-hook_module_load(hook_module_load_t *data)
+hook_module_load(struct hook_module_load *data)
 {
 	struct stat s;
 	char buf[BUFSIZE];

--- a/modules/statserv/netsplit.c
+++ b/modules/statserv/netsplit.c
@@ -40,7 +40,7 @@ netsplit_server_add(struct server *const restrict s)
 }
 
 static void
-netsplit_server_delete(hook_server_delete_t *const restrict serv)
+netsplit_server_delete(struct hook_server_delete *const restrict serv)
 {
 	struct netsplit *const s = mowgli_heap_alloc(split_heap);
 


### PR DESCRIPTION
Types with names ending in `_t` are reserved and should not be defined by applications.

This also moves all data structures passed to hook functions to one place, `include/atheme/hook.h`, and they are now sorted alphabetically, like in `include/atheme/hooktypes.in`. This makes finding/adding/deleting/modifying hooks easier.

Finally, a few confusing or inconsistent hook data structures were renamed. The hooks themselves were not renamed, but this may still affect some out-of-tree modules. The most obvious one is `hook_cmessage_data_t` -> `struct hook_channel_message`.