### PR TITLE
Update InspIRCd protocol module to use the 1205 (v3) protocol

### DIFF
--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -119,7 +119,7 @@
  * Charybdis IRCd                               protocol/charybdis
  * ChatIRCd                                     protocol/chatircd1.1
  * DreamForge 4.6.7 or later                    protocol/dreamforge
- * InspIRCd 2.x and 3.x                         protocol/inspircd
+ * InspIRCd 3.x and 4.x                         protocol/inspircd
  * ircd-ratbox 2.0 and later                    protocol/ratbox
  * IRCNet ircd (ircd 2.11)                      protocol/ircnet
  * solanum                                      protocol/solanum

--- a/doc/IRCD
+++ b/doc/IRCD
@@ -48,9 +48,9 @@ on the network.
 inspircd
 --------
 
-You should use the "inspircd" protocol module for InspIRCd 2.x and 3.x.
+You should use the "inspircd" protocol module for InspIRCd 3.x and 4.x.
 InspIRCd 1.2 support was deprecated in atheme 7.1 and has been dropped
-in atheme 7.2.
+in atheme 7.2. InspIRCd 2.x support has been dropped in atheme 7.3.
 
 You need <uline> tags for services on all servers on the network.
 

--- a/doc/IRCD
+++ b/doc/IRCD
@@ -59,9 +59,6 @@ usually not be a problem if those modules are not loaded. The exception to
 this is the m_services_account.so module, which must be loaded at all times
 on your inspircd servers if you wish to use this version of atheme.
 
-Using the m_invisible module on inspircd with Atheme connected is an unsupported
-condition and will result in your Atheme installation being "tainted".
-
 Jupes will use SIDs numerically following services's SID, make sure to leave
 plenty of space.
 

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -1243,7 +1243,9 @@ m_server(struct sourceinfo *si, int parc, char *parv[])
 	{
 		sts(":%s BURST", me.numeric);
 		get_version_string(ver, sizeof(ver));
-		sts(":%s VERSION :%s", me.numeric, ver);
+		sts(":%s SINFO version :%s", me.numeric, ver);
+		sts(":%s SINFO fullversion :[%s] %s", me.numeric, me.numeric, ver);
+		sts(":%s SINFO rawversion :%s-%s", me.numeric, PACKAGE_TARNAME, PACKAGE_VERSION);
 		services_init();
 		sts(":%s ENDBURST", me.numeric);
 	}

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -1038,6 +1038,31 @@ m_fjoin(struct sourceinfo *si, int parc, char *parv[])
 }
 
 static void
+m_ijoin(struct sourceinfo *si, int parc, char *parv[])
+{
+	// :<uid> IJOIN <chan> <membid> [<ts> [<flags>]]
+	struct channel *c;
+	char prefixandnick[51];
+
+	c = channel_find(parv[0]);
+	if (c == NULL)
+	{
+		sts(":%s RESYNC :%s", me.numeric, parv[0]);
+		return;
+	}
+
+	if (parc < 4)
+	{
+		chanuser_add(c, si->su->nick);
+		return;
+	}
+
+	mowgli_strlcpy(prefixandnick, parv[3], sizeof(prefixandnick));
+	mowgli_strlcpy(prefixandnick + strlen(parv[3]), si->su->nick, sizeof(prefixandnick) - strlen(parv[3]));
+	chanuser_add(c, prefixandnick);
+}
+
+static void
 m_part(struct sourceinfo *si, int parc, char *parv[])
 {
 	slog(LG_DEBUG, "m_part(): user left channel: %s -> %s", si->su->nick, parv[0]);
@@ -1754,6 +1779,7 @@ mod_init(struct module *const restrict m)
 	pcommand_add("PRIVMSG", m_privmsg, 2, MSRC_USER | MSRC_SERVER);
 	pcommand_add("NOTICE", m_notice, 2, MSRC_USER | MSRC_SERVER | MSRC_UNREG);
 	pcommand_add("FJOIN", m_fjoin, 3, MSRC_SERVER);
+	pcommand_add("IJOIN", m_ijoin, 2, MSRC_USER);
 	pcommand_add("PART", m_part, 1, MSRC_USER);
 	pcommand_add("NICK", m_nick, 2, MSRC_USER);
 	pcommand_add("UID", m_uid, 10, MSRC_SERVER);

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -1657,6 +1657,28 @@ m_capab(struct sourceinfo *si, int parc, char *parv[])
 		}
 		TAINT_ON(strstr(parv[1], "m_invisible.so") != NULL, "invisible (m_invisible) is not presently supported correctly in atheme, and won't be due to ethical obligations");
 	}
