### PR TITLE
Add protocol support for AspIRCd 3 & AspIRCd 4

### DIFF
--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -109,6 +109,7 @@
  * modules available.
  *
  * AspIRCd 3.0.1 or later                       protocol/aspircd
+ * AspIRCd 4.0.1 or later                       protocol/aspircd
  * Asuka 1.2.1 or later                         protocol/asuka
  * Bahamut 2.1.x                                protocol/bahamut
  * Charybdis IRCd                               protocol/charybdis
@@ -126,7 +127,7 @@
  * If your IRCd vendor has supplied a module file, build it and load it here
  * instead of one above.
  */
-#loadmodule "protocol/charybdis";
+#loadmodule "protocol/aspircd";
 
 /* Protocol mixins.
  *
@@ -290,7 +291,7 @@ loadmodule "crypto/pbkdf2";             /* Verify-only, see prev. */
  * synchronous manner, which means that an unresponsive LDAP server can
  * freeze services.
  */
-#loadmodule "auth/ldap";
+loadmodule "auth/ldap";
 
 
 

--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -108,6 +108,7 @@
  * Below is a listing of IRCds known to work with the various protocol
  * modules available.
  *
+ * AspIRCd 3.0.1 or later                       protocol/aspircd
  * Asuka 1.2.1 or later                         protocol/asuka
  * Bahamut 2.1.x                                protocol/bahamut
  * Charybdis IRCd                               protocol/charybdis

--- a/modules/protocol/Makefile
+++ b/modules/protocol/Makefile
@@ -17,6 +17,7 @@ include ../../extra.mk
 
 MODULE = protocol
 SRCS   =                    \
+    aspircd.c               \
     asuka.c                 \
     bahamut.c               \
     base36uid.c             \

