### PR TITLE
RETURN to a different address should HIDEMAIL if in defuflags

### DIFF
--- a/modules/nickserv/return.c
+++ b/modules/nickserv/return.c
@@ -59,6 +59,11 @@ ns_cmd_return(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+    if (!(mu->flags & MU_HIDEMAIL)                // doesn't have HIDEMAIL
+        && config_options.defuflags & MU_HIDEMAIL // HIDEMAIL is in default uflags
+        && strcmp(oldmail, newmail))              // new email is different
+        mu->flags |= MU_HIDEMAIL;
+
 	set_password(mu, newpass);
 
 	sfree(newpass);

--- a/modules/nickserv/return.c
+++ b/modules/nickserv/return.c
@@ -18,6 +18,7 @@ ns_cmd_return(struct sourceinfo *si, int parc, char *parv[])
 	char oldmail[EMAILLEN + 1];
 	struct myuser *mu;
 	struct user *u;
+	bool force_hidemail = false;
 	mowgli_node_t *n, *tn;
 
 	if (!target || !newmail)
@@ -59,10 +60,13 @@ ns_cmd_return(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-    if (!(mu->flags & MU_HIDEMAIL)                // doesn't have HIDEMAIL
-        && config_options.defuflags & MU_HIDEMAIL // HIDEMAIL is in default uflags
-        && strcmp(oldmail, newmail))              // new email is different
-        mu->flags |= MU_HIDEMAIL;
+	if (!(mu->flags & MU_HIDEMAIL)                    // doesn't have HIDEMAIL
+		&& config_options.defuflags & MU_HIDEMAIL // HIDEMAIL is in default uflags
+		&& strcmp(oldmail, newmail))              // new email is different
+	{
+		mu->flags |= MU_HIDEMAIL;
+		force_hidemail = true;
+	}
 
 	set_password(mu, newpass);
 
@@ -90,12 +94,17 @@ ns_cmd_return(struct sourceinfo *si, int parc, char *parv[])
 	mu->flags |= MU_NOBURSTLOGIN;
 	authcookie_destroy_all(mu);
 
-	wallops("%s returned the account \2%s\2 to \2%s\2", get_oper_name(si), target, newmail);
-	logcommand(si, CMDLOG_ADMIN | LG_REGISTER, "RETURN: \2%s\2 to \2%s\2", target, newmail);
+	wallops("%s returned the account \2%s\2 to \2%s\2%s", get_oper_name(si), target, newmail,
+						force_hidemail ? " (and set HIDEMAIL)" : "");
+	logcommand(si, CMDLOG_ADMIN | LG_REGISTER, "RETURN: \2%s\2 to \2%s\2%s", target, newmail,
+						force_hidemail ? " (HIDEMAIL)" : "");
 	command_success_nodata(si, _("The e-mail address for \2%s\2 has been set to \2%s\2"),
 						target, newmail);
 	command_success_nodata(si, _("A random password has been set; it has been sent to \2%s\2."),
 						newmail);
+	if (force_hidemail)
+		command_success_nodata(si, _("Forced HIDEMAIL on to \2%s\2 due to email change"),
+						target);
 }
 
 static struct command ns_return = {


### PR DESCRIPTION
per #737

if:
- user is not set HIDEMAIL and
- HIDEMAIL in defuflags and
- new email does not equal old email

then force HIDEMAIL on the user