### PR TITLE
Infoserv improvements

### DIFF
--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -2038,6 +2038,18 @@ infoserv {
 	 * Set this to 0 for unlimited.
 	 */
 	logoninfo_count = 3;
+
+	/* (*)(B) logoninfo_reverse
+	 *
+	 * Whether to display the InfoServ on-connect messages in reverse
+	 * chronological order, i.e. newest message first, oldest last.
+	 *
+	 * Note that if this option is disabled, messages added after
+	 * the logoninfo_count limit will not be shown at connection time
+	 * as only the oldest N messages will be shown, rather than
+	 * the most recent N messages (as configured by default).
+	 */
+	logoninfo_reverse;
 };
 
 /* OperServ configuration.

--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -2050,6 +2050,18 @@ infoserv {
 	 * the most recent N messages (as configured by default).
 	 */
 	logoninfo_reverse;
+
+	/* (*)(B) logoninfo_show_metadata
+	 *
+	 * By default, the InfoServ on-connect messages and the output
+	 * of the LIST command include information about the author
+	 * of the message as well as the time it was added.
+	 *
+	 * Disabling this option will remove that information for normal users.
+	 * Privileged users will still be able to see the information
+	 * in the output of the LIST (or OLIST) command.
+	 */
+	logoninfo_show_metadata;
 };
 
 /* OperServ configuration.

--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -2034,6 +2034,8 @@ infoserv {
 	 * The number of InfoServ messages a user will see upon connect. If
 	 * there are more than this number, the user will be able to see the
 	 * rest of them with the InfoServ LIST command.
+	 *
+	 * Set this to 0 for unlimited.
 	 */
 	logoninfo_count = 3;
 };

--- a/help/default/infoserv/move
+++ b/help/default/infoserv/move
@@ -1,0 +1,14 @@
+Help for MOVE:
+
+MOVE allows you to move informational messages, changing the order
+they are displayed to users on connect.
+
+The specified message will be inserted at the target position,
+shifting the surrounding entries as needed.
+
+To move messages displayed to opers, use the OMOVE command instead.
+
+Syntax: MOVE <old> <new>
+
+Example:
+    /msg &nick& MOVE 3 1

--- a/help/default/infoserv/omove
+++ b/help/default/infoserv/omove
@@ -1,0 +1,14 @@
+Help for OMOVE:
+
+OMOVE allows you to move oper logon messages, changing the order
+they are displayed to opers as they oper up.
+
+The specified message will be inserted at the target position,
+shifting the surrounding entries as needed.
+
+To move messages displayed to users, use the MOVE command instead.
+
+Syntax: OMOVE <old> <new>
+
+Example:
+    /msg &nick& OMOVE 3 1

--- a/modules/infoserv/main.c
+++ b/modules/infoserv/main.c
@@ -15,20 +15,15 @@
 
 #include <atheme.h>
 
+#define DB_TYPE_LOGONINFO "LI"
+#define DB_TYPE_LOGONINFO_OPER "LIO"
+
 struct logoninfo
 {
-        stringref nick;
-        char *subject;
-        time_t info_ts;
-        char *story;
-};
-
-struct operlogoninfo
-{
-        stringref nick;
-        char *subject;
-        time_t info_ts;
-        char *story;
+	stringref nick;
+	char *subject;
+	time_t info_ts;
+	char *story;
 };
 
 static mowgli_list_t logon_info;
@@ -66,32 +61,29 @@ underscores_to_spaces(char *y)
 }
 
 static void
