### PR TITLE
rectify throttling config example, as `replenish` is seconds-per-token

### DIFF
--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -2491,9 +2491,9 @@ httpd {
  *
  * This is achieved with a rudimentary token bucket system. You configure a
  * "burst" of attempts that can be made immediately, and configure a
- * "replenish" rate of how many tokens replenish each second. For example,
- * with "burst" set to 2 and "replenish" set to 0.5, you can attempt at most
- * twice in 2 seconds, and then once every 2 seconds thereafter.
+ * "replenish" rate of how many seconds it takes for a token to replenish. For
+ * example, with "burst" set to 2 and "replenish" set to 2, you can attempt at
+ * most twice in 2 seconds, and then once every 2 seconds thereafter.
  *
  * To disable a specific throttling mechanism (e.g. to only throttle IP
  * addresses, and not combinations of IP address and account), set the
@@ -2527,7 +2527,7 @@ throttle {
 	#address_replenish = 1;
 
 	#address_account_burst = 2;
-	#address_account_replenish = 0.5;
+	#address_account_replenish = 2;
 };
 
 


### PR DESCRIPTION
this throttle mechanism is documented in 2 places; `modules/misc/login_throttling.c` and in this file. the comments explain `replenish` differently; i've checked the math and i've checked in practice, and `modules/misc/login_throttling.c` is correct.

example with `burst` set to 1 and `replenish` set to 2:
```
02:34:47 <jess> identify jess a
02:34:47 -NickServ(NickServ@atheme.vpn.lolnerd.net)- Invalid password for jess.
02:34:47 <jess> identify jess a
02:34:47 -NickServ(NickServ@atheme.vpn.lolnerd.net)- You cannot identify to jess because the server configuration disallows it.
02:34:48 <jess> identify jess a
02:34:48 -NickServ(NickServ@atheme.vpn.lolnerd.net)- You cannot identify to jess because the server configuration disallows it.
02:34:48 <jess> identify jess a
02:34:48 -NickServ(NickServ@atheme.vpn.lolnerd.net)- You cannot identify to jess because the server configuration disallows it.
02:34:49 <jess> identify jess a
02:34:49 -NickServ(NickServ@atheme.vpn.lolnerd.net)- Invalid password for jess.
```