+	else if (strcasecmp(parv[0], "CHANMODES") == 0 && parc > 1)
+	{
+		varc = sjtoken(parv[1], ' ', varv);
+		for (i = 0; i < varc; i++)
+		{
+			if (strstr(varv[i], "prefix:") != varv[i])
+				continue; // not a prefix mode
+
+			switch (varv[i][(strlen(varv[i]) - 1)])
+			{
+				case 'q':
+					ircd->uses_owner = true;
+					break;
+				case 'a':
+					ircd->uses_protect = true;
+					break;
+				case 'h':
+					ircd->uses_halfops = true;
+					break;
+			}
+		}
+	}
 	else if (strcasecmp(parv[0], "USERMODES") == 0 && parc > 1)
 	{
 		varc = sjtoken(parv[1], ' ', varv);

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -1295,22 +1295,6 @@ m_away(struct sourceinfo *si, int parc, char *parv[])
 }
 
 static void
-m_join(struct sourceinfo *si, int parc, char *parv[])
-{
-	struct channel *c;
-
-	c = channel_find(parv[0]);
-	if (!c)
-	{
-		slog(LG_DEBUG, "m_join(): new channel: %s (modes lost)", parv[0]);
-		c = channel_add(parv[0], parc > 1 ? atol(parv[1]) : CURRTIME, si->su->server);
-		return_if_fail(c != NULL);
-		channel_mode_va(NULL, c, 1, "+");
-	}
-	chanuser_add(c, si->su->nick);
-}
-
-static void
 m_save(struct sourceinfo *si, int parc, char *parv[])
 {
 	struct user *u = user_find(parv[0]);
@@ -1788,7 +1772,6 @@ mod_init(struct module *const restrict m)
 	pcommand_add("MOTD", m_motd, 1, MSRC_USER);
 	pcommand_add("ADMIN", m_admin, 1, MSRC_USER);
 	pcommand_add("FTOPIC", m_ftopic, 4, MSRC_SERVER);
-	pcommand_add("JOIN", m_join, 1, MSRC_USER);
 	pcommand_add("ERROR", m_error, 1, MSRC_UNREG | MSRC_SERVER);
 	pcommand_add("TOPIC", m_topic, 2, MSRC_USER);
 	pcommand_add("FIDENT", m_fident, 1, MSRC_USER);

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -576,14 +576,14 @@ inspircd_topic_sts(struct channel *c, struct user *source, const char *setter, t
 	// Restoring old topic
 	if (ts > prevts + SECONDS_PER_MINUTE || prevts == 0)
 	{
-		sts(":%s FTOPIC %s %lu %s :%s", source->uid, c->name, (unsigned long)ts, setter, topic);
+		sts(":%s FTOPIC %s %lu %lu %s :%s", source->uid, c->name, (unsigned long)c->ts, (unsigned long)ts, setter, topic);
 		return;
 	}
 	// Tweaking a topic
 	else if (ts == prevts)
 	{
 		ts -= SECONDS_PER_MINUTE;
-		sts(":%s FTOPIC %s %lu %s :%s", source->uid, c->name, (unsigned long)ts, setter, topic);
+		sts(":%s FTOPIC %s %lu %lu %s :%s", source->uid, c->name, (unsigned long)c->ts, (unsigned long)ts, setter, topic);
 		c->topicts = ts;
 		return;
 	}
@@ -797,7 +797,7 @@ static void
 m_ftopic(struct sourceinfo *si, int parc, char *parv[])
 {
 	struct channel *c = channel_find(parv[0]);
-	time_t ts = atol(parv[1]);
+	time_t ts = atol(parv[2]);
 
 	if (!c)
 		return;
@@ -808,7 +808,7 @@ m_ftopic(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	handle_topic_from(si, c, parv[2], ts, parv[3]);
+	handle_topic_from(si, c, parv[3], ts, parv[4]);
 }
 
 static void
@@ -1760,7 +1760,7 @@ mod_init(struct module *const restrict m)
 	pcommand_add("STATS", m_stats, 2, MSRC_USER);
 	pcommand_add("MOTD", m_motd, 1, MSRC_USER);
 	pcommand_add("ADMIN", m_admin, 1, MSRC_USER);
-	pcommand_add("FTOPIC", m_ftopic, 4, MSRC_SERVER);
+	pcommand_add("FTOPIC", m_ftopic, 5, MSRC_SERVER);
 	pcommand_add("ERROR", m_error, 1, MSRC_UNREG | MSRC_SERVER);
 	pcommand_add("FIDENT", m_fident, 1, MSRC_USER);
 	pcommand_add("FHOST", m_fhost, 1, MSRC_USER);

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -616,7 +616,7 @@ inspircd_ping_sts(void)
 	if (!u)
 		return;
 
-	sts(":%s PING %s :%s", me.numeric, me.numeric, u->sid);
+	sts(":%s PING %s", me.numeric, u->sid);
 }
 
 static void
@@ -815,10 +815,7 @@ static void
 m_ping(struct sourceinfo *si, int parc, char *parv[])
 {
 	// reply to PINGs
-	if (parc == 1)
-		sts(":%s PONG %s", me.numeric, parv[0]);
-	else if (parc == 2)
-		sts(":%s PONG %s :%s", me.numeric, parv[1], parv[0]);
+	sts(":%s PONG %s", me.numeric, si->s->sid);
 }
 
 static void
@@ -1281,7 +1278,7 @@ solicit_pongs(struct server *s)
 {
 	mowgli_node_t *n;
 
-	sts(":%s PING %s %s", me.numeric, me.numeric, s->sid);
+	sts(":%s PING %s", me.numeric, s->sid);
 
 	MOWGLI_ITER_FOREACH(n, s->children.head)
 		solicit_pongs(n->data);
@@ -1774,7 +1771,7 @@ mod_init(struct module *const restrict m)
 
 	ircd = &InspIRCd;
 
-	pcommand_add("PING", m_ping, 1, MSRC_USER | MSRC_SERVER);
+	pcommand_add("PING", m_ping, 1, MSRC_SERVER);
 	pcommand_add("PONG", m_pong, 1, MSRC_SERVER);
 	pcommand_add("PRIVMSG", m_privmsg, 2, MSRC_USER | MSRC_SERVER);
 	pcommand_add("NOTICE", m_notice, 2, MSRC_USER | MSRC_SERVER | MSRC_UNREG);

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -680,7 +680,7 @@ inspircd_jupe(const char *server, const char *reason)
 		}
 	} while (server_find(sid));
 
-	sts(":%s SERVER %s * 1 %s :%s", me.numeric, server, sid, reason);
+	sts(":%s SERVER %s %s :%s", me.numeric, server, sid, reason);
 }
 
 static void
