### PR TITLE
implement groupserv mark

### DIFF
--- a/help/default/groupserv/mark
+++ b/help/default/groupserv/mark
@@ -1,0 +1,13 @@
+Help for MARK:
+
+MARK allows operators to attach a note to a group.
+For example, an operator could mark the group of a
+spammer so that others know it has previously been
+warned.
+
+MARK information will be displayed in INFO output.
+
+Syntax: MARK <!group> ON|OFF <reason>
+
+Example:
+    /msg &nick& MARK !trolls ON Lots of bad trolls

--- a/modules/groupserv/Makefile
+++ b/modules/groupserv/Makefile
@@ -22,6 +22,7 @@ SRCS    =                   \
     join.c                  \
     list.c                  \
     listchans.c             \
+    mark.c                  \
     register.c              \
     regnolimit.c            \
     set.c                   \

--- a/modules/groupserv/info.c
+++ b/modules/groupserv/info.c
@@ -89,6 +89,24 @@ gs_cmd_info(struct sourceinfo *si, int parc, char *parv[])
 		command_success_nodata(si, _("Join flags  : %s"), gflags_tostr(ga_flags, atoi(md->value)));
 	}
 
+	if (has_priv(si, PRIV_GROUP_AUSPEX) && (md = metadata_find(mg, "private:mark:setter")))
+	{
+		const char *setter = md->value;
+		const char *reason;
+		time_t ts;
+
+		md = metadata_find(mg, "private:mark:reason");
+		reason = md != NULL ? md->value : "unknown";
+
+		md = metadata_find(mg, "private:mark:timestamp");
+		ts = md != NULL ? atoi(md->value) : 0;
+
+		tm = localtime(&ts);
+		strftime(strfbuf, sizeof strfbuf, TIME_FORMAT, tm);
+
+		command_success_nodata(si, _("%s was \2MARKED\2 by \2%s\2 on \2%s\2 (%s)."), entity(mg)->name, setter, strfbuf, reason);
+	}
+
 	command_success_nodata(si, _("\2*** End of Info ***\2"));
 
 	logcommand(si, CMDLOG_GET, "INFO: \2%s\2", parv[0]);

--- a/modules/groupserv/mark.c
+++ b/modules/groupserv/mark.c
@@ -1,0 +1,103 @@
+/*
+ * SPDX-License-Identifier: ISC
+ * SPDX-URL: https://spdx.org/licenses/ISC.html
+ *
+ * Copyright (C) 2005 William Pitcock
+ *
+ * Marking for channels.
+ */
+
+#include <atheme.h>
+#include "groupserv.h"
+
+static void
+gs_cmd_mark(struct sourceinfo *si, int parc, char *parv[])
+{
+	char *target = parv[0];
+	char *action = parv[1];
+	char *info = parv[2];
+	struct mygroup *mg;
+
+	if (!target || !action)
+	{
+		command_fail(si, fault_needmoreparams, STR_INSUFFICIENT_PARAMS, "MARK");
+		command_fail(si, fault_needmoreparams, _("Usage: MARK <!group> <ON|OFF> [note]"));
+		return;
+	}
+
+	if (!(mg = mygroup_find(target)))
+	{
+		command_fail(si, fault_nosuch_target, STR_IS_NOT_REGISTERED, target);
+		return;
+	}
+
+	if (!strcasecmp(action, "ON"))
+	{
+		if (!info)
+		{
+			command_fail(si, fault_needmoreparams, STR_INSUFFICIENT_PARAMS, "MARK");
+			command_fail(si, fault_needmoreparams, _("Usage: MARK <!group> ON <note>"));
+			return;
+		}
+
+		if (metadata_find(mg, "private:mark:setter"))
+		{
+			command_fail(si, fault_nochange, _("\2%s\2 is already marked."), target);
+			return;
+		}
+
+		metadata_add(mg, "private:mark:setter", get_oper_name(si));
+		metadata_add(mg, "private:mark:reason", info);
+		metadata_add(mg, "private:mark:timestamp", number_to_string(CURRTIME));
+
+		wallops("\2%s\2 marked the group \2%s\2.", get_oper_name(si), target);
+		logcommand(si, CMDLOG_ADMIN, "MARK:ON: \2%s\2 (reason: \2%s\2)", entity(mg)->name, info);
+		command_success_nodata(si, _("\2%s\2 is now marked."), target);
+	}
+	else if (!strcasecmp(action, "OFF"))
+	{
+		if (!metadata_find(mg, "private:mark:setter"))
+		{
+			command_fail(si, fault_nochange, _("\2%s\2 is not marked."), target);
+			return;
+		}
+
+		metadata_delete(mg, "private:mark:setter");
+		metadata_delete(mg, "private:mark:reason");
+		metadata_delete(mg, "private:mark:timestamp");
+
+		wallops("\2%s\2 unmarked the group \2%s\2.", get_oper_name(si), target);
+		logcommand(si, CMDLOG_ADMIN, "MARK:OFF: \2%s\2", entity(mg)->name);
+		command_success_nodata(si, _("\2%s\2 is now unmarked."), target);
+	}
+	else
+	{
+		command_fail(si, fault_badparams, STR_INVALID_PARAMS, "MARK");
+		command_fail(si, fault_badparams, _("Usage: MARK <!group> <ON|OFF> [note]"));
+	}
+}
+
+static struct command gs_mark = {
+	.name           = "MARK",
+	.desc           = N_("Adds a note to a group."),
+	.access         = PRIV_MARK,
+	.maxparc        = 3,
+	.cmd            = &gs_cmd_mark,
+	.help           = { .path = "groupserv/mark" },
+};
+
+static void
+mod_init(struct module *const restrict m)
+{
+	use_groupserv_main_symbols(m);
+
+	service_named_bind_command("groupserv", &gs_mark);
+}
+
+static void
+mod_deinit(const enum module_unload_intent ATHEME_VATTR_UNUSED intent)
+{
+	service_named_unbind_command("groupserv", &gs_mark);
+}
+
+SIMPLE_DECLARE_MODULE_V1("groupserv/mark", MODULE_UNLOAD_CAPABILITY_OK)


### PR DESCRIPTION
Allow sopers to add marks to groups like they can to channels and accounts.