### PR TITLE
add hooks for adding and removing a certificate fingerprint

### DIFF
--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -242,7 +242,7 @@ struct hook_user_certfp
 {
 	struct sourceinfo * si;
 	struct myuser *     mu;
-	const char *        certfp;
+	char                certfp[512];
 };
 
 void hook_del_hook(const char *, hook_fn);

--- a/include/atheme/hook.h
+++ b/include/atheme/hook.h
@@ -238,6 +238,13 @@ struct hook_user_req
 	struct mynick *     mn;
 };
 
+struct hook_user_certfp
+{
+	struct sourceinfo * si;
+	struct myuser *     mu;
+	const char *        certfp;
+};
+
 void hook_del_hook(const char *, hook_fn);
 void hook_add_hook(const char *, hook_fn);
 void hook_add_hook_first(const char *, hook_fn);

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -93,6 +93,8 @@ user_needforce                  struct hook_user_needforce *
 user_register                   struct myuser *
 user_rename                     struct hook_user_rename *
 user_sethost                    struct user *
+user_certfp_add                 struct hook_user_certfp *
+user_certfp_del                 struct hook_user_certfp *
 user_verify_register            struct hook_user_req *
 
 # (sasl)

--- a/include/atheme/hooktypes.in
+++ b/include/atheme/hooktypes.in
@@ -84,6 +84,8 @@ user_can_login                  struct hook_user_login_check *
 user_can_logout                 struct hook_user_logout_check *
 user_can_register               struct hook_user_register_check *
 user_can_rename                 struct hook_user_rename_check *
+user_certfp_add                 struct hook_user_certfp *
+user_certfp_del                 struct hook_user_certfp *
 user_check_expire               struct hook_expiry_req *
 user_drop                       struct myuser *
 user_identify                   struct user *
@@ -93,8 +95,6 @@ user_needforce                  struct hook_user_needforce *
 user_register                   struct myuser *
 user_rename                     struct hook_user_rename *
 user_sethost                    struct user *
-user_certfp_add                 struct hook_user_certfp *
-user_certfp_del                 struct hook_user_certfp *
 user_verify_register            struct hook_user_req *
 
 # (sasl)

--- a/modules/nickserv/cert.c
+++ b/modules/nickserv/cert.c
@@ -134,7 +134,7 @@ ns_cmd_cert(struct sourceinfo *si, int parc, char *parv[])
 
 		struct hook_user_certfp hdata = {
 			.si = si,
-			.mu = mu
+			.mu = mu,
 		};
 		mowgli_strlcpy(hdata.certfp, mcfp, sizeof hdata.certfp);
 		hook_call_user_certfp_add(&hdata);
@@ -178,7 +178,7 @@ ns_cmd_cert(struct sourceinfo *si, int parc, char *parv[])
 
 		struct hook_user_certfp hdata = {
 			.si = si,
-			.mu = mu
+			.mu = mu,
 		};
 		mowgli_strlcpy(hdata.certfp, parv[1], sizeof hdata.certfp);
 		hook_call_user_certfp_del(&hdata);

--- a/modules/nickserv/cert.c
+++ b/modules/nickserv/cert.c
@@ -147,6 +147,13 @@ ns_cmd_cert(struct sourceinfo *si, int parc, char *parv[])
 		}
 		if (mycertfp_add(mu, mcfp, false))
 		{
+			struct hook_user_certfp hdata = {
+				.si     = si,
+				.mu     = mu,
+				.certfp = mcfp
+			};
+			hook_call_user_certfp_add(&hdata);
+
 			command_success_nodata(si, _("Added fingerprint \2%s\2 to your fingerprint list."), mcfp);
 			logcommand(si, CMDLOG_SET, "CERT:ADD: \2%s\2", mcfp);
 		}
@@ -173,6 +180,14 @@ ns_cmd_cert(struct sourceinfo *si, int parc, char *parv[])
 			command_fail(si, fault_nochange, _("Fingerprint \2%s\2 is not on your fingerprint list."), parv[1]);
 			return;
 		}
+
+		struct hook_user_certfp hdata = {
+			.si     = si,
+			.mu     = mu,
+			.certfp = mcfp
+		};
+		hook_call_user_certfp_del(&hdata);
+
 		command_success_nodata(si, _("Deleted fingerprint \2%s\2 from your fingerprint list."), parv[1]);
 		logcommand(si, CMDLOG_SET, "CERT:DEL: \2%s\2", parv[1]);
 		mycertfp_delete(cert);

--- a/modules/nickserv/cert.c
+++ b/modules/nickserv/cert.c
@@ -181,7 +181,7 @@ ns_cmd_cert(struct sourceinfo *si, int parc, char *parv[])
 			.mu = mu
 		};
 		mowgli_strlcpy(hdata.certfp, parv[1], sizeof hdata.certfp);
-		hook_call_user_certfp_add(&hdata);
+		hook_call_user_certfp_del(&hdata);
 
 		cert = mycertfp_find(hdata.certfp);
 		if (cert == NULL || cert->mu != mu)

--- a/modules/nickserv/cert.c
+++ b/modules/nickserv/cert.c
@@ -183,15 +183,18 @@ ns_cmd_cert(struct sourceinfo *si, int parc, char *parv[])
 		mowgli_strlcpy(hdata.certfp, parv[1], sizeof hdata.certfp);
 		hook_call_user_certfp_del(&hdata);
 
