### PR TITLE
Always send OPERTYPE on InspIRCd

### DIFF
--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -369,7 +369,7 @@ inspircd_introduce_nick(struct user *u)
 {
 	// :penguin.omega.org.za UID 497AAAAAB 1188302517 OperServ 127.0.0.1 127.0.0.1 OperServ +s 127.0.0.1 :Operator Server
 	const char *umode = user_get_umodestr(u);
-	const bool send_oper = (is_ircop(u) && !has_servprotectmod);
+	const bool send_oper = is_ircop(u);
 
 	sts(":%s UID %s %lu %s %s %s %s 0.0.0.0 %lu %s%s%s%s :%s", me.numeric, u->uid, (unsigned long)u->ts, u->nick, u->host, u->host, u->user, (unsigned long)u->ts, umode, (send_oper && has_hideopermod) ? "H" : "", has_hidechansmod ? "I" : "", has_servprotectmod ? "k" : "", u->gecos);
 	if (send_oper)


### PR DESCRIPTION
Since v4 a remote user must be an operator to send mass messages.

This fixes an issue reported by @gokturkyilmaz on IRC.