### PR TITLE
refuse to answer remote WHOIS for users not on our server

### DIFF
--- a/libathemecore/ptasks.c
+++ b/libathemecore/ptasks.c
@@ -351,7 +351,7 @@ handle_whois(struct user *u, const char *target)
 	if (floodcheck(u, NULL))
 		return;
 
-	if (t != NULL)
+	if (t != NULL && t->server == me.me)
 	{
 		numeric_sts(me.me, 311, u, "%s %s %s * :%s", t->nick, t->user, t->vhost, t->gecos);
 		/* channels purposely omitted */


### PR DESCRIPTION
I have a strong feeling this isn't going to be an acceptable solution to #728 but I can't actually think of a good reason for Atheme to tolerate remote whoises for remote users