-		cert = mycertfp_find(hdata.certfp);
+		cert = mycertfp_find(parv[1]);
+		if (cert == NULL && strcasecmp(parv[1], hdata.certfp))
+			cert = mycertfp_find(hdata.certfp);
+
 		if (cert == NULL || cert->mu != mu)
 		{
-			command_fail(si, fault_nochange, _("Fingerprint \2%s\2 is not on your fingerprint list."), hdata.certfp);
+			command_fail(si, fault_nochange, _("Fingerprint \2%s\2 is not on your fingerprint list."), parv[1]);
 			return;
 		}
 
-		command_success_nodata(si, _("Deleted fingerprint \2%s\2 from your fingerprint list."), hdata.certfp);
-		logcommand(si, CMDLOG_SET, "CERT:DEL: \2%s\2", hdata.certfp);
+		command_success_nodata(si, _("Deleted fingerprint \2%s\2 from your fingerprint list."), cert->certfp);
+		logcommand(si, CMDLOG_SET, "CERT:DEL: \2%s\2", cert->certfp);
 		mycertfp_delete(cert);
 	}
 	else

--- a/modules/nickserv/cert.c
+++ b/modules/nickserv/cert.c
@@ -139,6 +139,9 @@ ns_cmd_cert(struct sourceinfo *si, int parc, char *parv[])
 		mowgli_strlcpy(hdata.certfp, mcfp, sizeof hdata.certfp);
 		hook_call_user_certfp_add(&hdata);
 
+		if (!hdata.certfp[0])
+			return;
+
 		cert = mycertfp_find(hdata.certfp);
 		if (cert == NULL)
 			;

--- a/modules/nickserv/cert.c
+++ b/modules/nickserv/cert.c
@@ -132,30 +132,31 @@ ns_cmd_cert(struct sourceinfo *si, int parc, char *parv[])
 			return;
 		}
 
-		cert = mycertfp_find(mcfp);
+		struct hook_user_certfp hdata = {
+			.si = si,
+			.mu = mu
+		};
+		mowgli_strlcpy(hdata.certfp, mcfp, sizeof hdata.certfp);
+		hook_call_user_certfp_add(&hdata);
+
+		cert = mycertfp_find(hdata.certfp);
 		if (cert == NULL)
 			;
 		else if (cert->mu == mu)
 		{
-			command_fail(si, fault_nochange, _("Fingerprint \2%s\2 is already on your fingerprint list."), mcfp);
+			command_fail(si, fault_nochange, _("Fingerprint \2%s\2 is already on your fingerprint list."), hdata.certfp);
 			return;
 		}
 		else
 		{
-			command_fail(si, fault_nochange, _("Fingerprint \2%s\2 is already on another user's fingerprint list."), mcfp);
+			command_fail(si, fault_nochange, _("Fingerprint \2%s\2 is already on another user's fingerprint list."), hdata.certfp);
 			return;
 		}
-		if (mycertfp_add(mu, mcfp, false))
-		{
-			struct hook_user_certfp hdata = {
-				.si     = si,
-				.mu     = mu,
-				.certfp = mcfp
-			};
-			hook_call_user_certfp_add(&hdata);
 
-			command_success_nodata(si, _("Added fingerprint \2%s\2 to your fingerprint list."), mcfp);
-			logcommand(si, CMDLOG_SET, "CERT:ADD: \2%s\2", mcfp);
+		if (mycertfp_add(mu, hdata.certfp, false))
+		{
+			command_success_nodata(si, _("Added fingerprint \2%s\2 to your fingerprint list."), hdata.certfp);
+			logcommand(si, CMDLOG_SET, "CERT:ADD: \2%s\2", hdata.certfp);
 		}
 		else
 			command_fail(si, fault_toomany, _("Your fingerprint list is full."));
@@ -174,22 +175,23 @@ ns_cmd_cert(struct sourceinfo *si, int parc, char *parv[])
 			command_fail(si, fault_noprivs, STR_NOT_LOGGED_IN);
 			return;
 		}
-		cert = mycertfp_find(parv[1]);
+
+		struct hook_user_certfp hdata = {
+			.si = si,
+			.mu = mu
+		};
+		mowgli_strlcpy(hdata.certfp, parv[1], sizeof hdata.certfp);
+		hook_call_user_certfp_add(&hdata);
+
+		cert = mycertfp_find(hdata.certfp);
 		if (cert == NULL || cert->mu != mu)
 		{
-			command_fail(si, fault_nochange, _("Fingerprint \2%s\2 is not on your fingerprint list."), parv[1]);
+			command_fail(si, fault_nochange, _("Fingerprint \2%s\2 is not on your fingerprint list."), hdata.certfp);
 			return;
 		}
 
-		struct hook_user_certfp hdata = {
-			.si     = si,
-			.mu     = mu,
-			.certfp = mcfp
-		};
-		hook_call_user_certfp_del(&hdata);
-
-		command_success_nodata(si, _("Deleted fingerprint \2%s\2 from your fingerprint list."), parv[1]);
-		logcommand(si, CMDLOG_SET, "CERT:DEL: \2%s\2", parv[1]);
+		command_success_nodata(si, _("Deleted fingerprint \2%s\2 from your fingerprint list."), hdata.certfp);
+		logcommand(si, CMDLOG_SET, "CERT:DEL: \2%s\2", hdata.certfp);
 		mycertfp_delete(cert);
 	}
 	else


### PR DESCRIPTION
this is to support a module that will warn users when they add a certificate fingerprint that doesn't look like what we're expecting, i.e.:

```
<jess> cert add f10e2821bbbea527ea02200352313bc059445190
-NickServ- Warning: fingerprint of unexpected length. Expected hash algorithm: SHA512.
-NickServ- Added fingerprint f10e2821bbbea527ea02200352313bc059445190 to your fingerprint list.
```