### PR TITLE
Support +T (CMODE_NONOTICE)

### DIFF
--- a/modules/protocol/charybdis.c
+++ b/modules/protocol/charybdis.c
@@ -62,6 +62,7 @@ static const struct cmode charybdis_mode_list[] = {
   { 'T', CMODE_NONOTICE  },
   { 'M', CMODE_IMMUNE	 },
   { 'u', CMODE_NOFILTER	 },
+  { 'T', CMODE_NONOTICE  },
 
   { '\0', 0 }
 };

--- a/modules/protocol/ircd-seven.c
+++ b/modules/protocol/ircd-seven.c
@@ -64,6 +64,7 @@ static const struct cmode seven_mode_list[] = {
   { 'O', CMODE_OPERONLY  },
   { 'A', CMODE_ADMINONLY },
   { 'u', CMODE_NOFILTER  },
+  { 'T', CMODE_NONOTICE  },
 
   { '\0', 0 }
 };


### PR DESCRIPTION
This was already defined in the charybdis.h file, so just need to make
the rest of atheme recognize the mode.