### PR TITLE
modules/protocol/unreal4: Adjust default usermodes for service bots to include TLS-only & hide ircop usermodes

### DIFF
--- a/modules/protocol/unreal4.c
+++ b/modules/protocol/unreal4.c
@@ -323,9 +323,9 @@ unreal_introduce_nick(struct user *u)
 	const char *umode = user_get_umodestr(u);
 
 	if (!ircd->uses_uid)
-		sts("NICK %s 1 %lu %s %s %s 0 %sS * :%s", u->nick, (unsigned long)u->ts, u->user, u->host, me.name, umode, u->gecos);
+		sts("NICK %s 1 %lu %s %s %s 0 %szHS * :%s", u->nick, (unsigned long)u->ts, u->user, u->host, me.name, umode, u->gecos);
 	else
-		sts(":%s UID %s 1 %lu %s %s %s * %sS * * * :%s", ME, u->nick, (unsigned long)u->ts, u->user, u->host, u->uid, umode, u->gecos);
+		sts(":%s UID %s 1 %lu %s %s %s * %szHS * * * :%s", ME, u->nick, (unsigned long)u->ts, u->user, u->host, u->uid, umode, u->gecos);
 }
 
 static void


### PR DESCRIPTION
This adjusts atheme's services bots to include +z and +H as part of their introduced usermodes.

When +z (connected securely) isn't set on the service bot, and a services bot joins a +z (only secure clients can join) channel which only contains secure clients, then Unreal will send a NOTICE to the channel indicating the channel is no longer "secure" and unset +Z (which indicates that only secure clients are in the channel)

When +H (oper status hidden in /who, /whois & /lusers) isn't set on the service bot, the number of operators in /lusers appears higher than the number of "real" operators, as unreal doesn't exclude +S (services user) users from the list of operators.

