### PR TITLE
Fix displayed last/user seen times for logged-in Private users

### DIFF
--- a/modules/nickserv/info.c
+++ b/modules/nickserv/info.c
@@ -220,52 +220,52 @@ ns_cmd_info(struct sourceinfo *si, int parc, char *parv[])
 		// registered nickname is online
 		if (u != NULL)
 		{
-			if (!hide_info)
-				command_success_nodata(si, _("Last seen  : now"));
-			else
+			if (hide_info)
 			{
 				command_success_nodata(si, _("Last seen  : %s"), ns_obfuscate_time_ago(CURRTIME));
 				if (has_user_auspex)
 					command_success_nodata(si, _("Last seen  : (hidden) now"));
 			}
+			else
+				command_success_nodata(si, _("Last seen  : now"));
 		}
 		else
 		{
 			strftime(lastlogin, sizeof lastlogin, TIME_FORMAT, localtime(&mn->lastseen));
-			if (!hide_info)
-				command_success_nodata(si, _("Last seen  : %s (%s ago)"), lastlogin, time_ago(mn->lastseen));
-			else
+			if (hide_info)
 			{
 				command_success_nodata(si, _("Last seen  : %s"), ns_obfuscate_time_ago(mn->lastseen));
 				if (has_user_auspex)
 					command_success_nodata(si, _("Last seen  : (hidden) %s (%s ago)"), lastlogin, time_ago(mn->lastseen));
 			}
+			else
+				command_success_nodata(si, _("Last seen  : %s (%s ago)"), lastlogin, time_ago(mn->lastseen));
 		}
 	}
 
 	// account is logged in
 	if (MOWGLI_LIST_LENGTH(&mu->logins) > 0)
 	{
-		if (!hide_info)
-			command_success_nodata(si, _("User seen  : now"));
-		else
+		if (hide_info)
 		{
 			command_success_nodata(si, _("User seen  : %s"), ns_obfuscate_time_ago(CURRTIME));
 			if (has_user_auspex)
 				command_success_nodata(si, _("User seen  : (hidden) now"));
 		}
+		else
+			command_success_nodata(si, _("User seen  : now"));
 	}
 	else
 	{
 		strftime(lastlogin, sizeof lastlogin, TIME_FORMAT, localtime(&mu->lastlogin));
-		if (!hide_info)
-			command_success_nodata(si, _("User seen  : %s (%s ago)"), lastlogin, time_ago(mu->lastlogin));
-		else
+		if (hide_info)
 		{
 			command_success_nodata(si, _("User seen  : %s"), ns_obfuscate_time_ago(mu->lastlogin));
 			if (has_user_auspex)
 				command_success_nodata(si, _("User seen  : (hidden) %s (%s ago)"), lastlogin, time_ago(mu->lastlogin));
 		}
+		else
+			command_success_nodata(si, _("User seen  : %s (%s ago)"), lastlogin, time_ago(mu->lastlogin));
 	}
 
 	// if this is our account or we're a soper, show sessions

--- a/modules/nickserv/info.c
+++ b/modules/nickserv/info.c
@@ -217,53 +217,55 @@ ns_cmd_info(struct sourceinfo *si, int parc, char *parv[])
 	// we have a registered nickname
 	if (mn != NULL)
 	{
-		if (hide_info)
-			command_success_nodata(si, _("Last seen  : %s"), ns_obfuscate_time_ago(mn->lastseen));
-
 		// registered nickname is online
 		if (u != NULL)
 		{
-			// it's our nickname or the account isn't Private
 			if (!hide_info)
 				command_success_nodata(si, _("Last seen  : now"));
-			// it's not our nickname and the account is private but we're a soper
-			else if (has_user_auspex)
-				command_success_nodata(si, _("Last seen  : (hidden) now"));
+			else
+			{
+				command_success_nodata(si, _("Last seen  : %s"), ns_obfuscate_time_ago(CURRTIME));
+				if (has_user_auspex)
+					command_success_nodata(si, _("Last seen  : (hidden) now"));
+			}
 		}
-		// registered nickname is offline
 		else
 		{
 			strftime(lastlogin, sizeof lastlogin, TIME_FORMAT, localtime(&mn->lastseen));
-			// it's our nickname or the account isn't private
 			if (!hide_info)
 				command_success_nodata(si, _("Last seen  : %s (%s ago)"), lastlogin, time_ago(mn->lastseen));
-			// it's not our nickname and the account is private but we're a soper
-			else if (has_user_auspex)
-				command_success_nodata(si, _("Last seen  : (hidden) %s (%s ago)"), lastlogin, time_ago(mn->lastseen));
+			else
+			{
+				command_success_nodata(si, _("Last seen  : %s"), ns_obfuscate_time_ago(mn->lastseen));
+				if (has_user_auspex)
+					command_success_nodata(si, _("Last seen  : (hidden) %s (%s ago)"), lastlogin, time_ago(mn->lastseen));
+			}
 		}
 	}
 
-	if (hide_info)
-		command_success_nodata(si, _("User seen  : %s"), ns_obfuscate_time_ago(mu->lastlogin));
 	// account is logged in
 	if (MOWGLI_LIST_LENGTH(&mu->logins) > 0)
 	{
-		// it's our account or the account isn't private
 		if (!hide_info)
 			command_success_nodata(si, _("User seen  : now"));
-		// it's not our account and the account is private but we're a soper
-		else if (has_user_auspex)
-			command_success_nodata(si, _("User seen  : (hidden) now"));
+		else
+		{
+			command_success_nodata(si, _("User seen  : %s"), ns_obfuscate_time_ago(CURRTIME));
+			if (has_user_auspex)
+				command_success_nodata(si, _("User seen  : (hidden) now"));
+		}
 	}
 	else
 	{
 		strftime(lastlogin, sizeof lastlogin, TIME_FORMAT, localtime(&mu->lastlogin));
-		// it's our account or the account isn't private
 		if (!hide_info)
 			command_success_nodata(si, _("User seen  : %s (%s ago)"), lastlogin, time_ago(mu->lastlogin));
-		// it's not our account and the account is private but we're a soper
-		else if (has_user_auspex)
-			command_success_nodata(si, _("User seen  : (hidden) %s (%s ago)"), lastlogin, time_ago(mu->lastlogin));
+		else
+		{
+			command_success_nodata(si, _("User seen  : %s"), ns_obfuscate_time_ago(mu->lastlogin));
+			if (has_user_auspex)
+				command_success_nodata(si, _("User seen  : (hidden) %s (%s ago)"), lastlogin, time_ago(mu->lastlogin));
+		}
 	}
 
 	// if this is our account or we're a soper, show sessions


### PR DESCRIPTION
NS INFO, when the target user is Private, would unconditionally use `mn->lastseen` and `mu->lastlogin`. The upshot is that when a session has used a nick/account for a long enough without triggering anything that would cause these values to update (e.g. nick changes, secondary logins), the displayed times would increase.

This would lead to stuff like this (seen in the wild):
```
Last seen  : (about 2 weeks ago)
Last seen  : (hidden) now
User seen  : (about 2 weeks ago)
User seen  : (hidden) now
```

Those times (for the non-auspex lines) should say "less than two weeks ago".

This PR fixes the display without routinely updating the `lastseen` or `lastlogin` times
by moving the `command_success_nodata` call for `hide_info` into the `is online` checks,
and passing `CURRTIME` to `ns_obfuscate_time_ago` if the target is online.