### PR TITLE
include FNC_REGAIN/FNC_FORCE in ts6-generic's RSFNC

### DIFF
--- a/modules/protocol/ts6-generic.c
+++ b/modules/protocol/ts6-generic.c
@@ -485,11 +485,12 @@ static void
 ts6_fnc_sts(struct user *source, struct user *u, const char *newnick, int type)
 {
 	// XXX assumes the server will accept this -- jilles
-	sts(":%s ENCAP %s RSFNC %s %s %lu %lu", ME,
+	sts(":%s ENCAP %s RSFNC %s %s %lu %lu %u", ME,
 			u->server->name,
 			CLIENT_NAME(u), newnick,
 			(unsigned long)(CURRTIME - SECONDS_PER_MINUTE),
-			(unsigned long)u->ts);
+			(unsigned long)u->ts,
+			type);
 }
 
 static void


### PR DESCRIPTION
it may be better to only send this extra parameter to servers whose `CAPAB`/`GCAP` have indicated they support it. thoughts?