@@ -1239,7 +1239,16 @@ m_server(struct sourceinfo *si, int parc, char *parv[])
 		sts(":%s ENDBURST", me.numeric);
 	}
 
-	handle_server(si, parv[0], parv[3], atoi(parv[2]), parv[4]);
+	if (parc == 5)
+	{
+		// SERVER <name> <password> <hops> <sid> :<description>
+		handle_server(si, parv[0], parv[3], atoi(parv[2]), parv[4]);
+	}
+	else if (parc == 3)
+	{
+		// SERVER <name> <sid> :<description>
+		handle_server(si, parv[0], parv[1], 0, parv[2]);
+	}
 }
 
 static inline void
@@ -1756,7 +1765,7 @@ mod_init(struct module *const restrict m)
 	pcommand_add("SAVE", m_save, 2, MSRC_SERVER);
 	pcommand_add("SQUIT", m_squit, 1, MSRC_USER | MSRC_SERVER);
 	pcommand_add("RSQUIT", m_rsquit, 1, MSRC_USER);
-	pcommand_add("SERVER", m_server, 4, MSRC_UNREG | MSRC_SERVER);
+	pcommand_add("SERVER", m_server, 3, MSRC_UNREG | MSRC_SERVER);
 	pcommand_add("STATS", m_stats, 2, MSRC_USER);
 	pcommand_add("MOTD", m_motd, 1, MSRC_USER);
 	pcommand_add("ADMIN", m_admin, 1, MSRC_USER);

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -211,7 +211,7 @@ sid_find(const char *name)
 static inline void
 channel_metadata_sts(struct channel *c, const char *key, const char *value)
 {
-	sts(":%s METADATA %s %s :%s", ME, c->name, key, value);
+	sts(":%s METADATA %s %lu %s :%s", ME, c->name, (unsigned long)c->ts, key, value);
 }
 
 static bool

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -357,7 +357,7 @@ inspircd_server_login(void)
 	ret = sts("CAPAB START " PROTOCOL_PREFERRED_STR);
 	if (ret == 1)
 		return 1;
