### PR TITLE
add config option to hide oper status in remote whois (hide_opers)

### DIFF
--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -2697,6 +2697,12 @@ general {
 	 * can fix your configuration file.
 	 */
 	load_database_mdeps;
+
+	/* hide_opers
+	 *
+	 * whether or not to hide oper status in remote whois
+	 */
+	#hide_opers;
 };
 
 proxyscan {

--- a/include/atheme/global.h
+++ b/include/atheme/global.h
@@ -96,6 +96,7 @@ struct ConfOption
 	unsigned int    immune_level;           // what flag is required for kick immunity
 	bool            show_entity_id;         // do not require user:auspex to see entity IDs
 	bool            load_database_mdeps;    // for core module deps listed in DB, whether to load them or abort
+	bool            hide_opers;             // whether or not to hide RPL_WHOISOPERATOR from remote whois
 };
 
 extern struct ConfOption config_options;

--- a/libathemecore/conf.c
+++ b/libathemecore/conf.c
@@ -141,6 +141,9 @@ get_conf_opts(void)
 	optstr[optidx++] = 'M';
 #endif /* ATHEME_ENABLE_SODIUM_MALLOC */
 
+	if (config_options.hide_opers)
+		optstr[optidx++] = 'O';
+
 	if (! match_mapping)
 		optstr[optidx++] = 'R';
 
@@ -294,6 +297,7 @@ init_newconf(void)
 	add_duration_conf_item("COMMIT_INTERVAL", &conf_gi_table, 0, &config_options.commit_interval, "m", 300);
 	add_dupstr_conf_item("OPERSTRING", &conf_gi_table, 0, &config_options.operstring, "is an IRC Operator");
 	add_dupstr_conf_item("SERVICESTRING", &conf_gi_table, 0, &config_options.servicestring, "is a Network Service");
+	add_bool_conf_item("HIDE_OPERS", &conf_gi_table, 0, &config_options.hide_opers, false);
 
 	/* XXX: These options should probably move into operserv/clones eventually */
 	add_uint_conf_item("DEFAULT_CLONE_WARN", &conf_gi_table, 0, &config_options.default_clone_warn, 1, INT_MAX, 5);

--- a/libathemecore/ptasks.c
+++ b/libathemecore/ptasks.c
@@ -360,7 +360,7 @@ handle_whois(struct user *u, const char *target)
 			numeric_sts(me.me, 301, u, "%s :Gone", t->nick);
 		if (is_service(t))
 			numeric_sts(me.me, 313, u, "%s :%s", t->nick, config_options.servicestring);
-		else if (is_ircop(t))
+		else if (is_ircop(t) && !config_options.hide_opers)
 			numeric_sts(me.me, 313, u, "%s :%s", t->nick, config_options.operstring);
 		if (t->myuser && !(t->myuser->flags & MU_WAITAUTH))
 			numeric_sts(me.me, 330, u, "%s %s :is logged in as", t->nick, entity(t->myuser)->name);


### PR DESCRIPTION
as per #728 and the decision made in #730 