### PR TITLE
chanserv/{ban,kick,quiet,set,sync,taxonomy,unban}: Ensure channel is not closed

### DIFF
--- a/modules/chanserv/akick.c
+++ b/modules/chanserv/akick.c
@@ -489,18 +489,18 @@ cs_cmd_akick_del(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	if (metadata_find(mc, "private:close:closer"))
-	{
-		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, chan);
-		return;
-	}
-
 	struct akick_timeout *timeout;
 	struct chanban *cb;
 
 	if ((chanacs_source_flags(mc, si) & (CA_FLAGS | CA_REMOVE)) != (CA_FLAGS | CA_REMOVE))
 	{
 		command_fail(si, fault_noprivs, STR_NOT_AUTHORIZED);
+		return;
+	}
+
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, chan);
 		return;
 	}
 

--- a/modules/chanserv/ban.c
+++ b/modules/chanserv/ban.c
@@ -132,6 +132,12 @@ cs_cmd_unban(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, channel);
+		return;
+	}
+
 	if ((tu = user_find_named(target)))
 	{
 		mowgli_node_t *n, *tn;

--- a/modules/chanserv/clear_akicks.c
+++ b/modules/chanserv/clear_akicks.c
@@ -33,12 +33,6 @@ cs_cmd_clear_akicks(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	if (metadata_find(mc, "private:close:closer"))
-	{
-		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, name);
-		return;
-	}
-
 	if (!mc->chan)
 	{
 		command_fail(si, fault_nosuch_target, _("\2%s\2 does not exist."), name);
@@ -48,6 +42,12 @@ cs_cmd_clear_akicks(struct sourceinfo *si, int parc, char *parv[])
 	if (!(chanacs_source_has_flag(mc, si, CA_RECOVER) && chanacs_source_has_flag(mc, si, CA_FLAGS)))
 	{
 		command_fail(si, fault_noprivs, STR_NOT_AUTHORIZED);
+		return;
+	}
+
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, name);
 		return;
 	}
 

--- a/modules/chanserv/clear_akicks.c
+++ b/modules/chanserv/clear_akicks.c
@@ -35,7 +35,7 @@ cs_cmd_clear_akicks(struct sourceinfo *si, int parc, char *parv[])
 
 	if (!mc->chan)
 	{
-		command_fail(si, fault_nosuch_target, _("\2%s\2 does not exist."), name);
+		command_fail(si, fault_nosuch_target, STR_CHANNEL_IS_EMPTY, name);
 		return;
 	}
 

--- a/modules/chanserv/clear_flags.c
+++ b/modules/chanserv/clear_flags.c
@@ -33,15 +33,15 @@ cs_cmd_clear_flags(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	if (metadata_find(mc, "private:close:closer"))
-	{
-		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, name);
-		return;
-	}
-
 	if (!chanacs_source_has_flag(mc, si, CA_FOUNDER))
 	{
 		command_fail(si, fault_noprivs, STR_NOT_AUTHORIZED);
+		return;
+	}
+
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, name);
 		return;
 	}
 

--- a/modules/chanserv/clone.c
+++ b/modules/chanserv/clone.c
@@ -45,6 +45,18 @@ cs_cmd_clone(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (!(mc->flags & MC_PUBACL) && !chanacs_source_has_flag(mc, si, CA_ACLVIEW))
+	{
+		command_fail(si, fault_noprivs, STR_NOT_AUTHORIZED);
+		return;
+	}
+
+	if (!chanacs_source_has_flag(mc2, si, CA_FOUNDER))
+	{
+		command_fail(si, fault_noprivs, STR_NOT_AUTHORIZED);
+		return;
+	}
+
 	if (metadata_find(mc, "private:close:closer"))
 	{
 		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, source);
@@ -66,18 +78,6 @@ cs_cmd_clone(struct sourceinfo *si, int parc, char *parv[])
 	if (!mc2->chan)
 	{
 		command_fail(si, fault_nosuch_target, _("\2%s\2 does not exist."), target);
-		return;
-	}
-
-	if (!(mc->flags & MC_PUBACL) && !chanacs_source_has_flag(mc, si, CA_ACLVIEW))
-	{
-		command_fail(si, fault_noprivs, STR_NOT_AUTHORIZED);
-		return;
-	}
-
-	if (!chanacs_source_has_flag(mc2, si, CA_FOUNDER))
-	{
-		command_fail(si, fault_noprivs, STR_NOT_AUTHORIZED);
 		return;
 	}
 

--- a/modules/chanserv/clone.c
+++ b/modules/chanserv/clone.c
@@ -71,13 +71,13 @@ cs_cmd_clone(struct sourceinfo *si, int parc, char *parv[])
 
 	if (!mc->chan)
 	{
-		command_fail(si, fault_nosuch_target, _("\2%s\2 does not exist."), source);
+		command_fail(si, fault_nosuch_target, STR_CHANNEL_IS_EMPTY, source);
 		return;
 	}
 
 	if (!mc2->chan)
 	{
-		command_fail(si, fault_nosuch_target, _("\2%s\2 does not exist."), target);
+		command_fail(si, fault_nosuch_target, STR_CHANNEL_IS_EMPTY, target);
 		return;
 	}
 

--- a/modules/chanserv/getkey.c
+++ b/modules/chanserv/getkey.c
@@ -29,15 +29,15 @@ cs_cmd_getkey(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	if (metadata_find(mc, "private:close:closer"))
-	{
-		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, chan);
-		return;
-	}
-
 	if (!chanacs_source_has_flag(mc, si, CA_INVITE))
 	{
 		command_fail(si, fault_noprivs, STR_NOT_AUTHORIZED);
+		return;
+	}
+
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, chan);
 		return;
 	}
 