+write_infoentry(struct database_handle *db, struct logoninfo *l, bool oper)
+{
+	db_start_row(db, oper ? DB_TYPE_LOGONINFO_OPER : DB_TYPE_LOGONINFO);
+	db_write_word(db, l->nick);
+	db_write_word(db, l->subject);
+	db_write_time(db, l->info_ts);
+	db_write_str(db, l->story);
+	db_commit_row(db);
+}
+
+static void
 write_infodb(struct database_handle *db)
 {
 	mowgli_node_t *n;
 
 	MOWGLI_ITER_FOREACH(n, logon_info.head)
 	{
-		struct logoninfo *l = n->data;
-
-		db_start_row(db, "LI");
-		db_write_word(db, l->nick);
-		db_write_word(db, l->subject);
-		db_write_time(db, l->info_ts);
-		db_write_str(db, l->story);
-		db_commit_row(db);
+		write_infoentry(db, n->data, false);
 	}
 
 	MOWGLI_ITER_FOREACH(n, operlogon_info.head)
 	{
-		struct operlogoninfo *o = n->data;
-
-		db_start_row(db, "LIO");
-		db_write_word(db, o->nick);
-		db_write_word(db, o->subject);
-		db_write_time(db, o->info_ts);
-		db_write_str(db, o->story);
-		db_commit_row(db);
+		write_infoentry(db, n->data, true);
 	}
 
 }
@@ -109,38 +101,17 @@ db_h_li(struct database_handle *db, const char *type)
 	l->subject = sstrdup(subject);
 	l->info_ts = info_ts;
 	l->story = sstrdup(story);
-	mowgli_node_add(l, mowgli_node_create(), &logon_info);
+
+	if (strcasecmp(type, DB_TYPE_LOGONINFO_OPER) == 0)
+		mowgli_node_add(l, mowgli_node_create(), &operlogon_info);
+	else
+		mowgli_node_add(l, mowgli_node_create(), &logon_info);
 }
 
 static void
-db_h_lio(struct database_handle *db, const char *type)
+display_info(struct user *u, bool oper)
 {
-	const char *nick = db_sread_word(db);
-	const char *subject = db_sread_word(db);
-	time_t info_ts = db_sread_time(db);
-	const char *story = db_sread_str(db);
-
-	struct operlogoninfo *const o = smalloc(sizeof *o);
-	o->nick = strshare_get(nick);
-	o->subject = sstrdup(subject);
-	o->info_ts = info_ts;
-	o->story = sstrdup(story);
-	mowgli_node_add(o, mowgli_node_create(), &operlogon_info);
-}
-
-static void
-display_info(struct hook_user_nick *data)
-{
-	struct user *u;
-	mowgli_node_t *n;
-	struct logoninfo *l;
-	char dBuf[BUFSIZE];
-	struct tm *tm;
-	unsigned int count = 0;
-
-	u = data->u;
-	if (u == NULL)
-		return;
+	return_if_fail(u != NULL);
 
 	// abort if it's an internal client
 	if (is_internal_client(u))
@@ -149,19 +120,29 @@ display_info(struct hook_user_nick *data)
 	if (!(u->server->flags & SF_EOB))
 		return;
 
-	if (logon_info.count > 0)
+	mowgli_list_t *list = (oper ? &operlogon_info : &logon_info);
+	if (list->count > 0)
 	{
-		notice(infoserv->nick, u->nick, "*** \2Message(s) of the Day\2 ***");
+		if (oper)
+			notice(infoserv->nick, u->nick, "*** \2Oper Message(s) of the Day\2 ***");
+		else
+			notice(infoserv->nick, u->nick, "*** \2Message(s) of the Day\2 ***");
 
-		MOWGLI_ITER_FOREACH_PREV(n, logon_info.tail)
+		mowgli_node_t *n;
+		unsigned int count = 0;
+		MOWGLI_ITER_FOREACH_PREV(n, list->tail)
 		{
-			l = n->data;
+			struct logoninfo *l = n->data;
 
 			char *y = sstrdup(l->subject);
 			underscores_to_spaces(y);
 
+			struct tm *tm;
 			tm = localtime(&l->info_ts);
+
+			char dBuf[BUFSIZE];
 			strftime(dBuf, BUFSIZE, "%H:%M on %m/%d/%Y", tm);
+
 			notice(infoserv->nick, u->nick, "[\2%s\2] Notice from %s, posted %s:",
 				y, l->nick, dBuf);
 			notice(infoserv->nick, u->nick, "%s", l->story);
@@ -173,55 +154,24 @@ display_info(struct hook_user_nick *data)
 				break;
 		}
 
-		notice(infoserv->nick, u->nick, "*** \2End of Message(s) of the Day\2 ***");
+		if (oper)
+			notice(infoserv->nick, u->nick, "*** \2End of Oper Message(s) of the Day\2 ***");
+		else
+			notice(infoserv->nick, u->nick, "*** \2End of Message(s) of the Day\2 ***");
 	}
 }
 
 static void
