### PR TITLE
proxyscan/dnsbl: add IPv6 support

### DIFF
--- a/configure
+++ b/configure
@@ -5042,6 +5042,18 @@ fi
 
 done
 
+    for ac_header in arpa/inet.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "arpa/inet.h" "ac_cv_header_arpa_inet_h" "$ac_includes_default"
+if test "x$ac_cv_header_arpa_inet_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_ARPA_INET_H 1
+_ACEOF
+
+fi
+
+done
+
     for ac_header in ctype.h
 do :
   ac_fn_c_check_header_mongrel "$LINENO" "ctype.h" "ac_cv_header_ctype_h" "$ac_includes_default"
@@ -5564,6 +5576,22 @@ do :
 if test "x$ac_cv_func_gettimeofday" = xyes; then :
   cat >>confdefs.h <<_ACEOF
 #define HAVE_GETTIMEOFDAY 1
+_ACEOF
+
+else
+
+
+    as_fn_error $? "required function not available" "$LINENO" 5
+
+fi
+done
+
+    for ac_func in inet_pton
+do :
+  ac_fn_c_check_func "$LINENO" "inet_pton" "ac_cv_func_inet_pton"
+if test "x$ac_cv_func_inet_pton" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_INET_PTON 1
 _ACEOF
 
 else

--- a/include/atheme/sysconf.h.in
+++ b/include/atheme/sysconf.h.in
@@ -56,6 +56,9 @@
 /* Define to 1 if any password quality library appears to be usable */
 #undef HAVE_ANY_PASSWORD_QUALITY_LIBRARY
 
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+#undef HAVE_ARPA_INET_H
+
 /* Define to 1 if you have the <Availability.h> header file. */
 #undef HAVE_AVAILABILITY_H
 
@@ -136,6 +139,9 @@
 
 /* Define if you have the iconv() function and it works. */
 #undef HAVE_ICONV
+
+/* Define to 1 if you have the `inet_pton' function. */
+#undef HAVE_INET_PTON
 
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H

--- a/m4/atheme-check-build-requirements.m4
+++ b/m4/atheme-check-build-requirements.m4
@@ -18,6 +18,7 @@ AC_DEFUN([ATHEME_CHECK_BUILD_REQUIREMENTS], [
     AC_USE_SYSTEM_EXTENSIONS
 
     AC_CHECK_HEADERS([Availability.h], [], [], [])
+    AC_CHECK_HEADERS([arpa/inet.h], [], [], [])
     AC_CHECK_HEADERS([ctype.h], [], [], [])
     AC_CHECK_HEADERS([dirent.h], [], [], [])
     AC_CHECK_HEADERS([errno.h], [], [], [])
@@ -61,6 +62,7 @@ AC_DEFUN([ATHEME_CHECK_BUILD_REQUIREMENTS], [
     AC_CHECK_FUNCS([getpid], [], [ATHEME_REQUIRED_FUNC_MISSING])
     AC_CHECK_FUNCS([getrlimit], [], [])
     AC_CHECK_FUNCS([gettimeofday], [], [ATHEME_REQUIRED_FUNC_MISSING])
+    AC_CHECK_FUNCS([inet_pton], [], [ATHEME_REQUIRED_FUNC_MISSING])
     AC_CHECK_FUNCS([localeconv], [], [ATHEME_REQUIRED_FUNC_MISSING])
     AC_CHECK_FUNCS([memchr], [], [ATHEME_REQUIRED_FUNC_MISSING])
     AC_CHECK_FUNCS([memmove], [], [ATHEME_REQUIRED_FUNC_MISSING])


### PR DESCRIPTION
This does make the codebase now depend upon `inet_pton(3)`, which is pretty much universally available.