### PR TITLE
implement certfp list max check

### DIFF
--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -1443,6 +1443,15 @@ serverinfo {
 	 */
 	loglevel = { admin; error; info; network; wallops; };
 
+	/* (*) maxcertfp
+	 *
+	 * What is the maximum number of certificate fingerprints allowed to
+	 * be associated with one account?
+	 *
+	 * Set to 0 for no limit.
+	 */
+	maxcertfp = 0;
+
 	/* (*) maxlogins
 	 *
 	 * What is the maximum number of sessions allowed to login to one

--- a/include/atheme/account.h
+++ b/include/atheme/account.h
@@ -374,7 +374,7 @@ struct myuser_name *myuser_name_add(const char *name);
 void myuser_name_remember(const char *name, struct myuser *mu);
 void myuser_name_restore(const char *name, struct myuser *mu);
 
-struct mycertfp *mycertfp_add(struct myuser *mu, const char *certfp);
+struct mycertfp *mycertfp_add(struct myuser *mu, const char *certfp, bool force);
 void mycertfp_delete(struct mycertfp *mcfp);
 struct mycertfp *mycertfp_find(const char *certfp);
 

--- a/include/atheme/global.h
+++ b/include/atheme/global.h
@@ -34,6 +34,7 @@ struct me
 	bool            connected;              // are we connected?
 	bool            bursting;               // are we bursting?
 	bool            recvsvr;                // received server peer
+	unsigned int    maxcertfp;              // maximum fingerprints in certfp list
 	unsigned int    maxlogins;              // maximum logins per username
 	unsigned int    maxusers;               // maximum usernames from one email
 	unsigned int    maxmemos;

--- a/libathemecore/account.c
+++ b/libathemecore/account.c
@@ -921,19 +921,21 @@ myuser_name_restore(const char *name, struct myuser *mu)
  *******************/
 
 struct mycertfp *
-mycertfp_add(struct myuser *mu, const char *certfp)
+mycertfp_add(struct myuser *mu, const char *certfp, const bool force)
 {
-	struct mycertfp *mcfp;
-
 	return_val_if_fail(mu != NULL, NULL);
 	return_val_if_fail(certfp != NULL, NULL);
 
-	mcfp = mowgli_heap_alloc(mycertfp_heap);
+	if (me.maxcertfp && MOWGLI_LIST_LENGTH(&mu->cert_fingerprints) >= me.maxcertfp && ! force)
+		return NULL;
+
+	struct mycertfp *const mcfp = mowgli_heap_alloc(mycertfp_heap);
+
 	mcfp->mu = mu;
 	mcfp->certfp = sstrdup(certfp);
 
-	mowgli_node_add(mcfp, &mcfp->node, &mu->cert_fingerprints);
-	mowgli_patricia_add(certfplist, mcfp->certfp, mcfp);
+	(void) mowgli_node_add(mcfp, &mcfp->node, &mu->cert_fingerprints);
+	(void) mowgli_patricia_add(certfplist, mcfp->certfp, mcfp);
 
 	return mcfp;
 }

--- a/libathemecore/conf.c
+++ b/libathemecore/conf.c
@@ -262,6 +262,7 @@ init_newconf(void)
 	add_bool_conf_item("HIDDEN", &conf_si_table, 0, &me.hidden, false);
 	add_dupstr_conf_item("MTA", &conf_si_table, 0, &me.mta, NULL);
 	add_conf_item("LOGLEVEL", &conf_si_table, c_si_loglevel);
+	add_uint_conf_item("MAXCERTFP", &conf_si_table, 0, &me.maxcertfp, 0, INT_MAX, 0);
 	add_uint_conf_item("MAXLOGINS", &conf_si_table, 0, &me.maxlogins, 3, INT_MAX, 5);
 	add_uint_conf_item("MAXUSERS", &conf_si_table, 0, &me.maxusers, 0, INT_MAX, 0);
 	add_uint_conf_item("MDLIMIT", &conf_si_table, 0, &me.mdlimit, 0, INT_MAX, 30);

--- a/modules/backend/corestorage.c
+++ b/modules/backend/corestorage.c
@@ -613,7 +613,7 @@ corestorage_h_mcfp(struct database_handle *db, const char *type)
 		return;
 	}
 
-	mycertfp_add(mu, certfp);
+	mycertfp_add(mu, certfp, true);
 }
 
 static void

--- a/modules/backend/flatfile.c
+++ b/modules/backend/flatfile.c
@@ -303,7 +303,7 @@ flatfile_db_load(const char *filename)
 				continue;
 			}
 
-			mcfp = mycertfp_add(mu, certfp);
+			mcfp = mycertfp_add(mu, certfp, true);
 		}
 		else if (!strcmp("NAM", item))
 		{

--- a/modules/nickserv/cert.c
+++ b/modules/nickserv/cert.c
@@ -145,7 +145,7 @@ ns_cmd_cert(struct sourceinfo *si, int parc, char *parv[])
 			command_fail(si, fault_nochange, _("Fingerprint \2%s\2 is already on another user's fingerprint list."), mcfp);
 			return;
 		}
-		if (mycertfp_add(mu, mcfp))
+		if (mycertfp_add(mu, mcfp, false))
 		{
 			command_success_nodata(si, _("Added fingerprint \2%s\2 to your fingerprint list."), mcfp);
 			logcommand(si, CMDLOG_SET, "CERT:ADD: \2%s\2", mcfp);


### PR DESCRIPTION
this check was obviously meant to exist, given

https://github.com/atheme/atheme/blob/1eb6ce571015db4729ec2ce7177949f534c6f633/modules/nickserv/cert.c#L148-L154

the hardcoded `16` is a placeholder for a better value, maybe a setting?