### PR TITLE
[template/email] add french translation

### DIFF
--- a/email/fr/memo
+++ b/email/fr/memo
@@ -1,0 +1,17 @@
+From: &from&
+To: &to&
+Reply-To: &replyto&
+Subject: &netname& Nouveau Memo
+Date: &date&
+
+&accountname&,
+
+Vous avez un nouveau memo de &entityname& :
+
+&param&
+
+Pour désactiver cette fonctionnalité, faites /msg &nicksvs& SET EMAILMEMOS OFF via
+IRC.
+--
+Si ce message n'est pas sollicité, merci de contacter &replyto&
+avec une copie complète.

--- a/email/fr/register
+++ b/email/fr/register
@@ -1,0 +1,19 @@
+From: &from&
+To: &to&
+Reply-To: &replyto&
+Subject: &netname& Enregistrement de compte
+Date: &date&
+
+&accountname&,
+
+Pour compléter l'enregistrement de votre compte, vous devez taper la commande
+suivante sur IRC :
+
+/msg &nicksvs& VERIFY REGISTER &accountname& &param&
+
+Merci d'avoir enregistré votre compte sur le réseau IRC &netname& !
+
+--
+Ce mail a été envoyé en raison d'une commande de &sourceinfo&
+le &date&.  Si ce message n'est pas sollicité, merci de contacter &replyto&
+avec une copie complète.

--- a/email/fr/sendpass
+++ b/email/fr/sendpass
@@ -1,0 +1,18 @@
+From: &from&
+To: &to&
+Reply-To: &replyto&
+Subject: &netname& Récupération de mot de passe de compte
+Date: &date&
+
+&accountname&,
+
+Quelqu'un a demandé à ce que le mot de passe de votre compte soit
+réinitialisé, et envoyé par mail.  Si vous n'avez pas fait cette
+demande, merci de nous en informer immédiatement, car il pourrait
+s'agir d'une tentative de compromission de votre compte.
+
+Le mot de passe pour '&accountname&' est à présent '&param&'.
+
+--
+Si ce message n'est pas sollicité, merci de contacter &replyto&
+avec une copie complète.

--- a/email/fr/setemail
+++ b/email/fr/setemail
@@ -1,0 +1,18 @@
+From: &from&
+To: &to&
+Reply-To: &replyto&
+Subject: &netname& Vérification de nouvelle adresse email de compte
+Date: &date&
+
+&accountname&,
+
+Afin de compléter votre changement d'adresse mail, vous devez vérifier
+votre nouvelle adresse en envoyant les commandes suivantes sur IRC :
+
+/msg &nicksvs& VERIFY EMAILCHG &accountname& &param&
+
+Merci d'avoir mis à jour votre adresse mail avec le réseau IRC
+&netname& !
+--
+Si ce message n'est pas sollicité, merci de contacter &replyto&
+avec une copie complète.

--- a/email/fr/setpass
+++ b/email/fr/setpass
@@ -10,7 +10,7 @@ Quelqu'un a demandé à ce que le mot de passe de votre compte soit
 réinitialisé, avec un token envoyé à l'adresse mail pour ce compte.
 
 Si vous n'avez pas fait cette demande, merci d'ignorer ce message, car
-aucune action ne sera réalisé sur votre compte sans le token présent
+aucune action ne sera réalisée sur votre compte sans le token présent
 dans ce mail. Ce token sera également automatiquement invalidé la
 prochaine fois que vous vous connecterez à votre compte.
 

--- a/email/fr/setpass
+++ b/email/fr/setpass
@@ -1,0 +1,21 @@
+From: &from&
+To: &to&
+Reply-To: &replyto&
+Subject: &netname& Vérification de changement de mot de passe de compte
+Date: &date&
+
+&accountname&,
+
+Quelqu'un a demandé à ce que le mot de passe de votre compte soit
+réinitialisé, avec un token envoyé à l'adresse mail pour ce compte.
+
+Si vous n'avez pas fait cette demande, merci d'ignorer ce message, car
+aucune action ne sera réalisé sur votre compte sans le token présent
+dans ce mail. Ce token sera également automatiquement invalidé la
+prochaine fois que vous vous connecterez à votre compte.
+
+Afin de définir un nouveau mot de passe, vous devez envoyer les commandes
+suivantes sur IRC, où <mot-de-passe> est le nouveau mot de passe que vous
+souhaitez définir :
+
+/msg &nicksvs& SETPASS &accountname& &param& <mot-de-passe>


### PR DESCRIPTION
## Goal

Add french translation for email templates.

## Information

As discussed with `amdj` on IRC, there would still be some work to do to make services use this translated templates, but at least it's here now.