### PR TITLE
use try_kick() instead of kick() for channels that have been CS CLOSEd

### DIFF
--- a/modules/chanserv/close.c
+++ b/modules/chanserv/close.c
@@ -34,8 +34,8 @@ close_check_join(struct hook_channel_joinpart *data)
 		channel_mode_va(chansvs.me->me, cu->chan, 3, "+isbl", "*!*@*", "1");
 
 		// clear the channel
-		kick(chansvs.me->me, cu->chan, cu->user, "This channel has been closed");
-		data->cu = NULL;
+		if (try_kick(chansvs.me->me, cu->chan, cu->user, "This channel has been closed"))
+			data->cu = NULL;
 	}
 }
 

--- a/modules/chanserv/close.c
+++ b/modules/chanserv/close.c
@@ -106,7 +106,7 @@ cs_cmd_close(struct sourceinfo *si, int parc, char *parv[])
 				cu = (struct chanuser *)n->data;
 
 				if (!is_internal_client(cu->user))
-					kick(chansvs.me->me, c, cu->user, "This channel has been closed");
+					try_kick(chansvs.me->me, c, cu->user, "This channel has been closed");
 			}
 		}
 


### PR DESCRIPTION
my proposed solution for #743, stolen from cs/akick.c, still sets the closed channel modes but announces that it isn't kicking you because you're oper/immune.

I did consider instead only kicking users that joined when the channel is already closed, because anyone that can join through `+b *!*@*` should probably be allowed to, but that means you need to do join/kick before you can get in safely, and it's likely a bit vulnerable to timing attacks.