### PR TITLE
'user:regnolimit' -> 'user:exceedlimits', use :regnolimit for NS command

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -110,6 +110,10 @@ POTENTIAL COMPATIBILITY BREAKAGE
   database before it will start successfully. A migration script is located in
   this repository; please see the comment block in `contrib/database-ts.pl`.
 
+- The service oper privilege previously called `user:regnolimit` has been
+  changed to `user:exceedlimits`, and `user:regnolimit` now refers to the
+  ability to use the nickserv command `REGNOLIMIT`.
+
 Security
 --------
 - Services now accepts email addresses that may contain shell metacharacters.

--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -3031,6 +3031,7 @@ operclass "sra" {
 	extends "ircop";
 
 	privs {
+		user:exceedlimits;
 		user:hold;
 		user:regnolimit;
 	};

--- a/doc/PRIVILEGES
+++ b/doc/PRIVILEGES
@@ -90,6 +90,9 @@ user:mark
 user:hold
 	use ns/us/cs hold to prevent things from expiring
 user:regnolimit
+	allow ns REGNOLIMIT command to mark accounts as being able to
+	exceed limits on numbers of registrations
+user:exceedlimits
 	exempt from limits on numbers of registrations (does not work
 	fully if set on the ircop operclass)
 

--- a/include/atheme/privs.h
+++ b/include/atheme/privs.h
@@ -30,7 +30,8 @@
 #define PRIV_HOLD                       "user:hold"
 #define PRIV_LOGIN_NOLIMIT              "user:loginnolimit"
 #define PRIV_MARK                       "user:mark"
-#define PRIV_REG_NOLIMIT                "user:regnolimit"
+#define PRIV_EXCEED_LIMITS              "user:exceedlimits"
+#define PRIV_REGNOLIMIT                 "user:regnolimit"
 
 // GroupServ
 #define PRIV_GROUP_ADMIN                "group:admin"

--- a/libathemecore/entity.c
+++ b/libathemecore/entity.c
@@ -212,7 +212,7 @@ linear_can_register_channel(struct myentity *mt)
 	if (mu->flags & MU_REGNOLIMIT)
 		return true;
 
-	return has_priv_myuser(mu, PRIV_REG_NOLIMIT);
+	return has_priv_myuser(mu, PRIV_EXCEED_LIMITS);
 }
 
 static bool

--- a/modules/groupserv/register.c
+++ b/modules/groupserv/register.c
@@ -48,7 +48,7 @@ gs_cmd_register(struct sourceinfo *si, int parc, char *parv[])
 	}
 
 	if (myentity_count_group_flag(entity(si->smu), GA_FOUNDER) > gs_config->maxgroups &&
-	    !has_priv(si, PRIV_REG_NOLIMIT))
+	    !has_priv(si, PRIV_EXCEED_LIMITS))
 	{
 		command_fail(si, fault_toomany, _("You have too many groups registered."));
 		return;

--- a/modules/nickserv/group.c
+++ b/modules/nickserv/group.c
@@ -28,7 +28,7 @@ ns_cmd_group(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	if (MOWGLI_LIST_LENGTH(&si->smu->nicks) >= nicksvs.maxnicks && !has_priv(si, PRIV_REG_NOLIMIT))
+	if (MOWGLI_LIST_LENGTH(&si->smu->nicks) >= nicksvs.maxnicks && !has_priv(si, PRIV_EXCEED_LIMITS))
 	{
 		command_fail(si, fault_noprivs, _("You have too many nicks registered already."));
 		return;

--- a/modules/nickserv/regnolimit.c
+++ b/modules/nickserv/regnolimit.c
@@ -77,7 +77,7 @@ ns_cmd_regnolimit(struct sourceinfo *si, int parc, char *parv[])
 static struct command ns_regnolimit = {
 	.name           = "REGNOLIMIT",
 	.desc           = N_("Allow a user to bypass registration limits."),
-	.access         = PRIV_ADMIN,
+	.access         = PRIV_REGNOLIMIT,
 	.maxparc        = 2,
 	.cmd            = &ns_cmd_regnolimit,
 	.help           = { .path = "nickserv/regnolimit" },

--- a/modules/operserv/specs.c
+++ b/modules/operserv/specs.c
@@ -39,6 +39,7 @@ os_cmd_specs(struct sourceinfo *si, int parc, char *parv[])
 			{ PRIV_HOLD, N_("hold accounts") },
 			{ PRIV_EXCEED_LIMITS, N_("bypass nickname grouping limits") },
 			{ PRIV_LOGIN_NOLIMIT, N_("bypass login limits") },
+			{ PRIV_REGNOLIMIT, N_("allow other accounts to bypass channel registration limits") },
 			{ NULL, NULL },
 		}
 	};

--- a/modules/operserv/specs.c
+++ b/modules/operserv/specs.c
@@ -51,7 +51,7 @@ os_cmd_specs(struct sourceinfo *si, int parc, char *parv[])
 			{ PRIV_JOIN_STAFFONLY, N_("join staff channels") },
 			{ PRIV_MARK, N_("mark channels") },
 			{ PRIV_HOLD, N_("hold channels") },
-			{ PRIV_REG_NOLIMIT, N_("bypass channel registration limits") },
+			{ PRIV_EXCEED_LIMITS, N_("bypass channel registration limits") },
 			{ NULL, NULL },
 		}
 	};
@@ -87,7 +87,7 @@ os_cmd_specs(struct sourceinfo *si, int parc, char *parv[])
 		{
 			{ PRIV_GROUP_AUSPEX, N_("view concealed information about groups") },
 			{ PRIV_GROUP_ADMIN, N_("administer groups") },
-			{ PRIV_REG_NOLIMIT, N_("bypass group registration limits") },
+			{ PRIV_EXCEED_LIMITS, N_("bypass group registration limits") },
 			{ NULL, NULL },
 		}
 	};

--- a/modules/operserv/specs.c
+++ b/modules/operserv/specs.c
@@ -37,6 +37,7 @@ os_cmd_specs(struct sourceinfo *si, int parc, char *parv[])
 			{ PRIV_USER_FREGISTER, N_("register accounts on behalf of another user") },
 			{ PRIV_MARK, N_("mark accounts") },
 			{ PRIV_HOLD, N_("hold accounts") },
+			{ PRIV_EXCEED_LIMITS, N_("bypass nickname grouping limits") },
 			{ PRIV_LOGIN_NOLIMIT, N_("bypass login limits") },
 			{ NULL, NULL },
 		}


### PR DESCRIPTION
the priv `user:regnolimit` currently refers to yourself. if you have this priv, you can register as much of anything as you want.

the nickserv command `REGNOLIMIT` is used at run-time to change whether another user can register as many channels as they'd like.

we wanted to change the priv that the nickserv command requires (it currently requires `general:admin`), but `user:regnolimit` was already being used for the first usecase, so i've decided to change the first usecase to be `user:exceedlimits`