-display_oper_info(struct user *u)
+hook_user_add(struct hook_user_nick *hdata)
 {
-	mowgli_node_t *n;
-	struct operlogoninfo *o;
-	char dBuf[BUFSIZE];
-	struct tm *tm;
-	unsigned int count = 0;
+	if (hdata->u)
+		display_info(hdata->u, false);
+}
 
-	if (u == NULL)
-		return;
-
-	// abort if it's an internal client
-	if (is_internal_client(u))
-		return;
-	// abort if user is coming back from split
-	if (!(u->server->flags & SF_EOB))
-		return;
-
-	if (operlogon_info.count > 0)
-	{
-		notice(infoserv->nick, u->nick, "*** \2Oper Message(s) of the Day\2 ***");
-
-		MOWGLI_ITER_FOREACH_PREV(n, operlogon_info.tail)
-		{
-			o = n->data;
-
-			char *y = sstrdup(o->subject);
-			underscores_to_spaces(y);
-
-			tm = localtime(&o->info_ts);
-			strftime(dBuf, BUFSIZE, "%H:%M on %m/%d/%Y", tm);
-			notice(infoserv->nick, u->nick, "[\2%s\2] Notice from %s, posted %s:",
-				y, o->nick, dBuf);
-			notice(infoserv->nick, u->nick, "%s", o->story);
-			sfree(y);
-			count++;
-
-			// only display three latest entries, max.
-			if (count == logoninfo_count)
-				break;
-		}
-
-		notice(infoserv->nick, u->nick, "*** \2End of Oper Message(s) of the Day\2 ***");
-	}
+static void
+hook_user_oper(struct user *u)
+{
+	display_info(u, true);
 }
 
 static void
@@ -238,11 +188,6 @@ is_cmd_post(struct sourceinfo *si, int parc, char *parv[])
 	char *importance = parv[0];
 	char *subject = parv[1];
 	char *story = parv[2];
-	unsigned int imp;
-	struct logoninfo *l;
-	struct operlogoninfo *o;
-	mowgli_node_t *n;
-	char buf[BUFSIZE];
 
 	// make sure they're logged in
 	if (!si->smu)
