### PR TITLE
Do not prevent users from using regain while +b/+q

### DIFF
--- a/modules/nickserv/enforce.c
+++ b/modules/nickserv/enforce.c
@@ -445,13 +445,6 @@ ns_cmd_regain(struct sourceinfo *si, int parc, char *parv[])
 	}
 	if ((si->smu == mn->owner) || verify_password(mn->owner, password))
 	{
-		struct chanuser *cu = NULL;
-		if (si->su != NULL && ((cu = find_user_banned_channel(si->su, 'b')) || (cu = find_user_banned_channel(si->su, 'q'))))
-		{
-			command_fail(si, fault_noprivs, _("You can not regain your nickname while banned or quieted on a channel: \2%s\2"), cu->chan->name);
-			return;
-		}
-
 		if (qline_find_match(target) && !has_priv(si, PRIV_MASS_AKILL))
 		{
 			command_fail(si, fault_noprivs, _("You can not regain a reserved nickname."));


### PR DESCRIPTION
+q in particular is often used to cast a wide net, with masks like +q
$~a, which causes normal users to be unable to use regain without
parting as many as tens of channels first. The prohibition was never
useful in the first place and is causing problems now, so it's gotta go.