### PR TITLE
atheme_main: rehash if necessary after DB load

### DIFF
--- a/libathemecore/atheme.c
+++ b/libathemecore/atheme.c
@@ -563,6 +563,9 @@ atheme_main(int argc, char *argv[])
 		return 0;
 	}
 
+	if (conf_need_rehash)
+		conf_rehash();
+
 #ifdef HAVE_GETPID
 	/* write pid */
 	if ((pid_file = fopen(pidfilename, "w")))


### PR DESCRIPTION
Avoids an issue where a DB module dependency loads a service which then doesn't get configured properly.