--- a/modules/protocol/aspircd.c
+++ b/modules/protocol/aspircd.c
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 2003-2004 E. Will et al.
+ * Copyright (c) 2005-2007 Atheme Development Group
+ * Rights to this code are documented in doc/LICENSE.
+ *
+ * This file contains protocol support for AspIRCd 3 and AspIRCd 4.
+ * 
+ */
+
+#include "atheme.h"
+#include "uplink.h"
+#include "pmodule.h"
+#include "protocol/elemental-ircd.h"
+
+DECLARE_MODULE_V1("protocol/aspircd", true, _modinit, NULL, PACKAGE_STRING, "Protocol for AspIRCd 3 and AspIRCd 4 https://github.com/aspircd/aspircd");
+
+ircd_t aspircd = {
+	.ircdname = "aspircd",
+	.tldprefix = "$$",
+	.uses_uid = true,
+	.uses_rcommand = false,
+	.uses_owner = true,
+	.uses_protect = true,
+	.uses_halfops = true,
+	.uses_p10 = false,
+	.uses_vhost = false,
+	.oper_only_modes = CMODE_EXLIMIT | CMODE_PERM | CMODE_IMMUNE,
+	.owner_mode = 0,
+	.protect_mode = 0,
+	.halfops_mode = 0,
+	.owner_mchar = "+q",
+	.protect_mchar = "+a",
+	.halfops_mchar = "+h",
+	.type = PROTOCOL_CHARYBDIS,
+	.perm_mode = CMODE_CHANREG,
+	.oimmune_mode = CMODE_IMMUNE,
+	.ban_like_modes = "beIM",
+	.except_mchar = 'e',
+	.invex_mchar = 'I',
+	.flags = IRCD_CIDR_BANS | IRCD_HOLDNICK | IRCD_TOPIC_NOCOLOUR,
+};
+
+struct cmode_ aspircd_mode_list[] = {
+  { 'i', CMODE_INVITE },
+  { 'm', CMODE_MOD    },
+  { 'n', CMODE_NOEXT  },
+  { 'p', CMODE_PRIV   },
+  { 'r', CMODE_CHANREG},
+  { 's', CMODE_SEC    },
+  { 't', CMODE_TOPIC  },
+  { 'c', CMODE_NOCOLOR},
+  { 'R', CMODE_REGONLY},
+  { 'z', CMODE_OPMOD  },
+  { 'g', CMODE_FINVITE},
+  { 'L', CMODE_EXLIMIT},
+  { 'P', CMODE_PERM   },
+  { 'F', CMODE_FTARGET},
+  { 'Q', CMODE_DISFWD },
+  { 'M', CMODE_IMMUNE },
+  { 'T', CMODE_NONOTICE},
+  { 'C', CMODE_NOCTCP },
+  { 'D', CMODE_NOREPEAT },
+  /* following modes are added as extensions */
+  { 'S', CMODE_SSLONLY	 },
+  { 'O', CMODE_OPERONLY  },
+  { 'A', CMODE_ADMINONLY },
+
+  { '\0', 0 }
+};
+
+struct cmode_ aspircd_status_mode_list[] = {
+  { 'y', CSTATUS_IMMUNE	 },
+  { 'q', CSTATUS_OWNER	 },
+  { 'a', CSTATUS_PROTECT },
+  { 'o', CSTATUS_OP	 },
+  { 'h', CSTATUS_HALFOP  },
+  { 'v', CSTATUS_VOICE	 },
+  { '\0', 0 }
+};
+
+struct cmode_ aspircd_prefix_mode_list[] = {
+  { '*', CSTATUS_IMMUNE	 },
+  { '~', CSTATUS_OWNER	 },
+  { '&', CSTATUS_PROTECT },
+  { '@', CSTATUS_OP	 },
+  { '%', CSTATUS_HALFOP  },
+  { '+', CSTATUS_VOICE	 },
+  { '\0', 0 }
+};
+
+
+struct cmode_ aspircd_user_mode_list[] = {
+  { 'p', UF_IMMUNE   },
+  { 'a', UF_ADMIN    },
+  { 'i', UF_INVIS    },
+  { 'o', UF_IRCOP    },
+  { 'D', UF_DEAF     },
+  { 'S', UF_SERVICE  },
+  { '\0', 0 }
+};
+
+/* *INDENT-ON* */
+
+static bool aspircd_is_valid_hostslash(const char *host)
+{
+	const char *p;
+	bool dot = false;
+
+	if (*host == '.' || *host == '/' || *host == ':')
+		return false;
+
+	for (p = host; *p != '\0'; p++)
+	{
+		if (*p == '.' || *p == ':' || *p == '/')
+			dot = true;
+		else if (!((*p >= '0' && *p <= '9') || (*p >= 'A' && *p <= 'Z') ||
+					(*p >= 'a' && *p <= 'z') || *p == '-'))
+			return false;
+	}
+	/* hyperion allows a trailing / but RichiH does not want it, whatever */
+	if (dot && p[-1] == '/')
+		return false;
+	return dot;
+}
+
+static void aspircd_wallops_sts(const char *reason)
+{
+	sts(":%s ENCAP * SNOTE s :%s", ME, reason);
+}
+
+/* The following m_functions are copied from generic_ts6, with additions to handle the
+ * "identified" / "owns this nick" flag.
+ */
+
+static void m_euid(sourceinfo_t *si, int parc, char *parv[])
+{
+	server_t *s;
+	user_t *u;
+
+	/* got the right number of args for an introduction? */
+	if (parc >= 11)
+	{
+		s = si->s;
+		slog(LG_DEBUG, "m_euid(): new user on `%s': %s", s->name, parv[0]);
+
+		u = user_add(parv[0],				/* nick */
+			parv[4],				/* user */
+			*parv[8] != '*' ? parv[8] : parv[5],	/* hostname */
+			parv[5],				/* hostname (visible) */
+			parv[6],				/* ip */
+			parv[7],				/* uid */
+			parv[parc - 1],				/* gecos */
+			s,					/* object parent (server) */
+			atoi(parv[2]));				/* hopcount */
+		if (u == NULL)
+			return;
+
+		user_mode(u, parv[3]);
+		if (*parv[9] != '*')
+		{
+			handle_burstlogin(u, parv[9], 0);
+			/* If an account is given in burst, then either they logged in with sasl,
+			 * or they logged in before a split and are now returning. Either way we need
+			 * to check for identified-to-nick status and update the ircd state accordingly.
+			 * For sasl they should be marked identified, and when returning from a split
+			 * their nick may have been ungrouped, they may have changed nicks, or their account
+			 * may have been dropped.
+			 */
+			if (authservice_loaded)
+				sts(":%s ENCAP * IDENTIFIED %s %s %s", ME, CLIENT_NAME(u), u->nick,
+						should_reg_umode(u) ? "" : "OFF");
+		}
+
+		/* server_eob() cannot know if a user was introduced
+		 * with NICK/UID or EUID and handle_nickchange() must
+		 * be called exactly once for each new user -- jilles */
+		if (s->flags & SF_EOB)
+			handle_nickchange(u);
+	}
+	else
+	{
+		int i;
+		slog(LG_DEBUG, "m_euid(): got EUID with wrong number of params");
+
+		for (i = 0; i < parc; i++)
+			slog(LG_DEBUG, "m_euid():   parv[%d] = %s", i, parv[i]);
+	}
+}
+
+static void m_nick(sourceinfo_t *si, int parc, char *parv[])
+{
+	server_t *s;
+	user_t *u;
+
+	/* got the right number of args for an introduction? */
+	if (parc == 8)
+	{
+		s = server_find(parv[6]);
+		if (!s)
+		{
+			slog(LG_DEBUG, "m_nick(): new user on nonexistant server: %s", parv[6]);
+			return;
+		}
+
+		slog(LG_DEBUG, "m_nick(): new user on `%s': %s", s->name, parv[0]);
+
+		u = user_add(parv[0], parv[4], parv[5], NULL, NULL, NULL, parv[7], s, atoi(parv[2]));
+		if (u == NULL)
+			return;
+
+		user_mode(u, parv[3]);
+
+		/* If server is not yet EOB we will do this later.
+		 * This avoids useless "please identify" -- jilles */
+		if (s->flags & SF_EOB)
+			handle_nickchange(user_find(parv[0]));
+	}
+
+	/* if it's only 2 then it's a nickname change */
+	else if (parc == 2)
+	{
+		bool realchange;
+
+		if (!si->su)
+		{
+			slog(LG_DEBUG, "m_nick(): server trying to change nick: %s", si->s != NULL ? si->s->name : "<none>");
+			return;
+		}
+
+		slog(LG_DEBUG, "m_nick(): nickname change from `%s': %s", si->su->nick, parv[0]);
+
+		realchange = irccasecmp(si->su->nick, parv[0]);
+
+		if (user_changenick(si->su, parv[0], atoi(parv[1])))
+			return;
+
+		/* fix up +e if necessary -- jilles */
+		if (realchange && should_reg_umode(si->su))
+			/* changed nick to registered one, reset +e */
+			sts(":%s ENCAP * IDENTIFIED %s %s", ME, CLIENT_NAME(si->su), si->su->nick);
+
+		/* It could happen that our PING arrived late and the
+		 * server didn't acknowledge EOB yet even though it is
+		 * EOB; don't send double notices in that case -- jilles */
+		if (si->su->server->flags & SF_EOB)
+			handle_nickchange(si->su);
+	}
+	else
+	{
+		int i;
+		slog(LG_DEBUG, "m_nick(): got NICK with wrong number of params");
+
+		for (i = 0; i < parc; i++)
+			slog(LG_DEBUG, "m_nick():   parv[%d] = %s", i, parv[i]);
+	}
+}
+
+/* protocol-specific stuff to do on login */
+static void aspircd_on_login(user_t *u, myuser_t *mu, const char *wantedhost)
+{
+	return_if_fail(u != NULL);
+
+	sts(":%s ENCAP * SU %s %s", ME, CLIENT_NAME(u), entity(mu)->name);
+
+	if (should_reg_umode(u))
+		sts(":%s ENCAP * IDENTIFIED %s %s", ME, CLIENT_NAME(u), u->nick);
+}
+
+static bool aspircd_on_logout(user_t *u, const char *account)
+{
+	return_val_if_fail(u != NULL, false);
+
+	sts(":%s ENCAP * SU %s", ME, CLIENT_NAME(u));
+	sts(":%s ENCAP * IDENTIFIED %s %s OFF", ME, CLIENT_NAME(u), u->nick);
+	return false;
+}
+
+static void nick_group(hook_user_req_t *hdata)
+{
+	user_t *u;
+
+	u = hdata->si->su != NULL && !irccasecmp(hdata->si->su->nick, hdata->mn->nick) ? hdata->si->su : user_find_named(hdata->mn->nick);
+	if (u != NULL && should_reg_umode(u))
+		sts(":%s ENCAP * IDENTIFIED %s %s", ME, CLIENT_NAME(u), u->nick);
+}
+
+static void nick_ungroup(hook_user_req_t *hdata)
+{
+	user_t *u;
+
+	u = hdata->si->su != NULL && !irccasecmp(hdata->si->su->nick, hdata->mn->nick) ? hdata->si->su : user_find_named(hdata->mn->nick);
+	if (u != NULL && !nicksvs.no_nick_ownership)
+		sts(":%s ENCAP * IDENTIFIED %s %s OFF", ME, CLIENT_NAME(u), u->nick);
+}
+
+void _modinit(module_t * m)
+{
+	MODULE_TRY_REQUEST_DEPENDENCY(m, "protocol/charybdis");
+
+	mode_list = aspircd_mode_list;
+	user_mode_list = aspircd_user_mode_list;
+	status_mode_list = aspircd_status_mode_list;
+	prefix_mode_list = aspircd_prefix_mode_list;
+
+	wallops_sts = &aspircd_wallops_sts;
+	ircd_on_login = &aspircd_on_login;
+	ircd_on_logout = &aspircd_on_logout;
+	is_valid_host = &aspircd_is_valid_hostslash;
+
+	pcommand_delete("NICK");
+	pcommand_add("NICK", m_nick, 2, MSRC_USER | MSRC_SERVER);
+	pcommand_delete("EUID");
+	pcommand_add("EUID", m_euid, 11, MSRC_SERVER);
+
+	ircd = &aspircd;
+
+	hook_add_event("nick_group");
+	hook_add_nick_group(nick_group);
+	hook_add_event("nick_ungroup");
+	hook_add_nick_ungroup(nick_ungroup);
+
+	m->mflags = MODTYPE_CORE;
+
+	pmodule_loaded = true;
+}

