### PR TITLE
Add examples to NickServ help entries.

### DIFF
--- a/help/default/nickserv/set_accountname
+++ b/help/default/nickserv/set_accountname
@@ -6,3 +6,6 @@ Your account name is used in various places as
 a name for you.
 
 Syntax: SET ACCOUNTNAME <nick>
+
+Example:
+    /msg &nick& SET ACCOUNTNAME amdj

--- a/help/default/nickserv/set_enforce
+++ b/help/default/nickserv/set_enforce
@@ -9,3 +9,6 @@ and temporarily block its use, which can be
 removed at your discretion. See help on RELEASE.
 
 Syntax: SET ENFORCE ON|OFF
+
+Example:
+    /msg &nick& SET ENFORCE ON

--- a/help/default/nickserv/set_pubkey
+++ b/help/default/nickserv/set_pubkey
@@ -7,3 +7,6 @@ If no pubkey is given, your public key will
 be removed from the services database.
 
 Syntax: SET PUBKEY [<pubkey>]
+
+Example:
+    /msg &nick& SET PUBKEY Ao8he4hEXkOo8xW1Yot4gKzQAxudXRng57zoPZV9fsjm

--- a/help/default/nickserv/setpass
+++ b/help/default/nickserv/setpass
@@ -12,3 +12,6 @@ To set a new password if you know the current
 password, use SET PASSWORD instead of SETPASS.
 
 Syntax: SETPASS <nickname> <key> <password>
+
+Example:
+    /msg &nick& SETPASS ilbelkyr llgqriuiosit hunter2


### PR DESCRIPTION
For consistenty with other entries.
Adds examples to set_accountname, set_enforce, set_pubkey, and setpass.