-	sts("CAPAB CAPABILITIES :PROTOCOL=" PROTOCOL_PREFERRED_STR);
+	sts("CAPAB CAPABILITIES :CASEMAPPING=%s", match_mapping == MATCH_ASCII ? "ascii" : "rfc1459");
 	sts("CAPAB END");
 	sts("SERVER %s %s 0 %s :%s", me.name, curr_uplink->send_pass, me.numeric, me.desc);
 
@@ -1606,22 +1606,7 @@ m_capab(struct sourceinfo *si, int parc, char *parv[])
 		varc = sjtoken(parv[1], ' ', varv);
 		for (i = 0; i < varc; i++)
 		{
-			if(!strncmp(varv[i], "PREFIX=", 7))
-			{
-				if (strstr(varv[i] + 7, "q"))
-				{
-					ircd->uses_owner = true;
-				}
-				if (strstr(varv[i] + 7, "a"))
-				{
-					ircd->uses_protect = true;
-				}
-				if (strstr(varv[i] + 7, "h"))
-				{
-					ircd->uses_halfops = true;
-				}
-			}
-			else if (!strcmp(varv[i], "GLOBOPS=1"))
+			if (!strcmp(varv[i], "GLOBOPS=1"))
 			{
 				has_globopsmod = true;
 			}

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -467,7 +467,7 @@ inspircd_numeric_sts(struct server *from, int numeric, struct user *target, cons
 	vsnprintf(buf, BUFSIZE, fmt, ap);
 	va_end(ap);
 
-	sts(":%s PUSH %s ::%s %d %s %s", from->sid, target->uid, from->name, numeric, target->nick, buf);
+	sts(":%s NUM %s %s %d %s", from->sid, from->sid, target->uid, numeric, buf);
 }
 
 static void

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -794,17 +794,6 @@ inspircd_topiclock_sts(struct channel *c)
 }
 
 static void