@@ -258,6 +203,7 @@ is_cmd_post(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	unsigned int imp;
 	if (! string_to_uint(importance, &imp) || imp > 4)
 	{
 		command_fail(si, fault_badparams, _("Importance must be a digit between 0 and 4"));
@@ -269,6 +215,7 @@ is_cmd_post(struct sourceinfo *si, int parc, char *parv[])
 
 	if (imp == 4)
 	{
+		char buf[BUFSIZE];
 		snprintf(buf, sizeof buf, "[CRITICAL NETWORK NOTICE] %s - [%s] %s", get_source_name(si), y, story);
 		msg_global_sts(infoserv->me, "*", buf);
 		command_success_nodata(si, _("The InfoServ message has been sent"));
@@ -279,6 +226,7 @@ is_cmd_post(struct sourceinfo *si, int parc, char *parv[])
 
 	if (imp == 2)
 	{
+		char buf[BUFSIZE];
 		snprintf(buf, sizeof buf, "[Network Notice] %s - [%s] %s", get_source_name(si), y, story);
 		notice_global_sts(infoserv->me, "*", buf);
 		command_success_nodata(si, _("The InfoServ message has been sent"));
@@ -287,35 +235,21 @@ is_cmd_post(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	if (imp == 0)
-	{
-		o = smalloc(sizeof *o);
-		o->nick = strshare_ref(entity(si->smu)->name);
-		o->info_ts = CURRTIME;
-		o->story = sstrdup(story);
-		o->subject = sstrdup(subject);
+	struct logoninfo *l = smalloc(sizeof *l);
+	l->nick = strshare_ref(entity(si->smu)->name);
+	l->info_ts = CURRTIME;
+	l->story = sstrdup(story);
+	l->subject = sstrdup(subject);
 
-		n = mowgli_node_create();
-		mowgli_node_add(o, n, &operlogon_info);
-	}
-
-	if (imp > 0)
-	{
-		l = smalloc(sizeof *l);
-		l->nick = strshare_ref(entity(si->smu)->name);
-		l->info_ts = CURRTIME;
-		l->story = sstrdup(story);
-		l->subject = sstrdup(subject);
-
-		n = mowgli_node_create();
-		mowgli_node_add(l, n, &logon_info);
-	}
+	mowgli_node_t *n = mowgli_node_create();
+	mowgli_node_add(l, n, (imp == 0) ? &operlogon_info : &logon_info);
 
 	command_success_nodata(si, _("Added entry to logon info"));
 	logcommand(si, CMDLOG_ADMIN, "INFO:POST: Importance: \2%s\2, Subject: \2%s\2, Message: \2%s\2", importance, y, story);
 
 	if (imp == 3)
 	{
+		char buf[BUFSIZE];
 		snprintf(buf, sizeof buf, "[Network Notice] %s - [%s] %s", get_source_name(si), y, story);
 		notice_global_sts(infoserv->me, "*", buf);
 	}
@@ -326,159 +260,122 @@ is_cmd_post(struct sourceinfo *si, int parc, char *parv[])
 }
 
 static void
-is_cmd_del(struct sourceinfo *si, int parc, char *parv[])
+is_del_impl(struct sourceinfo *si, int parc, char *parv[], bool oper)
 {
 	char *target = parv[0];
-	unsigned int x = 0;
-	unsigned int id;
-	struct logoninfo *l;
-	mowgli_node_t *n;
 
 	if (!target)
 	{
-		command_fail(si, fault_needmoreparams, STR_INSUFFICIENT_PARAMS, "DEL");
-		command_fail(si, fault_needmoreparams, _("Syntax: DEL <id>"));
+		command_fail(si, fault_needmoreparams, STR_INSUFFICIENT_PARAMS, oper ? "ODEL" : "DEL");
+		if (oper)
+			command_fail(si, fault_needmoreparams, _("Syntax: ODEL <id>"));
+		else
+			command_fail(si, fault_needmoreparams, _("Syntax: DEL <id>"));
 		return;
 	}
 
+	unsigned int id;
 	if (! string_to_uint(target, &id) || ! id)
 	{
-		command_fail(si, fault_badparams, STR_INVALID_PARAMS, "DEL");
-		command_fail(si, fault_badparams, _("Syntax: DEL <id>"));
+		command_fail(si, fault_badparams, STR_INVALID_PARAMS, oper ? "ODEL" : "DEL");
+		if (oper)
+			command_fail(si, fault_needmoreparams, _("Syntax: ODEL <id>"));
+		else
+			command_fail(si, fault_needmoreparams, _("Syntax: DEL <id>"));
 		return;
 	}
 
+	mowgli_list_t *list = (oper ? &operlogon_info : &logon_info);
+
+	unsigned int x = 0;
+	struct logoninfo *l;
+	mowgli_node_t *n;
+
 	// search for it
-	MOWGLI_ITER_FOREACH(n, logon_info.head)
+	MOWGLI_ITER_FOREACH(n, list->head)
 	{
 		l = n->data;
 		x++;
 
 		if (x == id)
 		{
-			logcommand(si, CMDLOG_ADMIN, "INFO:DEL: \2%s\2, \2%s\2", l->subject, l->story);
+			logcommand(si, CMDLOG_ADMIN, "INFO:%s: \2%s\2, \2%s\2", oper ? "ODEL" : "DEL", l->subject, l->story);
 
-			mowgli_node_delete(n, &logon_info);
+			mowgli_node_delete(n, list);
 
 			strshare_unref(l->nick);
 			sfree(l->subject);
 			sfree(l->story);
 			sfree(l);
 
-			command_success_nodata(si, _("Deleted entry %u from logon info."), id);
+			if (oper)
+				command_success_nodata(si, _("Deleted entry %u from oper logon info."), id);
+			else
+				command_success_nodata(si, _("Deleted entry %u from logon info."), id);
 			return;
 		}
 	}
 
-	command_fail(si, fault_nosuch_target, _("Entry \2%u\2 not found in logon info."), id);
+	if (oper)
+		command_fail(si, fault_nosuch_target, _("Entry \2%u\2 not found in oper logon info."), id);
+	else
+		command_fail(si, fault_nosuch_target, _("Entry \2%u\2 not found in logon info."), id);
 	return;
+}
+
+static void
+is_cmd_del(struct sourceinfo *si, int parc, char *parv[])
+{
+	is_del_impl(si, parc, parv, false);
 }
 
 static void
 is_cmd_odel(struct sourceinfo *si, int parc, char *parv[])
 {
-	char *target = parv[0];
-	unsigned int x = 0;
-	unsigned int id;
-	struct operlogoninfo *o;
+	is_del_impl(si, parc, parv, true);
+}
+
+static void
+is_list_impl(struct sourceinfo *si, int parc, char *parv[], bool oper)
+{
 	mowgli_node_t *n;
+	unsigned int x = 0;
 
-	if (!target)
+	MOWGLI_ITER_FOREACH(n, (oper ? operlogon_info : logon_info).head)
 	{
-		command_fail(si, fault_needmoreparams, STR_INSUFFICIENT_PARAMS, "ODEL");
-		command_fail(si, fault_needmoreparams, _("Syntax: ODEL <id>"));
-		return;
-	}
-
-	if (! string_to_uint(target, &id) || ! id)
-	{
-		command_fail(si, fault_badparams, STR_INVALID_PARAMS, "ODEL");
-		command_fail(si, fault_badparams, _("Syntax: ODEL <id>"));
-		return;
-	}
-
-	// search for it
-	MOWGLI_ITER_FOREACH(n, operlogon_info.head)
-	{
-		o = n->data;
+		struct logoninfo *l = n->data;
 		x++;
 
-		if (x == id)
-		{
-			logcommand(si, CMDLOG_ADMIN, "INFO:ODEL: \2%s\2, \2%s\2", o->subject, o->story);
+		char *y = sstrdup(l->subject);
+		underscores_to_spaces(y);
 
-			mowgli_node_delete(n, &operlogon_info);
+		struct tm *tm;
+		tm = localtime(&l->info_ts);
 
-			strshare_unref(o->nick);
-			sfree(o->subject);
-			sfree(o->story);
-			sfree(o);
+		char dBuf[BUFSIZE];
+		strftime(dBuf, BUFSIZE, "%H:%M on %m/%d/%Y", tm);
 
-			command_success_nodata(si, _("Deleted entry %u from oper logon info."), id);
-			return;
-		}
+		command_success_nodata(si, _("%u: [\2%s\2] by \2%s\2 at \2%s\2: \2%s\2"),
+			x, y, l->nick, dBuf, l->story);
+
+		sfree(y);
 	}
 
-	command_fail(si, fault_nosuch_target, _("Entry \2%u\2 not found in oper logon info."), id);
+	command_success_nodata(si, _("End of list."));
+	logcommand(si, CMDLOG_GET, (oper ? "OLIST" : "LIST"));
 	return;
 }
 
 static void
 is_cmd_list(struct sourceinfo *si, int parc, char *parv[])
 {
-	struct logoninfo *l;
-	mowgli_node_t *n;
-	struct tm *tm;
-	char dBuf[BUFSIZE];
-	unsigned int x = 0;
-
-	MOWGLI_ITER_FOREACH(n, logon_info.head)
-	{
-		l = n->data;
-		x++;
-
-		char *y = sstrdup(l->subject);
-		underscores_to_spaces(y);
-
-		tm = localtime(&l->info_ts);
-		strftime(dBuf, BUFSIZE, "%H:%M on %m/%d/%Y", tm);
-		command_success_nodata(si, _("%u: [\2%s\2] by \2%s\2 at \2%s\2: \2%s\2"),
-			x, y, l->nick, dBuf, l->story);
-		sfree(y);
-	}
-
-	command_success_nodata(si, _("End of list."));
-	logcommand(si, CMDLOG_GET, "LIST");
-	return;
+	is_list_impl(si, parc, parv, false);
 }
 
 static void
 is_cmd_olist(struct sourceinfo *si, int parc, char *parv[])
 {
-	struct operlogoninfo *o;
-	mowgli_node_t *n;
-	struct tm *tm;
-	char dBuf[BUFSIZE];
-	unsigned int x = 0;
-
-	MOWGLI_ITER_FOREACH(n, operlogon_info.head)
-	{
-		o = n->data;
-		x++;
-
-		char *y = sstrdup(o->subject);
-		underscores_to_spaces(y);
-
-		tm = localtime(&o->info_ts);
-		strftime(dBuf, BUFSIZE, "%H:%M on %m/%d/%Y", tm);
-		command_success_nodata(si, _("%u: [\2%s\2] by \2%s\2 at \2%s\2: \2%s\2"),
-			x, y, o->nick, dBuf, o->story);
-		sfree(y);
-	}
-
-	command_success_nodata(si, _("End of list."));
-	logcommand(si, CMDLOG_GET, "OLIST");
-	return;
+	is_list_impl(si, parc, parv, true);
 }
 
 static struct command is_help = {
@@ -549,13 +446,13 @@ mod_init(struct module *const restrict m)
 	infoserv = service_add("infoserv", NULL);
 	add_uint_conf_item("LOGONINFO_COUNT", &infoserv->conf_table, 0, &logoninfo_count, 0, INT_MAX, 3);
 
-	hook_add_user_add(display_info);
-	hook_add_user_oper(display_oper_info);
+	hook_add_user_add(hook_user_add);
+	hook_add_user_oper(hook_user_oper);
 	hook_add_operserv_info(osinfo_hook);
 	hook_add_db_write(write_infodb);
 
-	db_register_type_handler("LI", db_h_li);
-	db_register_type_handler("LIO", db_h_lio);
+	db_register_type_handler(DB_TYPE_LOGONINFO, db_h_li);
+	db_register_type_handler(DB_TYPE_LOGONINFO_OPER, db_h_li);
 
 	service_bind_command(infoserv, &is_help);
 	service_bind_command(infoserv, &is_post);

--- a/modules/infoserv/main.c
+++ b/modules/infoserv/main.c
@@ -27,6 +27,7 @@ struct logoninfo
 	char *subject;
 	time_t info_ts;
 	char *story;
+	mowgli_node_t node;
 };
 
 struct infoserv_persist_record
@@ -114,9 +115,9 @@ db_h_li(struct database_handle *db, const char *type)
 	l->story = sstrdup(story);
 
 	if (strcasecmp(type, DB_TYPE_LOGONINFO_OPER) == 0)
-		mowgli_node_add(l, mowgli_node_create(), &operlogon_info);
+		mowgli_node_add(l, &l->node, &operlogon_info);
 	else
-		mowgli_node_add(l, mowgli_node_create(), &logon_info);
+		mowgli_node_add(l, &l->node, &logon_info);
 }
 
 static void
@@ -265,8 +266,7 @@ is_cmd_post(struct sourceinfo *si, int parc, char *parv[])
 	l->subject = sstrdup(subject);
 
 	mowgli_list_t *list = (imp == 0) ? &operlogon_info : &logon_info;
-	mowgli_node_t *n = mowgli_node_create();
-	mowgli_node_add(l, n, list);
+	mowgli_node_add(l, &l->node, list);
 
 	command_success_nodata(si, _("Added entry to logon info"));
 	if (logoninfo_count != 0 && !logoninfo_reverse && list->count > logoninfo_count)
@@ -331,7 +331,6 @@ is_del_impl(struct sourceinfo *si, int parc, char *parv[], bool oper)
 			logcommand(si, CMDLOG_ADMIN, "INFO:%s: \2%s\2, \2%s\2", oper ? "ODEL" : "DEL", l->subject, l->story);
 
 			mowgli_node_delete(n, list);
-			mowgli_node_free(n);
 
 			strshare_unref(l->nick);
 			sfree(l->subject);

--- a/modules/infoserv/main.c
+++ b/modules/infoserv/main.c
@@ -302,6 +302,7 @@ is_del_impl(struct sourceinfo *si, int parc, char *parv[], bool oper)
 			logcommand(si, CMDLOG_ADMIN, "INFO:%s: \2%s\2, \2%s\2", oper ? "ODEL" : "DEL", l->subject, l->story);
 
 			mowgli_node_delete(n, list);
+			mowgli_node_free(n);
 
 			strshare_unref(l->nick);
 			sfree(l->subject);

--- a/modules/infoserv/main.c
+++ b/modules/infoserv/main.c
@@ -158,8 +158,8 @@ display_info(struct user *u, bool oper)
 			sfree(y);
 			count++;
 
-			// only display three latest entries, max.
-			if (count == logoninfo_count)
+			// only display up to the configured number of entries
+			if (logoninfo_count != 0 && count == logoninfo_count)
 				break;
 		}
 

--- a/modules/infoserv/main.c
+++ b/modules/infoserv/main.c
@@ -19,7 +19,7 @@
 #define DB_TYPE_LOGONINFO_OPER "LIO"
 
 #define INFOSERV_PERSIST_STORAGE_NAME "atheme.infoserv.main.persist"
-#define INFOSERV_PERSIST_VERSION      1
+#define INFOSERV_PERSIST_VERSION      1U
 
 struct logoninfo
 {
@@ -627,7 +627,7 @@ mod_init(struct module *const restrict m)
 
 		if (rec->version > INFOSERV_PERSIST_VERSION)
 		{
-			slog(LG_ERROR, "%s: attempted downgrade is not supported (from %d to %d)", m->name, rec->version, INFOSERV_PERSIST_VERSION);
+			slog(LG_ERROR, "%s: attempted downgrade is not supported (from %u to %u)", m->name, rec->version, INFOSERV_PERSIST_VERSION);
 			m->mflags |= MODFLAG_FAIL;
 
 			sfree(rec);

--- a/modules/infoserv/main.c
+++ b/modules/infoserv/main.c
@@ -472,8 +472,9 @@ is_list_impl(struct sourceinfo *si, int parc, char *parv[], bool oper)
 {
 	mowgli_node_t *n;
 	unsigned int x = 0;
+	mowgli_list_t list = oper ? operlogon_info : logon_info;
 
-	MOWGLI_ITER_FOREACH(n, (oper ? operlogon_info : logon_info).head)
+	MOWGLI_ITER_FOREACH(n, list.head)
 	{
 		struct logoninfo *l = n->data;
 		x++;
@@ -486,6 +487,14 @@ is_list_impl(struct sourceinfo *si, int parc, char *parv[], bool oper)
 
 		char dBuf[BUFSIZE];
 		strftime(dBuf, BUFSIZE, "%H:%M on %m/%d/%Y", tm);
+
+		if (logoninfo_count != 0 && has_priv(si, PRIV_GLOBAL) && list.count > logoninfo_count)
+		{
+			if (!logoninfo_reverse && x == logoninfo_count + 1)
+				command_success_nodata(si, _("(Messages below this line are not shown by default)"));
+			else if (logoninfo_reverse && x == list.count - logoninfo_count + 1)
+				command_success_nodata(si, _("(Messages above this line are no longer shown by default)"));
+		}
 
 		command_success_nodata(si, _("%u: [\2%s\2] by \2%s\2 at \2%s\2: \2%s\2"),
 			x, y, l->nick, dBuf, l->story);


### PR DESCRIPTION
Fixes #597, which inspired this PR to allow reordering entries and add an option to display just the entries without their setter and timestamp information. It ended up including a few other improvements as well.