### PR TITLE
add an option to disable email canon for LISTOWNMAIL comparisons

### DIFF
--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -1576,14 +1576,14 @@ nickserv {
 	#shorthelp = "";
 
 	/*
-	 * (*)listownmail_dont_canon
+	 * (*)listownmail_canon
 	 *
-	 * Whether or not to canonicalize emails when doing LISTOWNMAIL. Depending on
-	 * what custom canonicalizers you have loaded, LISTOWNMAIL can expose
-	 * user:email mappings via LISTOWNMAIL when it might not be safe to do so
-	 * (e.g. if you unconditionally strip +subaddress from emails)
+	 * Whether to canonicalize emails when doing LISTOWNMAIL. Depending on what
+	 * custom canonicalizers you have loaded, LISTOWNMAIL can expose user:email
+	 * mappings via LISTOWNMAIL when it might not be safe to do so (e.g. if you
+	 * unconditionally strip +subaddress from emails.)
 	 */
-	#listownmail_dont_canon;
+	listownmail_canon;
 };
 
 /* ChanServ configuration.

--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -1574,6 +1574,16 @@ nickserv {
 	 * disable listing command descriptions in `/msg NickServ HELP'.
 	 */
 	#shorthelp = "";
+
+	/*
+	 * (*)listownmail_dont_canon
+	 *
+	 * Whether or not to canonicalize emails when doing LISTOWNMAIL. Depending on
+	 * what custom canonicalizers you have loaded, LISTOWNMAIL can expose
+	 * user:email mappings via LISTOWNMAIL when it might not be safe to do so
+	 * (e.g. if you unconditionally strip +subaddress from emails)
+	 */
+	#listownmail_dont_canon;
 };
 
 /* ChanServ configuration.

--- a/modules/nickserv/listownmail.c
+++ b/modules/nickserv/listownmail.c
@@ -9,7 +9,7 @@
 
 #include <atheme.h>
 
-static bool listownmail_dont_canon = false;
+static bool listownmail_canon = false;
 
 static void
 ns_cmd_listownmail(struct sourceinfo *si, int parc, char *parv[])
@@ -43,8 +43,8 @@ ns_cmd_listownmail(struct sourceinfo *si, int parc, char *parv[])
 
 		continue_if_fail(mu != NULL);
 
-		if ((!listownmail_dont_canon && !strcasecmp(si->smu->email_canonical, mu->email_canonical))
-		 || (listownmail_dont_canon && !strcasecmp(si->smu->email, mu->email)))
+		if ((listownmail_canon && !strcasecmp(si->smu->email_canonical, mu->email_canonical))
+		 || (!listownmail_canon && !strcasecmp(si->smu->email, mu->email)))
 		{
 			// in the future we could add a LIMIT parameter
 			if (matches == 0)
@@ -75,7 +75,7 @@ mod_init(struct module *const restrict m)
 	MODULE_TRY_REQUEST_DEPENDENCY(m, "nickserv/main")
 
 	service_named_bind_command("nickserv", &ns_listownmail);
-	add_bool_conf_item("LISTOWNMAIL_DONT_CANON", &nicksvs.me->conf_table, 0, &listownmail_dont_canon, false);
+	add_bool_conf_item("LISTOWNMAIL_DONT_CANON", &nicksvs.me->conf_table, 0, &listownmail_canon, true);
 }
 
 static void

--- a/modules/nickserv/listownmail.c
+++ b/modules/nickserv/listownmail.c
@@ -9,6 +9,8 @@
 
 #include <atheme.h>
 
+static bool listownmail_dont_canon = false;
+
 static void
 ns_cmd_listownmail(struct sourceinfo *si, int parc, char *parv[])
 {
@@ -41,7 +43,8 @@ ns_cmd_listownmail(struct sourceinfo *si, int parc, char *parv[])
 
 		continue_if_fail(mu != NULL);
 
-		if (!strcasecmp(si->smu->email_canonical, mu->email_canonical))
+		if ((!listownmail_dont_canon && !strcasecmp(si->smu->email_canonical, mu->email_canonical))
+		 || (listownmail_dont_canon && !strcasecmp(si->smu->email, mu->email)))
 		{
 			// in the future we could add a LIMIT parameter
 			if (matches == 0)
@@ -72,6 +75,7 @@ mod_init(struct module *const restrict m)
 	MODULE_TRY_REQUEST_DEPENDENCY(m, "nickserv/main")
 
 	service_named_bind_command("nickserv", &ns_listownmail);
+	add_bool_conf_item("LISTOWNMAIL_DONT_CANON", &nicksvs.me->conf_table, 0, &listownmail_dont_canon, false);
 }
 
 static void

--- a/modules/nickserv/listownmail.c
+++ b/modules/nickserv/listownmail.c
@@ -82,6 +82,7 @@ static void
 mod_deinit(const enum module_unload_intent ATHEME_VATTR_UNUSED intent)
 {
 	service_named_unbind_command("nickserv", &ns_listownmail);
+	del_conf_item("LISTOWNMAIL_CANON", &nicksvs.me->conf_table);
 }
 
 SIMPLE_DECLARE_MODULE_V1("nickserv/listownmail", MODULE_UNLOAD_CAPABILITY_OK)

--- a/modules/nickserv/listownmail.c
+++ b/modules/nickserv/listownmail.c
@@ -75,7 +75,7 @@ mod_init(struct module *const restrict m)
 	MODULE_TRY_REQUEST_DEPENDENCY(m, "nickserv/main")
 
 	service_named_bind_command("nickserv", &ns_listownmail);
-	add_bool_conf_item("LISTOWNMAIL_DONT_CANON", &nicksvs.me->conf_table, 0, &listownmail_canon, true);
+	add_bool_conf_item("LISTOWNMAIL_CANON", &nicksvs.me->conf_table, 0, &listownmail_canon, true);
 }
 
 static void


### PR DESCRIPTION
closes #742.

stole modular setting from `pwquality_warn_only`. I'm not sure I like how visually complicated the `if` is now. pls be gentle