### PR TITLE
allow config sopers who are specified by EID to drop their account

### DIFF
--- a/modules/nickserv/drop.c
+++ b/modules/nickserv/drop.c
@@ -62,7 +62,7 @@ cmd_ns_drop_func(struct sourceinfo *const restrict si, const int ATHEME_VATTR_UN
 	if (is_conf_named_soper(mu))
 	{
 		(void) command_fail(si, fault_noprivs, _("The nickname \2%s\2 belongs to a services operator "
-							 "whose operclass is defined by name in the configuration "
+							 "defined by name in the configuration "
 		                                         "file; it cannot be dropped."), acc);
 		return;
 	}

--- a/modules/nickserv/drop.c
+++ b/modules/nickserv/drop.c
@@ -59,10 +59,11 @@ cmd_ns_drop_func(struct sourceinfo *const restrict si, const int ATHEME_VATTR_UN
 		return;
 	}
 
-	if (is_soper(mu))
+	if (is_conf_named_soper(mu))
 	{
-		(void) command_fail(si, fault_noprivs, _("The nickname \2%s\2 belongs to a services operator; "
-		                                         "it cannot be dropped."), acc);
+		(void) command_fail(si, fault_noprivs, _("The nickname \2%s\2 belongs to a services operator "
+							 "whose operclass is defined by name in the configuration "
+		                                         "file; it cannot be dropped."), acc);
 		return;
 	}
 


### PR DESCRIPTION
corollary to atheme/atheme@214b0efbbde3ab55f7bbfd93d6cc7d2a5d181df6