### PR TITLE
bad_password: provide hook for login failures

### DIFF
--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -187,6 +187,12 @@ struct hook_user_logout_check
 	bool                allowed;
 };
 
+struct hook_user_identify_fail
+{
+	struct sourceinfo * si;
+	struct myuser *     mu;
+};
+
 struct hook_user_needforce
 {
 	struct sourceinfo * si;

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -85,6 +85,7 @@ user_can_rename                 struct hook_user_rename_check *
 user_check_expire               struct hook_expiry_req *
 user_drop                       struct myuser *
 user_identify                   struct user *
+user_identify_fail              struct hook_user_identify_fail *
 user_info                       struct hook_user_req *
 user_info_noexist               struct hook_info_noexist_req *
 user_needforce                  struct hook_user_needforce *

--- a/libathemecore/services.c
+++ b/libathemecore/services.c
@@ -887,6 +887,13 @@ bad_password(struct sourceinfo *si, struct myuser *mu)
 		wallops("Warning: \2%d\2 failed login attempts to \2%s\2. Last attempt received from \2%s\2 on %s.", count, entity(mu)->name, mask, strfbuf);
 	}
 
+	struct hook_user_identify_fail req = {
+		.si = si,
+		.mu = mu,
+	};
+
+	hook_call_user_identify_fail(&req);
+
 	return false;
 }
 


### PR DESCRIPTION
Resolves #724. I'm not entirely sure about the name yet given login failures may not necessarily involve a user in the `struct user` sense, and this hook only covers authentication failures due to invalid credentials (as opposed to attempts that did not even reach that point), which isn't conveyed by the name either.

It may be worth thinking about whether other sorts of authentication failures would be useful to expose to the hook as well or if this should be strictly a hook into the "bad credentials" path.