### PR TITLE
nickserv: Prefer advertising two-argument IDENTIFY

### DIFF
--- a/help/default/nickserv/identify
+++ b/help/default/nickserv/identify
@@ -4,13 +4,12 @@ IDENTIFY identifies you with services so that you
 can perform general maintenance and commands that
 require you to be logged in.
 
-Syntax: IDENTIFY <password>
-
-You can also identify for another nick than you
-are currently using.
-
 Syntax: IDENTIFY <nick> <password>
 
-Examples:
-    /msg &nick& IDENTIFY foo
+You can also omit <nick> to identify to the nick
+you are currently using.
+
+Syntax: IDENTIFY <password>
+
+Example:
     /msg &nick& IDENTIFY jilles foo

--- a/modules/nickserv/main.c
+++ b/modules/nickserv/main.c
@@ -72,13 +72,14 @@ nickserv_handle_nickchange(struct user *u)
 	// OpenServices: is user on access list? -nenolod
 	if (myuser_access_verify(u, mn->owner))
 	{
-		notice(nicksvs.nick, u->nick, "Please identify via \2/msg %s IDENTIFY <password>\2",
-		                              nicksvs.me->disp);
+		notice(nicksvs.nick, u->nick, "Please identify via \2/msg %s IDENTIFY %s <password>\2",
+		                              nicksvs.me->disp, entity(mn->owner)->name);
 		return;
 	}
 
 	notice(nicksvs.nick, u->nick, "This nickname is registered. Please choose a different nickname, or "
-	                              "identify via \2/msg %s IDENTIFY <password>\2", nicksvs.me->disp);
+	                              "identify via \2/msg %s IDENTIFY %s <password>\2",
+	                              nicksvs.me->disp, entity(mn->owner)->name);
 
 	hdata.u = u;
 	hdata.mn = mn;


### PR DESCRIPTION
Many users are only ever exposed to the one-argument variant, and require human assistance to get out of situations that could have been resolved easily. For example, a user matching a `+q $~a` may find themselves stuck on an alternate nick.

Attempt to mitigate this problem by making two-argument IDENTIFY more prominent in help and nags.