### PR TITLE
give solanum its own protocol headers, add CMODE_MODREG for regmsg

### DIFF
--- a/include/atheme/protocol/solanum.h
+++ b/include/atheme/protocol/solanum.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: ISC
+ * SPDX-URL: https://spdx.org/licenses/ISC.html
+ *
+ * Copyright (C) 2022 Atheme Development Group (https://atheme.github.io/)
+ */
+
+#ifndef ATHEME_INC_PROTOCOL_SOLANUM_H
+#define ATHEME_INC_PROTOCOL_SOLANUM_H 1
+
+#define CMODE_NOCOLOR           0x00001000U
+#define CMODE_REGONLY           0x00002000U
+#define CMODE_OPMOD             0x00004000U
+#define CMODE_FINVITE           0x00008000U
+#define CMODE_EXLIMIT           0x00010000U
+#define CMODE_PERM              0x00020000U
+#define CMODE_FTARGET           0x00040000U
+#define CMODE_DISFWD            0x00080000U
+#define CMODE_NOCTCP            0x00100000U
+#define CMODE_NPC               0x00200000U
+#define CMODE_SSLONLY           0x00400000U
+#define CMODE_OPERONLY          0x00800000U
+#define CMODE_ADMINONLY         0x01000000U
+#define CMODE_NONOTICE          0x02000000U
+#define CMODE_IMMUNE            0x04000000U
+#define CMODE_NOFILTER		0x08000000U
+#define CMODE_MODREG            0x10000000U
+
+#endif /* !ATHEME_INC_PROTOCOL_SOLANUM_H */

--- a/modules/protocol/solanum.c
+++ b/modules/protocol/solanum.c
@@ -9,7 +9,7 @@
  */
 
 #include <atheme.h>
-#include <atheme/protocol/charybdis.h>
+#include <atheme/protocol/solanum.h>
 
 #define UF_NOLOGOUT UF_CUSTOM1
 #define UF_HELPER   UF_CUSTOM2
@@ -65,6 +65,7 @@ static const struct cmode solanum_mode_list[] = {
   { 'A', CMODE_ADMINONLY },
   { 'u', CMODE_NOFILTER  },
   { 'T', CMODE_NONOTICE  },
+  { 'R', CMODE_MODREG    },
 
   { '\0', 0 }
 };


### PR DESCRIPTION
would've felt wrong to put this in the charybdis headers given the mode is new since the fork