### PR TITLE
Fix password overflow error message to mention bytes instead of characters

### DIFF
--- a/modules/nickserv/register.c
+++ b/modules/nickserv/register.c
@@ -60,7 +60,7 @@ ns_cmd_register(struct sourceinfo *si, int parc, char *parv[])
 	if (strlen(pass) > PASSLEN)
 	{
 		command_fail(si, fault_badparams, STR_INVALID_PARAMS, "REGISTER");
-		command_fail(si, fault_badparams, _("Registration passwords may not be longer than \2%u\2 characters."), PASSLEN);
+		command_fail(si, fault_badparams, _("Registration passwords may not be longer than \2%u\2 bytes."), PASSLEN);
 		return;
 	}
 

--- a/modules/nickserv/set_password.c
+++ b/modules/nickserv/set_password.c
@@ -33,7 +33,7 @@ ns_cmd_set_password(struct sourceinfo *si, int parc, char *parv[])
 	if (strlen(password) > PASSLEN)
 	{
 		command_fail(si, fault_badparams, STR_INVALID_PARAMS, "SET PASSWORD");
-		command_fail(si, fault_badparams, _("Registration passwords may not be longer than \2%u\2 characters."), PASSLEN);
+		command_fail(si, fault_badparams, _("Registration passwords may not be longer than \2%u\2 bytes."), PASSLEN);
 		return;
 	}
 

--- a/modules/nickserv/setpass.c
+++ b/modules/nickserv/setpass.c
@@ -47,7 +47,7 @@ ns_cmd_setpass(struct sourceinfo *si, int parc, char *parv[])
 	if (strlen(password) > PASSLEN)
 	{
 		command_fail(si, fault_badparams, STR_INVALID_PARAMS, "SETPASS");
-		command_fail(si, fault_badparams, _("Registration passwords may not be longer than \2%u\2 characters."), PASSLEN);
+		command_fail(si, fault_badparams, _("Registration passwords may not be longer than \2%u\2 bytes."), PASSLEN);
 		return;
 	}
 


### PR DESCRIPTION
For example, when using this 150-characters password:

```
C -> S: PRIVMSG NickServ :REGISTER éééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééééé foo@example.org
S -> C: :nickserv!nickserv@services.int NOTICE foo :Invalid parameters for REGISTER.
S -> C: :nickserv!nickserv@services.int NOTICE foo :Registration passwords may not be longer than 288 characters.
```

(Same bug on Anope: https://github.com/anope/anope/pull/275 ^^)