### PR TITLE
libathemecore: handle CTCPs case-insensitively

### DIFF
--- a/libathemecore/ctcp-common.c
+++ b/libathemecore/ctcp-common.c
@@ -67,7 +67,7 @@ ctcp_about_handler(struct sourceinfo *si, char *cmd, char *args)
 void
 common_ctcp_init(void)
 {
-	ctcptree = mowgli_patricia_create(irccasecanon	);
+	ctcptree = mowgli_patricia_create(irccasecanon);
 
 	mowgli_patricia_add(ctcptree, "\001PING", ctcp_ping_handler);
 	mowgli_patricia_add(ctcptree, "\001VERSION\001", ctcp_version_handler);

--- a/libathemecore/ctcp-common.c
+++ b/libathemecore/ctcp-common.c
@@ -67,7 +67,7 @@ ctcp_about_handler(struct sourceinfo *si, char *cmd, char *args)
 void
 common_ctcp_init(void)
 {
-	ctcptree = mowgli_patricia_create(noopcanon);
+	ctcptree = mowgli_patricia_create(irccasecanon	);
 
 	mowgli_patricia_add(ctcptree, "\001PING", ctcp_ping_handler);
 	mowgli_patricia_add(ctcptree, "\001VERSION\001", ctcp_version_handler);


### PR DESCRIPTION
Switch CTCP handling to case-insensitive to match modern IRC docs