--- a/modules/chanserv/info.c
+++ b/modules/chanserv/info.c
@@ -44,18 +44,18 @@ cs_cmd_info(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	if (!has_priv(si, PRIV_CHAN_AUSPEX) && metadata_find(mc, "private:close:closer"))
-	{
-		command_fail(si, fault_noprivs, _("\2%s\2 has been closed down by the %s administration."), mc->name, me.netname);
-		return;
-	}
-
 	hide_info = (mc->flags & MC_PRIVATE) && !chanacs_source_has_flag(mc, si, CA_ACLVIEW) &&
 		!has_priv(si, PRIV_CHAN_AUSPEX);
 
 	hide_acl = !chanacs_source_has_flag(mc, si, CA_ACLVIEW) &&
 		!has_priv(si, PRIV_CHAN_AUSPEX) &&
 		!(mc->flags & MC_PUBACL);
+
+	if (!has_priv(si, PRIV_CHAN_AUSPEX) && metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, _("\2%s\2 has been closed down by the %s administration."), mc->name, me.netname);
+		return;
+	}
 
 	tm = localtime(&mc->registered);
 	strftime(strfbuf, sizeof strfbuf, TIME_FORMAT, tm);

--- a/modules/chanserv/invite.c
+++ b/modules/chanserv/invite.c
@@ -42,15 +42,15 @@ cs_cmd_invite(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	if (metadata_find(mc, "private:close:closer"))
-	{
-		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, chan);
-		return;
-	}
-
 	if (!chanacs_source_has_flag(mc, si, CA_INVITE))
 	{
 		command_fail(si, fault_noprivs, STR_NOT_AUTHORIZED);
+		return;
+	}
+
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, chan);
 		return;
 	}
 

--- a/modules/chanserv/kick.c
+++ b/modules/chanserv/kick.c
@@ -119,6 +119,12 @@ cs_cmd_kickban(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, chan);
+		return;
+	}
+
 	// figure out who we're going to kick
 	if ((tu = user_find_named(nick)) == NULL)
 	{

--- a/modules/chanserv/quiet.c
+++ b/modules/chanserv/quiet.c
@@ -405,6 +405,12 @@ cs_cmd_unquiet(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, channel);
+		return;
+	}
+
 	targetlist = sstrdup(target);
 	target = strtok_r(targetlist, " ", &strtokctx);
 	do

--- a/modules/chanserv/recover.c
+++ b/modules/chanserv/recover.c
@@ -36,15 +36,15 @@ cs_cmd_recover(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	if (metadata_find(mc, "private:close:closer"))
-	{
-		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, name);
-		return;
-	}
-
 	if (!chanacs_source_has_flag(mc, si, CA_RECOVER))
 	{
 		command_fail(si, fault_noprivs, STR_NOT_AUTHORIZED);
+		return;
+	}
+
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, name);
 		return;
 	}
 