--- a/modules/protocol/aspircd.c
+++ b/modules/protocol/aspircd.c
@@ -12,9 +12,7 @@
 #include "atheme.h"
 #include "protocol/elemental-ircd.h"
 
-SIMPLE_DECLARE_MODULE_V1("protocol/aspircd", MODULE_UNLOAD_CAPABILITY_NEVER)
-
-ircd_t aspircd = {
+static struct ircd aspircd = {
 	.ircdname = "aspircd",
 	.tldprefix = "$$",
 	.uses_uid = true,
@@ -37,10 +35,10 @@ ircd_t aspircd = {
 	.ban_like_modes = "beIM",
 	.except_mchar = 'e',
 	.invex_mchar = 'I',
-	.flags = IRCD_CIDR_BANS | IRCD_HOLDNICK | IRCD_TOPIC_NOCOLOUR,
+	.flags = IRCD_CIDR_BANS | IRCD_HOLDNICK,
 };
 
-struct cmode_ aspircd_mode_list[] = {
+static const struct cmode aspircd_mode_list[] = {
   { 'i', CMODE_INVITE },
   { 'm', CMODE_MOD    },
   { 'n', CMODE_NOEXT  },
@@ -68,7 +66,7 @@ struct cmode_ aspircd_mode_list[] = {
   { '\0', 0 }
 };
 
-struct cmode_ aspircd_status_mode_list[] = {
+static const struct cmode aspircd_status_mode_list[] = {
   { 'y', CSTATUS_IMMUNE	 },
   { 'q', CSTATUS_OWNER	 },
   { 'a', CSTATUS_PROTECT },
@@ -78,7 +76,7 @@ struct cmode_ aspircd_status_mode_list[] = {
   { '\0', 0 }
 };
 
-struct cmode_ aspircd_prefix_mode_list[] = {
+static const struct cmode aspircd_prefix_mode_list[] = {
   { '*', CSTATUS_IMMUNE	 },
   { '~', CSTATUS_OWNER	 },
   { '&', CSTATUS_PROTECT },
@@ -89,7 +87,7 @@ struct cmode_ aspircd_prefix_mode_list[] = {
 };
 
 
-struct cmode_ aspircd_user_mode_list[] = {
+static const struct cmode aspircd_user_mode_list[] = {
   { 'p', UF_IMMUNE   },
   { 'a', UF_ADMIN    },
   { 'i', UF_INVIS    },
@@ -117,3 +115,5 @@ mod_deinit(const enum module_unload_intent ATHEME_VATTR_UNUSED intent)
 {
 
 }
+
+SIMPLE_DECLARE_MODULE_V1("protocol/aspircd", MODULE_UNLOAD_CAPABILITY_NEVER)

--- a/modules/protocol/aspircd.c
+++ b/modules/protocol/aspircd.c
@@ -10,11 +10,9 @@
  */
 
 #include "atheme.h"
-#include "uplink.h"
-#include "pmodule.h"
 #include "protocol/elemental-ircd.h"
 
-DECLARE_MODULE_V1("protocol/aspircd", true, _modinit, NULL, PACKAGE_STRING, "Protocol for AspIRCd 3 and AspIRCd 4 https://github.com/aspircd/aspircd");
+SIMPLE_DECLARE_MODULE_V1("protocol/aspircd", MODULE_UNLOAD_CAPABILITY_NEVER)
 
 ircd_t aspircd = {
 	.ircdname = "aspircd",
@@ -101,201 +99,8 @@ struct cmode_ aspircd_user_mode_list[] = {
   { '\0', 0 }
 };
 
-/* *INDENT-ON* */
-
-static bool aspircd_is_valid_hostslash(const char *host)
-{
-	const char *p;
-	bool dot = false;
-
-	if (*host == '.' || *host == '/' || *host == ':')
-		return false;
-
-	for (p = host; *p != '\0'; p++)
-	{
-		if (*p == '.' || *p == ':' || *p == '/')
-			dot = true;
-		else if (!((*p >= '0' && *p <= '9') || (*p >= 'A' && *p <= 'Z') ||
-					(*p >= 'a' && *p <= 'z') || *p == '-'))
-			return false;
-	}
-	/* hyperion allows a trailing / but RichiH does not want it, whatever */
-	if (dot && p[-1] == '/')
-		return false;
-	return dot;
-}
-
-static void aspircd_wallops_sts(const char *reason)
-{
-	sts(":%s ENCAP * SNOTE s :%s", ME, reason);
-}
-
-/* The following m_functions are copied from generic_ts6, with additions to handle the
- * "identified" / "owns this nick" flag.
- */
-
-static void m_euid(sourceinfo_t *si, int parc, char *parv[])
-{
-	server_t *s;
-	user_t *u;
-
-	/* got the right number of args for an introduction? */
-	if (parc >= 11)
-	{
-		s = si->s;
-		slog(LG_DEBUG, "m_euid(): new user on `%s': %s", s->name, parv[0]);
-
-		u = user_add(parv[0],				/* nick */
-			parv[4],				/* user */
-			*parv[8] != '*' ? parv[8] : parv[5],	/* hostname */
-			parv[5],				/* hostname (visible) */
-			parv[6],				/* ip */
-			parv[7],				/* uid */
-			parv[parc - 1],				/* gecos */
-			s,					/* object parent (server) */
-			atoi(parv[2]));				/* hopcount */
-		if (u == NULL)
-			return;
-
-		user_mode(u, parv[3]);
-		if (*parv[9] != '*')
-		{
-			handle_burstlogin(u, parv[9], 0);
-			/* If an account is given in burst, then either they logged in with sasl,
-			 * or they logged in before a split and are now returning. Either way we need
-			 * to check for identified-to-nick status and update the ircd state accordingly.
-			 * For sasl they should be marked identified, and when returning from a split
-			 * their nick may have been ungrouped, they may have changed nicks, or their account
-			 * may have been dropped.
-			 */
-			if (authservice_loaded)
-				sts(":%s ENCAP * IDENTIFIED %s %s %s", ME, CLIENT_NAME(u), u->nick,
-						should_reg_umode(u) ? "" : "OFF");
-		}
-
-		/* server_eob() cannot know if a user was introduced
-		 * with NICK/UID or EUID and handle_nickchange() must
-		 * be called exactly once for each new user -- jilles */
-		if (s->flags & SF_EOB)
-			handle_nickchange(u);
-	}
-	else
-	{
-		int i;
-		slog(LG_DEBUG, "m_euid(): got EUID with wrong number of params");
-
-		for (i = 0; i < parc; i++)
-			slog(LG_DEBUG, "m_euid():   parv[%d] = %s", i, parv[i]);
-	}
-}
-
-static void m_nick(sourceinfo_t *si, int parc, char *parv[])
-{
-	server_t *s;
-	user_t *u;
-
-	/* got the right number of args for an introduction? */
-	if (parc == 8)
-	{
-		s = server_find(parv[6]);
-		if (!s)
-		{
-			slog(LG_DEBUG, "m_nick(): new user on nonexistant server: %s", parv[6]);
-			return;
-		}
-
-		slog(LG_DEBUG, "m_nick(): new user on `%s': %s", s->name, parv[0]);
-
-		u = user_add(parv[0], parv[4], parv[5], NULL, NULL, NULL, parv[7], s, atoi(parv[2]));
-		if (u == NULL)
-			return;
-
-		user_mode(u, parv[3]);
-
-		/* If server is not yet EOB we will do this later.
-		 * This avoids useless "please identify" -- jilles */
-		if (s->flags & SF_EOB)
-			handle_nickchange(user_find(parv[0]));
-	}
-
-	/* if it's only 2 then it's a nickname change */
-	else if (parc == 2)
-	{
-		bool realchange;
-
-		if (!si->su)
-		{
-			slog(LG_DEBUG, "m_nick(): server trying to change nick: %s", si->s != NULL ? si->s->name : "<none>");
-			return;
-		}
-
-		slog(LG_DEBUG, "m_nick(): nickname change from `%s': %s", si->su->nick, parv[0]);
-
-		realchange = irccasecmp(si->su->nick, parv[0]);
-
-		if (user_changenick(si->su, parv[0], atoi(parv[1])))
-			return;
-
-		/* fix up +e if necessary -- jilles */
-		if (realchange && should_reg_umode(si->su))
-			/* changed nick to registered one, reset +e */
-			sts(":%s ENCAP * IDENTIFIED %s %s", ME, CLIENT_NAME(si->su), si->su->nick);
-
-		/* It could happen that our PING arrived late and the
-		 * server didn't acknowledge EOB yet even though it is
-		 * EOB; don't send double notices in that case -- jilles */
-		if (si->su->server->flags & SF_EOB)
-			handle_nickchange(si->su);
-	}
-	else
-	{
-		int i;
-		slog(LG_DEBUG, "m_nick(): got NICK with wrong number of params");
-
-		for (i = 0; i < parc; i++)
-			slog(LG_DEBUG, "m_nick():   parv[%d] = %s", i, parv[i]);
-	}
-}
-
-/* protocol-specific stuff to do on login */
-static void aspircd_on_login(user_t *u, myuser_t *mu, const char *wantedhost)
-{
-	return_if_fail(u != NULL);
-
-	sts(":%s ENCAP * SU %s %s", ME, CLIENT_NAME(u), entity(mu)->name);
-
-	if (should_reg_umode(u))
-		sts(":%s ENCAP * IDENTIFIED %s %s", ME, CLIENT_NAME(u), u->nick);
-}
-
-static bool aspircd_on_logout(user_t *u, const char *account)
-{
-	return_val_if_fail(u != NULL, false);
-
-	sts(":%s ENCAP * SU %s", ME, CLIENT_NAME(u));
-	sts(":%s ENCAP * IDENTIFIED %s %s OFF", ME, CLIENT_NAME(u), u->nick);
-	return false;
-}
-
-static void nick_group(hook_user_req_t *hdata)
-{
-	user_t *u;
-
-	u = hdata->si->su != NULL && !irccasecmp(hdata->si->su->nick, hdata->mn->nick) ? hdata->si->su : user_find_named(hdata->mn->nick);
-	if (u != NULL && should_reg_umode(u))
-		sts(":%s ENCAP * IDENTIFIED %s %s", ME, CLIENT_NAME(u), u->nick);
-}
-
-static void nick_ungroup(hook_user_req_t *hdata)
-{
-	user_t *u;
-
-	u = hdata->si->su != NULL && !irccasecmp(hdata->si->su->nick, hdata->mn->nick) ? hdata->si->su : user_find_named(hdata->mn->nick);
-	if (u != NULL && !nicksvs.no_nick_ownership)
-		sts(":%s ENCAP * IDENTIFIED %s %s OFF", ME, CLIENT_NAME(u), u->nick);
-}
-
-void _modinit(module_t * m)
+static void
+mod_init(struct module *const restrict m)
 {
 	MODULE_TRY_REQUEST_DEPENDENCY(m, "protocol/charybdis");
 
@@ -304,24 +109,11 @@ void _modinit(module_t * m)
 	status_mode_list = aspircd_status_mode_list;
 	prefix_mode_list = aspircd_prefix_mode_list;
 
-	wallops_sts = &aspircd_wallops_sts;
-	ircd_on_login = &aspircd_on_login;
-	ircd_on_logout = &aspircd_on_logout;
-	is_valid_host = &aspircd_is_valid_hostslash;
-
-	pcommand_delete("NICK");
-	pcommand_add("NICK", m_nick, 2, MSRC_USER | MSRC_SERVER);
-	pcommand_delete("EUID");
-	pcommand_add("EUID", m_euid, 11, MSRC_SERVER);
-
 	ircd = &aspircd;
+}
 
-	hook_add_event("nick_group");
-	hook_add_nick_group(nick_group);
-	hook_add_event("nick_ungroup");
-	hook_add_nick_ungroup(nick_ungroup);
+static void
+mod_deinit(const enum module_unload_intent ATHEME_VATTR_UNUSED intent)
+{
 
-	m->mflags = MODTYPE_CORE;
-
-	pmodule_loaded = true;
 }

--- a/modules/protocol/aspircd.c
+++ b/modules/protocol/aspircd.c
@@ -4,6 +4,8 @@
  * Rights to this code are documented in doc/LICENSE.
  *
  * This file contains protocol support for AspIRCd 3 and AspIRCd 4.
+ * AspIRCd - A Modern, Scalable, and Advanced IRC Daemon.
+ * Copyright (C) - 2018-2021 Flox <flox -at- aspircd.com>
  * 
  */
 

--- a/modules/protocol/aspircd.c
+++ b/modules/protocol/aspircd.c
@@ -9,8 +9,8 @@
  * 
  */
 
-#include "atheme.h"
-#include "protocol/elemental-ircd.h"
+#include <atheme.h>
+#include <atheme/protocol/elemental-ircd.h>
 
 static struct ircd aspircd = {
 	.ircdname = "aspircd",


### PR DESCRIPTION
Sup Folks,

This is Vibhor here (aka Flox) , maintainer and founder of AspIRCd Org (https://aspircd.com)

The reason to create this pull request is to add protocol support for AspIRCd.
Here is a short description of my project:

AspIRCd 3: Fork of Charybdis 3.5 and with addition of additional features.
Similarly, we have recently launched AspIRCd 4: which is a fork of Solanum-1.0-dev aka Charybdis-4.1.3-dev and with addition of all the features from the 3.1.5 branch of AspIRCd.

Here are some major changes from Solanum:

|       Features             |       Solanum               |             AspIRCd 4               |
|-----------------------|-------------------------|------------------------------|
|                                  |                                     |                                           |
| Channel Modes        |  +o : @ Operator        |   +y : * Oper Business        |
|                                  |  +v : + Voice               |   +q : ~ Owner                   |
|                                  |                                    |   +a : & Administrator        |
|                                  |                                    |   +o : @ Operator               |
|                                  |                                    |   +h : % Half Operator        |
|                                  |                                    |   +v : + Voice                      |

- Addition of usermode +B : Bot Mode: displays the swhois "is a Bot on ExampleNET"
- Addition of usermode +I (Hide Idle) and +M (Hide Channel list) from non-IRC Operators
- Addition of usermode +h : which marks an IRC Operator available for help and adds them in the /stats p List. -: also adds the swhois "is available for help" in their /whois.
- Addition of snomasks: sno_whois : +W snomask, sno_farconnect: +F snomask, sno_globaloper, sno_globalkline, sno_channelcreate, sno_globalnickchange
- Addition of usermode +t : SSL Only Message: Filters non-SSL users from messaging you!
- Addition of usermode +F : Hides your SSL Certificates from non-IRC Operators.
- Removed channel membership prefixes from /whois like : "Channels: qao, #lounge , ao, #services" => "Channels: #lounge, #services"
- Web IRC: Improved the modules/m_webirc.c module by adding a lot of features and optimizations.
- Addition of new IP_Cloaking module which supports the cloaking of both IPv4 and IPv4 hostnames and also is more UnrealIRCd like.
and much more changes!

