### PR TITLE
chanserv: allow hiding AKICK entries from public ACLs

### DIFF
--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -1750,6 +1750,20 @@ chanserv {
 	 */
 	#hide_xop;
 
+	/* (*) hide_pubacl_akicks
+	 *
+	 * Hide AKICKs (ACL entries with only the +b flag) from the public
+	 * access lists of channels. Users with the +A flag or chan:auspex
+	 * will see these entries listed as normal.
+	 *
+	 * AKICK expiries and reasons will not be disclosed to unauthorized
+	 * users in any case.
+	 *
+	 * This option is only meaningful if you are using the PUBACL flag
+	 * to allow channel access lists to be public.
+	 */
+	#hide_pubacl_akicks;
+
 	/* (*) templates
 	 *
 	 * Defines what flags the global templates comprise.

--- a/include/atheme/services.h
+++ b/include/atheme/services.h
@@ -23,22 +23,23 @@
 /* core services */
 struct chansvs
 {
-	char *          nick;           // the IRC client's nickname
-	char *          user;           // the IRC client's username
-	char *          host;           // the IRC client's hostname
-	char *          real;           // the IRC client's realname
-	bool            fantasy;        // enable fantasy commands
-	char *          trigger;        // trigger, e.g. !, ` or .
-	bool            changets;       // use TS to better deop people
-	struct service *me;             // our struct user
-	unsigned int    expiry;         // expiry time
-	unsigned int    akick_time;     // default akick duration
-	unsigned int    maxchans;       // max channels one can register
-	unsigned int    maxchanacs;     // max entries in chanacs list
-	unsigned int    maxfounders;    // max founders per channel
-	char *          founder_flags;  // default founder flags for new channels
-	char *          deftemplates;   // default templates
-	bool            hide_xop;       // hide XOP templates
+	char *          nick;               // the IRC client's nickname
+	char *          user;               // the IRC client's username
+	char *          host;               // the IRC client's hostname
+	char *          real;               // the IRC client's realname
+	bool            fantasy;            // enable fantasy commands
+	char *          trigger;            // trigger, e.g. !, ` or .
+	bool            changets;           // use TS to better deop people
+	struct service *me;                 // our struct user
+	unsigned int    expiry;             // expiry time
+	unsigned int    akick_time;         // default akick duration
+	unsigned int    maxchans;           // max channels one can register
+	unsigned int    maxchanacs;         // max entries in chanacs list
+	unsigned int    maxfounders;        // max founders per channel
+	char *          founder_flags;      // default founder flags for new channels
+	char *          deftemplates;       // default templates
+	bool            hide_xop;           // hide XOP templates
+	bool            hide_pubacl_akicks; // hide AKICKs only visible via PUBACL
 };
 
 /* authentication services */

--- a/modules/chanserv/main.c
+++ b/modules/chanserv/main.c
@@ -849,6 +849,7 @@ mod_init(struct module ATHEME_VATTR_UNUSED *const restrict m)
 	add_conf_item("TEMPLATES", &chansvs.me->conf_table, c_ci_templates);
 	add_bool_conf_item("CHANGETS", &chansvs.me->conf_table, 0, &chansvs.changets, false);
 	add_bool_conf_item("HIDE_XOP", &chansvs.me->conf_table, 0, &chansvs.hide_xop, false);
+	add_bool_conf_item("HIDE_PUBACL_AKICKS", &chansvs.me->conf_table, 0, &chansvs.hide_pubacl_akicks, false);
 	add_dupstr_conf_item("TRIGGER", &chansvs.me->conf_table, 0, &chansvs.trigger, "!");
 	add_duration_conf_item("EXPIRE", &chansvs.me->conf_table, 0, &chansvs.expiry, "d", 0);
 	add_uint_conf_item("MAXCHANS", &chansvs.me->conf_table, 0, &chansvs.maxchans, 1, INT_MAX, 5);


### PR DESCRIPTION
This essentially allows networks to enable PUBACL even if they can't make akicks public (e.g. networks like freenode that already make ACLs public but exclude akicks from the public listing, so exposing akicks isn't an option without breaking users' existing assumptions about them being private).

Tested, but there's likely to be some edge cases I haven't thought of.