### PR TITLE
transport/rfc1459: Skip IRCv3 message tags if they exist.

### DIFF
--- a/modules/transport/rfc1459/parse.c
+++ b/modules/transport/rfc1459/parse.c
@@ -54,6 +54,20 @@ irc_parse(char *line)
 
 		slog(LG_RAWDATA, "-> %s", line);
 
+		/* If it starts with a @ we have IRCv3 message tags.
+		 * We don't handle these so just skip them.
+		 */
+		if (*line == '@')
+		{
+			line = strchr(line, ' ');
+			if (!line)
+				goto cleanup; /* just "@tags" */
+
+			line++;
+			if (*line == '\n' || *line == '\000')
+				goto cleanup; /* just "@tags " */
+		}
+
 		// find the first space
 		if ((pos = strchr(line, ' ')))
 		{


### PR DESCRIPTION
This fixes parsing some messages on InspIRCd and other IRCds that send message tags.