--- a/modules/chanserv/set_email.c
+++ b/modules/chanserv/set_email.c
@@ -30,6 +30,12 @@ cs_cmd_set_email(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	if (!mail || !strcasecmp(mail, "NONE") || !strcasecmp(mail, "OFF"))
 	{
 		if (metadata_find(mc, "email"))

--- a/modules/chanserv/set_entrymsg.c
+++ b/modules/chanserv/set_entrymsg.c
@@ -31,6 +31,12 @@ cs_cmd_set_entrymsg(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	if (!parv[1] || !strcasecmp("OFF", parv[1]) || !strcasecmp("NONE", parv[1]))
 	{
 		/* entrymsg is private because users won't see it if they're AKICKED,

--- a/modules/chanserv/set_fantasy.c
+++ b/modules/chanserv/set_fantasy.c
@@ -35,6 +35,12 @@ cs_cmd_set_fantasy(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	if (!strcasecmp("ON", parv[1]))
 	{
 		struct metadata *md = metadata_find(mc, "disable_fantasy");

--- a/modules/chanserv/set_gameserv.c
+++ b/modules/chanserv/set_gameserv.c
@@ -37,6 +37,12 @@ cs_cmd_set_gameserv(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	if (!strcasecmp("ALL", parv[1]))
 		val = "ALL";
 	else if (!strcasecmp("VOICE", parv[1]) || !strcasecmp("VOICES", parv[1]))

--- a/modules/chanserv/set_guard.c
+++ b/modules/chanserv/set_guard.c
@@ -35,6 +35,12 @@ cs_cmd_set_guard(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	if (!strcasecmp("ON", parv[1]))
 	{
 		if (MC_GUARD & mc->flags)

--- a/modules/chanserv/set_keeptopic.c
+++ b/modules/chanserv/set_keeptopic.c
@@ -35,6 +35,12 @@ cs_cmd_set_keeptopic(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	if (!strcasecmp("ON", parv[1]))
 	{
 		if (MC_KEEPTOPIC & mc->flags)

--- a/modules/chanserv/set_limitflags.c
+++ b/modules/chanserv/set_limitflags.c
@@ -35,6 +35,12 @@ cs_cmd_set_limitflags(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	if (!strcasecmp("ON", parv[1]))
 	{
 		if (MC_LIMITFLAGS & mc->flags)

--- a/modules/chanserv/set_mlock.c
+++ b/modules/chanserv/set_mlock.c
@@ -57,6 +57,12 @@ cs_cmd_set_mlock(struct sourceinfo *si, int parc, char *parv[])
 
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	for (i = 0; i < ignore_mode_list_size; i++)
 	{
 		newlock_ext[i][0] = '\0';

--- a/modules/chanserv/set_prefix.c
+++ b/modules/chanserv/set_prefix.c
@@ -44,6 +44,12 @@ cs_cmd_set_prefix(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	if (!prefix || !strcasecmp(prefix, "DEFAULT"))
 	{
 		metadata_delete(mc, "private:prefix");

--- a/modules/chanserv/set_private.c
+++ b/modules/chanserv/set_private.c
@@ -35,6 +35,12 @@ cs_cmd_set_private(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	if (!strcasecmp("ON", parv[1]))
 	{
 		if (MC_PRIVATE & mc->flags)

--- a/modules/chanserv/set_property.c
+++ b/modules/chanserv/set_property.c
@@ -47,6 +47,12 @@ cs_cmd_set_property(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	if (strchr(property, ':'))
 		logcommand(si, CMDLOG_SET, "SET:PROPERTY: \2%s\2: \2%s\2/\2%s\2", mc->name, property, value);
 

--- a/modules/chanserv/set_pubacl.c
+++ b/modules/chanserv/set_pubacl.c
@@ -35,6 +35,12 @@ cs_cmd_set_pubacl(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	if (!strcasecmp("ON", parv[1]))
 	{
 		if (MC_PUBACL & mc->flags)

--- a/modules/chanserv/set_restricted.c
+++ b/modules/chanserv/set_restricted.c
@@ -81,6 +81,12 @@ cs_cmd_set_restricted(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	if (!strcasecmp("ON", parv[1]))
 	{
 		if (MC_RESTRICTED & mc->flags)

--- a/modules/chanserv/set_secure.c
+++ b/modules/chanserv/set_secure.c
@@ -35,6 +35,12 @@ cs_cmd_set_secure(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	if (!strcasecmp("ON", parv[1]))
 	{
 		if (MC_SECURE & mc->flags)

--- a/modules/chanserv/set_topiclock.c
+++ b/modules/chanserv/set_topiclock.c
@@ -35,6 +35,12 @@ cs_cmd_set_topiclock(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	if (!strcasecmp("ON", parv[1]))
 	{
 		if (MC_TOPICLOCK & mc->flags)

--- a/modules/chanserv/set_url.c
+++ b/modules/chanserv/set_url.c
@@ -30,6 +30,12 @@ cs_cmd_set_url(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	if (!url || !strcasecmp("OFF", url) || !strcasecmp("NONE", url))
 	{
 		/* not in a namespace to allow more natural use of SET PROPERTY.

--- a/modules/chanserv/set_verbose.c
+++ b/modules/chanserv/set_verbose.c
@@ -35,6 +35,12 @@ cs_cmd_set_verbose(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	if (!strcasecmp("ON", parv[1]) || !strcasecmp("ALL", parv[1]))
 	{
 		if (MC_VERBOSE & mc->flags)

--- a/modules/chanserv/sync.c
+++ b/modules/chanserv/sync.c
@@ -192,6 +192,12 @@ cs_cmd_set_nosync(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, parv[0]);
+		return;
+	}
+
 	if (!strcasecmp("ON", parv[1]))
 	{
 		if (MC_NOSYNC & mc->flags)

--- a/modules/chanserv/sync.c
+++ b/modules/chanserv/sync.c
@@ -143,6 +143,12 @@ cs_cmd_sync(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (!chanacs_source_has_flag(mc, si, CA_RECOVER))
+	{
+		command_fail(si, fault_noprivs, STR_NOT_AUTHORIZED);
+		return;
+	}
+
 	if (metadata_find(mc, "private:close:closer"))
 	{
 		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, name);
@@ -152,12 +158,6 @@ cs_cmd_sync(struct sourceinfo *si, int parc, char *parv[])
 	if (!mc->chan)
 	{
 		command_fail(si, fault_nosuch_target, STR_CHANNEL_IS_EMPTY, name);
-		return;
-	}
-
-	if (!chanacs_source_has_flag(mc, si, CA_RECOVER))
-	{
-		command_fail(si, fault_noprivs, STR_NOT_AUTHORIZED);
 		return;
 	}
 

--- a/modules/chanserv/taxonomy.c
+++ b/modules/chanserv/taxonomy.c
@@ -40,6 +40,12 @@ cs_cmd_taxonomy(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, target);
+		return;
+	}
+
 	if (isoper)
 		logcommand(si, CMDLOG_ADMIN, "TAXONOMY: \2%s\2 (oper)", mc->name);
 	else

--- a/modules/chanserv/topic.c
+++ b/modules/chanserv/topic.c
@@ -33,12 +33,11 @@ cs_cmd_topic(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	c = channel_find(chan);
-	if (!c)
+	if (!chanacs_source_has_flag(mc, si, CA_TOPIC))
 	{
-                command_fail(si, fault_nosuch_target, STR_CHANNEL_IS_EMPTY, chan);
-                return;
-        }
+		command_fail(si, fault_noprivs, STR_NOT_AUTHORIZED);
+		return;
+	}
 
 	if (metadata_find(mc, "private:close:closer"))
 	{
@@ -46,11 +45,12 @@ cs_cmd_topic(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	if (!chanacs_source_has_flag(mc, si, CA_TOPIC))
+	c = channel_find(chan);
+	if (!c)
 	{
-		command_fail(si, fault_noprivs, STR_NOT_AUTHORIZED);
-		return;
-	}
+                command_fail(si, fault_nosuch_target, STR_CHANNEL_IS_EMPTY, chan);
+                return;
+        }
 
 	if (!validtopic(topic))
 	{

--- a/modules/chanserv/unban_self.c
+++ b/modules/chanserv/unban_self.c
@@ -49,12 +49,6 @@ cs_cmd_unban(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	if (!c)
-	{
-		command_fail(si, fault_nosuch_target, STR_CHANNEL_IS_EMPTY, channel);
-		return;
-	}
-
 	if (!si->smu)
 	{
 		command_fail(si, fault_noprivs, STR_NOT_LOGGED_IN);
@@ -71,6 +65,12 @@ cs_cmd_unban(struct sourceinfo *si, int parc, char *parv[])
 	if (metadata_find(mc, "private:close:closer"))
 	{
 		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, channel);
+		return;
+	}
+
+	if (!c)
+	{
+		command_fail(si, fault_nosuch_target, STR_CHANNEL_IS_EMPTY, channel);
 		return;
 	}
 

--- a/modules/chanserv/unban_self.c
+++ b/modules/chanserv/unban_self.c
@@ -68,6 +68,12 @@ cs_cmd_unban(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, channel);
+		return;
+	}
+
 	tu = si->su;
 	{
 		mowgli_node_t *n, *tn;

--- a/modules/chanserv/xop.c
+++ b/modules/chanserv/xop.c
@@ -422,15 +422,15 @@ cs_cmd_forcexop(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	if (metadata_find(mc, "private:close:closer"))
-	{
-		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, chan);
-		return;
-	}
-
 	if (!is_founder(mc, entity(si->smu)))
 	{
 		command_fail(si, fault_noprivs, STR_NOT_AUTHORIZED);
+		return;
+	}
+
+	if (metadata_find(mc, "private:close:closer"))
+	{
+		command_fail(si, fault_noprivs, STR_CHANNEL_IS_CLOSED, chan);
 		return;
 	}
 


### PR DESCRIPTION
ChanServ `SET MLOCK` and `UNBAN` work on closed channels. Add the channel closed check to those commands and the rest of the commands missing the check, `ACCESS` could probably also use a check, but it's not as clear where that should go.