-m_topic(struct sourceinfo *si, int parc, char *parv[])
-{
-	struct channel *c = channel_find(parv[0]);
-
-	if (!c)
-		return;
-
-	handle_topic_from(si, c, si->su->nick, time(NULL), parv[1]);
-}
-
-static void
 m_ftopic(struct sourceinfo *si, int parc, char *parv[])
 {
 	struct channel *c = channel_find(parv[0]);
@@ -1773,7 +1762,6 @@ mod_init(struct module *const restrict m)
 	pcommand_add("ADMIN", m_admin, 1, MSRC_USER);
 	pcommand_add("FTOPIC", m_ftopic, 4, MSRC_SERVER);
 	pcommand_add("ERROR", m_error, 1, MSRC_UNREG | MSRC_SERVER);
-	pcommand_add("TOPIC", m_topic, 2, MSRC_USER);
 	pcommand_add("FIDENT", m_fident, 1, MSRC_USER);
 	pcommand_add("FHOST", m_fhost, 1, MSRC_USER);
 	pcommand_add("IDLE", m_idle, 1, MSRC_USER);

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -10,8 +10,8 @@
 #include <atheme.h>
 #include <atheme/protocol/inspircd.h>
 
-#define PROTOCOL_MINIMUM 1202 // we do not support anything older than this
-#define PROTOCOL_PREFERRED_STR "1202"
+#define PROTOCOL_MINIMUM 1205 // we do not support anything older than this
+#define PROTOCOL_PREFERRED_STR "1205"
 
 static struct ircd InspIRCd = {
 	.ircdname = "InspIRCd",

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -708,7 +708,7 @@ inspircd_fnc_sts(struct user *source, struct user *u, const char *newnick, int t
 static void
 inspircd_invite_sts(struct user *sender, struct user *target, struct channel *channel)
 {
-	sts(":%s INVITE %s %s", sender->uid, target->uid, channel->name);
+	sts(":%s INVITE %s %s %lu", sender->uid, target->uid, channel->name, (unsigned long)channel->ts);
 }
 
 static void

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -1662,11 +1662,11 @@ m_capab(struct sourceinfo *si, int parc, char *parv[])
 		varc = sjtoken(parv[1], ' ', varv);
 		for (i = 0; i < varc; i++)
 		{
-			if (!strcmp(varv[i], "hidechans=I"))
+			if (!strcmp(varv[i], "simple:hidechans=I"))
 				has_hidechansmod = true;
-			else if (!strcmp(varv[i], "hideoper=H"))
+			else if (!strcmp(varv[i], "simple:hideoper=H"))
 				has_hideopermod = true;
-			else if (!strcmp(varv[i], "servprotect=k"))
+			else if (!strcmp(varv[i], "simple:servprotect=k"))
 				has_servprotectmod = true;
 		}
 	}

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -11,7 +11,6 @@
 #include <atheme/protocol/inspircd.h>
 
 #define PROTOCOL_MINIMUM 1205 // we do not support anything older than this
-#define PROTOCOL_PREFERRED_STR "1205"
 
 static struct ircd InspIRCd = {
 	.ircdname = "InspIRCd",
@@ -354,7 +353,7 @@ inspircd_server_login(void)
 	ircd->uses_protect = false;
 	ircd->uses_halfops = false;
 
-	ret = sts("CAPAB START " PROTOCOL_PREFERRED_STR);
+	ret = sts("CAPAB START %u", PROTOCOL_MINIMUM);
 	if (ret == 1)
 		return 1;
 	sts("CAPAB CAPABILITIES :CASEMAPPING=%s", match_mapping == MATCH_ASCII ? "ascii" : "rfc1459");
@@ -1590,12 +1589,7 @@ m_capab(struct sourceinfo *si, int parc, char *parv[])
 		 */
 		if (parc > 1)
 			has_protocol = atoi(parv[1]);
-		if (has_protocol == 1203 || has_protocol == 1204)
-		{
-			slog(LG_ERROR, "m_capab(): InspIRCd 2.1 beta is not supported.");
-			exit(EXIT_FAILURE);
-		}
-		else if (has_protocol < PROTOCOL_MINIMUM)
+		if (has_protocol < PROTOCOL_MINIMUM)
 		{
 			slog(LG_ERROR, "m_capab(): remote protocol version too old (%d). you may need another protocol module or a newer inspircd. exiting.", has_protocol);
 			exit(EXIT_FAILURE);
@@ -1655,7 +1649,6 @@ m_capab(struct sourceinfo *si, int parc, char *parv[])
 			if (it)
 				max_rejoindelay = atoi(it + 1);
 		}
-		TAINT_ON(strstr(parv[1], "m_invisible.so") != NULL, "invisible (m_invisible) is not presently supported correctly in atheme, and won't be due to ethical obligations");
 	}
 	else if (strcasecmp(parv[0], "CHANMODES") == 0 && parc > 1)
 	{

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -1005,6 +1005,11 @@ m_fjoin(struct sourceinfo *si, int parc, char *parv[])
 				// yup, skip over the comma
 				userv[i]++;
 
+				// we dont handle membership ids so it can just be thrown away
+				char *membid = strchr(userv[i], ':');
+				if (membid != NULL)
+					*membid = '\0';
+
 				// if we're ignoring status (keep_new_modes is false) then just add them to chan here...
 				if (keep_new_modes == false)
 				{


### PR DESCRIPTION
This drops support for v2 (which has been eol for years now) and adds support for v4 (via the v3 compatibility layer).

I'd appreciate help testing this. I have tested it myself but I might have missed some stuff.

Closes #904.