### PR TITLE
unreal4: CHGIDENT and CHGHOST on SASL

### DIFF
--- a/modules/protocol/unreal4.c
+++ b/modules/protocol/unreal4.c
@@ -708,6 +708,10 @@ unreal_svslogin_sts(const char *target, const char *nick, const char *user, cons
 		*p = '\0';
 
 	sts(":%s SVSLOGIN %s %s %s", saslserv->me->nick, servermask, target, entity(account)->name);
+	if (strcmp(user, "*"))
+		sts(":%s CHGIDENT %s %s", me.numeric, target, user);
+	if (strcmp(host, "*"))
+		sts(":%s CHGHOST %s %s", me.numeric, target, host);
 }
 
 static void


### PR DESCRIPTION
This makes it so in the unreal4 protocol module `CHGIDENT` and `CHGHOST` get sent on SASL when instructed to do so.

Actually this doesn't help much, since right now the `svslogin_sts` function is always called with `*` for both `user` and `host` but that is another issue :D