### PR TITLE
Add `git clone --recursive` suggestion to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ as the source. Atheme will default to installing in `$HOME/atheme`, so make
 sure you plan accordingly for this.
 
     $ git submodule update --init
+    # Or clone the repo with 'git clone --recursive https://github.com/atheme/atheme.git' instead
     $ ./configure
     $ make
     $ make install
@@ -38,6 +39,7 @@ slightly differently:
 
     # pkg_add gmake
     $ git submodule update --init
+    # Or clone the repo with 'git clone --recursive https://github.com/atheme/atheme.git' instead
     $ ./configure --disable-linker-defs
     $ gmake
     $ gmake install

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ just by editing the configuration.
 
 ## Obtaining Atheme
 
-You can either git clone `https://github.com/atheme/atheme.git` or download a
+You can either `git clone --recursive 'https://github.com/atheme/atheme.git' atheme-devel` or download a
 package via our website at `https://atheme.github.io/` -- Please do not click
 the "Download" buttons on GitHub as they lack needed submodules, etc.
 
@@ -28,8 +28,8 @@ Whatever you do, make sure you do *not* install Atheme into the same location
 as the source. Atheme will default to installing in `$HOME/atheme`, so make
 sure you plan accordingly for this.
 
-    $ git submodule update --init
-    # Or clone the repo with 'git clone --recursive https://github.com/atheme/atheme.git' instead
+    $ git clone --recursive 'https://github.com/atheme/atheme.git' atheme-devel
+    $ cd atheme-devel
     $ ./configure
     $ make
     $ make install
@@ -38,8 +38,7 @@ If you are on an OpenBSD system, or similar, you will need to do things
 slightly differently:
 
     # pkg_add gmake
-    $ git submodule update --init
-    # Or clone the repo with 'git clone --recursive https://github.com/atheme/atheme.git' instead
+    $ git clone --recursive 'https://github.com/atheme/atheme.git' atheme-devel
     $ ./configure --disable-linker-defs
     $ gmake
     $ gmake install

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ slightly differently:
 
     # pkg_add gmake
     $ git clone --recursive 'https://github.com/atheme/atheme.git' atheme-devel
+    $ cd atheme-devel
     $ ./configure --disable-linker-defs
     $ gmake
     $ gmake install


### PR DESCRIPTION
Cloning with `git clone --recursive https://github.com/atheme/atheme.git` spares the user having to do `git submodule update --init`.