### PR TITLE
modules/protocol/unreal4: Adjust UID parsing to correctly parse IP

### DIFF
--- a/modules/protocol/unreal4.c
+++ b/modules/protocol/unreal4.c
@@ -1040,9 +1040,9 @@ m_uid(struct sourceinfo *si, int parc, char *parv[])
 
 		vhost = strcmp(parv[8], "*") ? parv[8] : NULL;
 		iplen = 0;
-		if (parc == 11 && strcmp(parv[parc - 2], "*"))
+		if (strcmp(parv[10], "*"))
 		{
-			ipb64 = parv[parc - 2];
+			ipb64 = parv[10];
 			af = AF_INET;
 			if (strlen(ipb64) == 8)
 			{


### PR DESCRIPTION
When parsing the UID message from UnrealIRCd, the real IP of the user is not being correctly detected.

According to UnrealIRCd documentation (5+), the UID line should be as follows.

    UID nickname hopcount timestamp username hostname uid servicestamp umodes virthost cloakedhost ip :gecos

This appears to be caused due to an additional check that requires parc to be both 11 and 12 to successfully extract the IP.