### PR TITLE
Support +T (CMODE_NONOTICE) in ircd-seven

### DIFF
--- a/modules/protocol/ircd-seven.c
+++ b/modules/protocol/ircd-seven.c
@@ -64,6 +64,7 @@ static const struct cmode seven_mode_list[] = {
   { 'O', CMODE_OPERONLY  },
   { 'A', CMODE_ADMINONLY },
   { 'u', CMODE_NOFILTER  },
+  { 'T', CMODE_NONOTICE  },
 
   { '\0', 0 }
 };


### PR DESCRIPTION
This was already defined in the charybdis protocol module but not in ircd-seven, so define it there too.