### PR TITLE
Avoid year-2038-problem

### DIFF
--- a/include/atheme/tools.h
+++ b/include/atheme/tools.h
@@ -105,6 +105,7 @@ const char *create_weak_challenge(struct sourceinfo *si, const char *name);
 void tb2sp(char *line);
 char *replace(char *s, int size, const char *old, const char *new);
 const char *number_to_string(int num);
+const char *int64_to_string(int64_t num);
 bool string_to_uint(const char *, unsigned int *) ATHEME_FATTR_WUR;
 bool validhostmask(const char *host);
 char *pretty_mask(char *mask);

--- a/libathemecore/function.c
+++ b/libathemecore/function.c
@@ -170,6 +170,14 @@ number_to_string(int num)
 	return ret;
 }
 
+/* reverse of atoll() */
+const char *int64_to_string(int64_t num)
+{
+	static char ret[32];
+	snprintf(ret, 32, "%lld", (long long)num);
+	return ret;
+}
+
 /* a better atoi() but detects errors and doesn't allow negative values */
 bool ATHEME_FATTR_WUR
 string_to_uint(const char *const restrict in, unsigned int *const restrict out)

--- a/libathemecore/services.c
+++ b/libathemecore/services.c
@@ -204,7 +204,7 @@ join(const char *chan, const char *nick)
 			ts = mc->registered;
 			md = metadata_find(mc, "private:channelts");
 			if (md != NULL)
-				ts = atol(md->value);
+				ts = atoll(md->value);
 			if (ts == 0)
 				ts = CURRTIME;
 		}
@@ -712,7 +712,7 @@ myuser_login(struct service *svs, struct user *u, struct myuser *mu, bool sendac
 
 		md_failtime = metadata_find(mu, "private:loginfail:lastfailtime");
 		if (md_failtime != NULL)
-			ts = atol(md_failtime->value);
+			ts = atoll(md_failtime->value);
 
 		md_failaddr = metadata_find(mu, "private:loginfail:lastfailaddr");
 		if (md_failaddr != NULL)

--- a/modules/backend/flatfile.c
+++ b/modules/backend/flatfile.c
@@ -196,7 +196,7 @@ flatfile_db_load(const char *filename)
 
 			mu = myuser_find(strtok(NULL, " "));
 			sender = strtok(NULL, " ");
-			mtime = atoi(strtok(NULL, " "));
+			mtime = atoll(strtok(NULL, " "));
 			status = atoi(strtok(NULL, " "));
 			text = strtok(NULL, "\n");
 
@@ -284,8 +284,8 @@ flatfile_db_load(const char *filename)
 			}
 
 			mn = mynick_add(mu, nick);
-			mn->registered = atoi(treg);
-			mn->lastseen = atoi(tseen);
+			mn->registered = atoll(treg);
+			mn->lastseen = atoll(tseen);
 		}
 		else if (!strcmp("MCFP", item))
 		{
@@ -361,8 +361,8 @@ flatfile_db_load(const char *filename)
 
 				founder = myuser_find(strtok(NULL, " "));
 
-				mc->registered = atoi(strtok(NULL, " "));
-				mc->used = atoi(strtok(NULL, " "));
+				mc->registered = atoll(strtok(NULL, " "));
+				mc->used = atoll(strtok(NULL, " "));
 				mc->flags = atoi(strtok(NULL, " "));
 
 				mc->mlock_on = atoi(strtok(NULL, " "));
@@ -504,7 +504,7 @@ flatfile_db_load(const char *filename)
 					 */
 					tsstr = strtok(NULL, " ");
 					if (tsstr != NULL)
-						ts = atoi(tsstr);
+						ts = atoll(tsstr);
 
 					/* previous to CA_ACLVIEW, everyone could view
 					 * access lists. If they aren't AKICKed, upgrade
@@ -583,7 +583,7 @@ flatfile_db_load(const char *filename)
 
 			mask = strtok(NULL, " ");
                         tmp = strtok(NULL, " ");
-			settime = atol(tmp);
+			settime = atoll(tmp);
 			setby = strtok(NULL, " ");
 			reason = strtok(NULL, "");
 
@@ -612,7 +612,7 @@ flatfile_db_load(const char *filename)
 			tmp = strtok(NULL, " ");
 			duration = atol(tmp);
 			tmp = strtok(NULL, " ");
-			settime = atol(tmp);
+			settime = atoll(tmp);
 			setby = strtok(NULL, " ");
 			reason = strtok(NULL, "");
 
@@ -642,7 +642,7 @@ flatfile_db_load(const char *filename)
 			tmp = strtok(NULL, " ");
 			duration = atol(tmp);
 			tmp = strtok(NULL, " ");
-			settime = atol(tmp);
+			settime = atoll(tmp);
 			setby = strtok(NULL, " ");
 			reason = strtok(NULL, "");
 
@@ -672,7 +672,7 @@ flatfile_db_load(const char *filename)
 			tmp = strtok(NULL, " ");
 			duration = atol(tmp);
 			tmp = strtok(NULL, " ");
-			settime = atol(tmp);
+			settime = atoll(tmp);
 			setby = strtok(NULL, " ");
 			reason = strtok(NULL, "");
 

--- a/modules/chanfix/fix.c
+++ b/modules/chanfix/fix.c
@@ -619,7 +619,7 @@ chanfix_cmd_info(struct sourceinfo *si, int parc, char *parv[])
 		reason = md != NULL ? md->value : "unknown";
 
 		md = metadata_find(chan, "private:mark:timestamp");
-		ts = md != NULL ? atoi(md->value) : 0;
+		ts = md != NULL ? atoll(md->value) : 0;
 
 		tm = localtime(&ts);
 		strftime(strfbuf, sizeof strfbuf, TIME_FORMAT, tm);
@@ -637,7 +637,7 @@ chanfix_cmd_info(struct sourceinfo *si, int parc, char *parv[])
                 reason = md != NULL ? md->value : "unknown";
 
                 md = metadata_find(chan, "private:mark:timestamp");
-                ts = md != NULL ? atoi(md->value) : 0;
+                ts = md != NULL ? atoll(md->value) : 0;
 
                 tm = localtime(&ts);
                 strftime(strfbuf, sizeof strfbuf, TIME_FORMAT, tm);
@@ -694,7 +694,7 @@ chanfix_cmd_mark(struct sourceinfo *si, int parc, char *parv[])
 
 		metadata_add(chan, "private:mark:setter", get_oper_name(si));
 		metadata_add(chan, "private:mark:reason", info);
-		metadata_add(chan, "private:mark:timestamp", number_to_string(CURRTIME));
+		metadata_add(chan, "private:mark:timestamp", int64_to_string(CURRTIME));
 
 		logcommand(si, CMDLOG_ADMIN, "MARK:ON: \2%s\2 (reason: \2%s\2)", chan->name, info);
 		command_success_nodata(si, _("\2%s\2 is now marked."), target);
@@ -767,7 +767,7 @@ chanfix_cmd_nofix(struct sourceinfo *si, int parc, char *parv[])
 
 		metadata_add(chan, "private:nofix:setter", get_oper_name(si));
 		metadata_add(chan, "private:nofix:reason", info);
-		metadata_add(chan, "private:nofix:timestamp", number_to_string(CURRTIME));
+		metadata_add(chan, "private:nofix:timestamp", int64_to_string(CURRTIME));
 
 		logcommand(si, CMDLOG_ADMIN, "NOFIX:ON: \2%s\2 (reason: \2%s\2)", chan->name, info);
 		command_success_nodata(si, _("\2%s\2 is now set to NOFIX."), target);

--- a/modules/chanserv/close.c
+++ b/modules/chanserv/close.c
@@ -87,7 +87,7 @@ cs_cmd_close(struct sourceinfo *si, int parc, char *parv[])
 
 		metadata_add(mc, "private:close:closer", get_oper_name(si));
 		metadata_add(mc, "private:close:reason", reason);
-		metadata_add(mc, "private:close:timestamp", number_to_string(CURRTIME));
+		metadata_add(mc, "private:close:timestamp", int64_to_string(CURRTIME));
 
 		if ((c = channel_find(target)))
 		{

--- a/modules/chanserv/info.c
+++ b/modules/chanserv/info.c
@@ -286,7 +286,7 @@ cs_cmd_info(struct sourceinfo *si, int parc, char *parv[])
 		reason = md != NULL ? md->value : "unknown";
 
 		md = metadata_find(mc, "private:mark:timestamp");
-		ts = md != NULL ? atoi(md->value) : 0;
+		ts = md != NULL ? atoll(md->value) : 0;
 
 		tm = localtime(&ts);
 		strftime(strfbuf, sizeof strfbuf, TIME_FORMAT, tm);
@@ -307,7 +307,7 @@ cs_cmd_info(struct sourceinfo *si, int parc, char *parv[])
 		reason = md != NULL ? md->value : "unknown";
 
 		md = metadata_find(mc, "private:close:timestamp");
-		ts = md != NULL ? atoi(md->value) : 0;
+		ts = md != NULL ? atoll(md->value) : 0;
 
 		tm = localtime(&ts);
 		strftime(strfbuf, sizeof strfbuf, TIME_FORMAT, tm);

--- a/modules/chanserv/main.c
+++ b/modules/chanserv/main.c
@@ -581,7 +581,7 @@ cs_keeptopic_topicset(struct channel *c)
 		metadata_add(mc, "private:topic:text",
 			c->topic);
 		metadata_add(mc, "private:topic:ts",
-			number_to_string(c->topicts));
+			int64_to_string(c->topicts));
 	}
 	else
 		slog(LG_DEBUG, "KeepTopic: topic cleared for %s", c->name);
@@ -651,7 +651,7 @@ cs_newchan(struct channel *c)
 
 	md = metadata_find(mc, "private:channelts");
 	if (md != NULL)
-		channelts = atol(md->value);
+		channelts = atoll(md->value);
 	if (channelts == 0)
 		channelts = mc->registered;
 
@@ -717,7 +717,7 @@ cs_newchan(struct channel *c)
 	md = metadata_find(mc, "private:topic:ts");
 	if (md == NULL)
 		return;
-	topicts = atol(md->value);
+	topicts = atoll(md->value);
 
 	handle_topic(c, setter, topicts, text);
 	topic_sts(c, chansvs.me->me, setter, topicts, 0, text);

--- a/modules/chanserv/mark.c
+++ b/modules/chanserv/mark.c
@@ -53,7 +53,7 @@ cs_cmd_mark(struct sourceinfo *si, int parc, char *parv[])
 
 		metadata_add(mc, "private:mark:setter", get_oper_name(si));
 		metadata_add(mc, "private:mark:reason", info);
-		metadata_add(mc, "private:mark:timestamp", number_to_string(CURRTIME));
+		metadata_add(mc, "private:mark:timestamp", int64_to_string(CURRTIME));
 
 		wallops("\2%s\2 marked the channel \2%s\2.", get_oper_name(si), target);
 		logcommand(si, CMDLOG_ADMIN, "MARK:ON: \2%s\2 (reason: \2%s\2)", mc->name, info);

--- a/modules/hostserv/vhost.c
+++ b/modules/hostserv/vhost.c
@@ -89,7 +89,7 @@ hs_cmd_listvhost(struct sourceinfo *si, int parc, char *parv[])
 
 			if (md_timestamp)
 			{
-				vhost_time = atoi(md_timestamp->value);
+				vhost_time = atoll(md_timestamp->value);
 				tm = localtime(&vhost_time);
 				strftime(strfbuf, sizeof strfbuf, TIME_FORMAT, tm);
 				len += snprintf(buf + len, BUFSIZE - len, _(" on %s (%s ago)"), strfbuf, time_ago(vhost_time));

--- a/modules/nickserv/freeze.c
+++ b/modules/nickserv/freeze.c
@@ -85,7 +85,7 @@ ns_cmd_freeze(struct sourceinfo *si, int parc, char *parv[])
 
 		metadata_add(mu, "private:freeze:freezer", get_oper_name(si));
 		metadata_add(mu, "private:freeze:reason", reason);
-		metadata_add(mu, "private:freeze:timestamp", number_to_string(CURRTIME));
+		metadata_add(mu, "private:freeze:timestamp", int64_to_string(CURRTIME));
 
 		// log them out
 		MOWGLI_ITER_FOREACH_SAFE(n, tn, mu->logins.head)

--- a/modules/nickserv/info.c
+++ b/modules/nickserv/info.c
@@ -82,7 +82,7 @@ ns_cmd_info(struct sourceinfo *si, int parc, char *parv[])
 			md = metadata_find(mun, "private:mark:reason");
 			reason = md != NULL ? md->value : "unknown";
 			md = metadata_find(mun, "private:mark:timestamp");
-			ts = md != NULL ? atoi(md->value) : 0;
+			ts = md != NULL ? atoll(md->value) : 0;
 
 			tm = localtime(&ts);
 			strftime(strfbuf, sizeof strfbuf, TIME_FORMAT, tm);
@@ -167,7 +167,7 @@ ns_cmd_info(struct sourceinfo *si, int parc, char *parv[])
 
 		if (vhost_timestring && (vhost || has_user_auspex))
 		{
-			vhost_time = atoi(vhost_timestring);
+			vhost_time = atoll(vhost_timestring);
 			tm2 = localtime(&vhost_time);
 			strftime(strfbuf, sizeof strfbuf, TIME_FORMAT, tm2);
 			buflen += snprintf(buf + buflen, BUFSIZE - buflen, _(" on %s (%s ago)"), strfbuf, time_ago(vhost_time));
@@ -458,7 +458,7 @@ ns_cmd_info(struct sourceinfo *si, int parc, char *parv[])
 		reason = md != NULL ? md->value : "unknown";
 
 		md = metadata_find(mu, "private:freeze:timestamp");
-		ts = md != NULL ? atoi(md->value) : 0;
+		ts = md != NULL ? atoll(md->value) : 0;
 
 		tm = localtime(&ts);
 		strftime(strfbuf, sizeof strfbuf, TIME_FORMAT, tm);
@@ -478,7 +478,7 @@ ns_cmd_info(struct sourceinfo *si, int parc, char *parv[])
 		reason = md != NULL ? md->value : "unknown";
 
 		md = metadata_find(mu, "private:mark:timestamp");
-		ts = md != NULL ? atoi(md->value) : 0;
+		ts = md != NULL ? atoll(md->value) : 0;
 
 		tm = localtime(&ts);
 		strftime(strfbuf, sizeof strfbuf, TIME_FORMAT, tm);
@@ -496,7 +496,7 @@ ns_cmd_info(struct sourceinfo *si, int parc, char *parv[])
 		time_t ts;
 
 		md = metadata_find(mu, "private:verify:emailchg:timestamp");
-		ts = md != NULL ? atoi(md->value) : 0;
+		ts = md != NULL ? atoll(md->value) : 0;
 		tm = localtime(&ts);
 		strftime(strfbuf, sizeof strfbuf, TIME_FORMAT, tm);
 

--- a/modules/nickserv/mark.c
+++ b/modules/nickserv/mark.c
@@ -85,7 +85,7 @@ ns_cmd_mark(struct sourceinfo *si, int parc, char *parv[])
 
 		metadata_add(mu, "private:mark:setter", get_oper_name(si));
 		metadata_add(mu, "private:mark:reason", info);
-		metadata_add(mu, "private:mark:timestamp", number_to_string(time(NULL)));
+		metadata_add(mu, "private:mark:timestamp", int64_to_string(time(NULL)));
 
 		wallops("\2%s\2 marked the account \2%s\2.", get_oper_name(si), entity(mu)->name);
 		logcommand(si, CMDLOG_ADMIN, "MARK:ON: \2%s\2 (reason: \2%s\2)", entity(mu)->name, info);

--- a/modules/nickserv/multimark.c
+++ b/modules/nickserv/multimark.c
@@ -293,7 +293,7 @@ migrate_user(struct myuser *mu)
 	md = metadata_find(mu, "private:mark:reason");
 	reason = md != NULL ? md->value : "unknown";
 	md = metadata_find(mu, "private:mark:timestamp");
-	time = md != NULL ? atoi(md->value) : 0;
+	time = md != NULL ? atoll(md->value) : 0;
 
 	struct multimark *const mm = smalloc(sizeof *mm);
 

--- a/modules/nickserv/register.c
+++ b/modules/nickserv/register.c
@@ -179,7 +179,7 @@ ns_cmd_register(struct sourceinfo *si, int parc, char *parv[])
 		mu->flags |= MU_WAITAUTH;
 
 		metadata_add(mu, "private:verify:register:key", key);
-		metadata_add(mu, "private:verify:register:timestamp", number_to_string(time(NULL)));
+		metadata_add(mu, "private:verify:register:timestamp", int64_to_string(time(NULL)));
 
 		if (!sendemail(si->su != NULL ? si->su : si->service->me, mu, EMAIL_REGISTER, mu->email, key))
 		{

--- a/modules/nickserv/resetpass.c
+++ b/modules/nickserv/resetpass.c
@@ -72,7 +72,7 @@ ns_cmd_resetpass(struct sourceinfo *si, int parc, char *parv[])
 
 	metadata_delete(mu, "private:setpass:key");
 	metadata_add(mu, "private:sendpass:sender", get_oper_name(si));
-	metadata_add(mu, "private:sendpass:timestamp", number_to_string(time(NULL)));
+	metadata_add(mu, "private:sendpass:timestamp", int64_to_string(time(NULL)));
 	command_success_nodata(si, _("The password for \2%s\2 has been changed to \2%s\2."), entity(mu)->name, newpass);
 
 	sfree(newpass);

--- a/modules/nickserv/restrict.c
+++ b/modules/nickserv/restrict.c
@@ -52,7 +52,7 @@ info_hook(struct hook_user_req *hdata)
 		reason = md != NULL ? md->value : "unknown";
 
 		md = metadata_find(hdata->mu, "private:restrict:timestamp");
-		ts = md != NULL ? atoi(md->value) : 0;
+		ts = md != NULL ? atoll(md->value) : 0;
 
 		tm = localtime(&ts);
 		strftime(strfbuf, sizeof strfbuf, TIME_FORMAT, tm);
@@ -99,7 +99,7 @@ ns_cmd_restrict(struct sourceinfo *si, int parc, char *parv[])
 
 		metadata_add(mu, "private:restrict:setter", get_oper_name(si));
 		metadata_add(mu, "private:restrict:reason", info);
-		metadata_add(mu, "private:restrict:timestamp", number_to_string(time(NULL)));
+		metadata_add(mu, "private:restrict:timestamp", int64_to_string(time(NULL)));
 
 		wallops("\2%s\2 restricted the account \2%s\2.", get_oper_name(si), entity(mu)->name);
 		logcommand(si, CMDLOG_ADMIN, "RESTRICT:ON: \2%s\2 (reason: \2%s\2)", entity(mu)->name, info);

--- a/modules/nickserv/sendpass_user.c
+++ b/modules/nickserv/sendpass_user.c
@@ -123,7 +123,7 @@ ns_cmd_sendpass(struct sourceinfo *si, int parc, char *parv[])
 			wallops("\2%s\2 sent the password for the \2MARKED\2 account %s.", get_oper_name(si), entity(mu)->name);
 		logcommand(si, CMDLOG_ADMIN, "SENDPASS: \2%s\2 (change key)", name);
 		metadata_add(mu, "private:sendpass:sender", get_oper_name(si));
-		metadata_add(mu, "private:sendpass:timestamp", number_to_string(time(NULL)));
+		metadata_add(mu, "private:sendpass:timestamp", int64_to_string(time(NULL)));
 		metadata_add(mu, "private:setpass:key", hash);
 		command_success_nodata(si, _("The password change key for \2%s\2 has been sent to the corresponding email address."), entity(mu)->name);
 	}

--- a/modules/nickserv/set_email.c
+++ b/modules/nickserv/set_email.c
@@ -59,7 +59,7 @@ ns_cmd_set_email(struct sourceinfo *si, int parc, char *parv[])
 
 		metadata_add(si->smu, "private:verify:emailchg:key", number_to_string(key));
 		metadata_add(si->smu, "private:verify:emailchg:newemail", email);
-		metadata_add(si->smu, "private:verify:emailchg:timestamp", number_to_string(CURRTIME));
+		metadata_add(si->smu, "private:verify:emailchg:timestamp", int64_to_string(CURRTIME));
 
 		if (!sendemail(si->su != NULL ? si->su : si->service->me, si->smu, EMAIL_SETEMAIL, email, number_to_string(key)))
 		{

--- a/modules/nickserv/setpass.c
+++ b/modules/nickserv/setpass.c
@@ -126,7 +126,7 @@ show_setpass(struct hook_user_req *hdata)
 			struct tm *tm;
 
 			md = metadata_find(hdata->mu, "private:sendpass:timestamp");
-			ts = md != NULL ? atoi(md->value) : 0;
+			ts = md != NULL ? atoll(md->value) : 0;
 
 			tm = localtime(&ts);
 			strftime(strfbuf, sizeof strfbuf, TIME_FORMAT, tm);

--- a/modules/protocol/asuka.c
+++ b/modules/protocol/asuka.c
@@ -149,7 +149,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 		slog(LG_DEBUG, "m_nick(): new user on `%s': %s", si->s->name, parv[0]);
 
 		decode_p10_ip(parv[parc - 3], ipstring);
-		u = user_add(parv[0], parv[3], parv[4], NULL, ipstring, parv[parc - 2], parv[parc - 1], si->s, atoi(parv[2]));
+		u = user_add(parv[0], parv[3], parv[4], NULL, ipstring, parv[parc - 2], parv[parc - 1], si->s, atoll(parv[2]));
 		if (u == NULL)
 			return;
 
@@ -217,7 +217,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 
 		slog(LG_DEBUG, "m_nick(): nickname change from `%s': %s", si->su->nick, parv[0]);
 
-		if (user_changenick(si->su, parv[0], atoi(parv[1])))
+		if (user_changenick(si->su, parv[0], atoll(parv[1])))
 			return;
 
 		handle_nickchange(si->su);

--- a/modules/protocol/bahamut.c
+++ b/modules/protocol/bahamut.c
@@ -516,7 +516,7 @@ m_sjoin(struct sourceinfo *si, int parc, char *parv[])
 	{
 		// :origin SJOIN ts chan modestr [key or limits] :users
 		c = channel_find(parv[1]);
-		ts = atol(parv[0]);
+		ts = atoll(parv[0]);
 
 		if (!c)
 		{
@@ -592,7 +592,7 @@ m_sjoin(struct sourceinfo *si, int parc, char *parv[])
 	else if (parc >= 2 && si->su != NULL)
 	{
 		c = channel_find(parv[1]);
-		ts = atol(parv[0]);
+		ts = atoll(parv[0]);
 
 		if (c == NULL || ts < c->ts)
 		{
@@ -661,7 +661,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 		else
 			mowgli_strlcpy(ipstring, parv[8], sizeof ipstring);
 
-		u = user_add(parv[0], parv[4], parv[5], NULL, ipstring, NULL, parv[9], s, atoi(parv[2]));
+		u = user_add(parv[0], parv[4], parv[5], NULL, ipstring, NULL, parv[9], s, atoll(parv[2]));
 		if (u == NULL)
 			return;
 
@@ -697,7 +697,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 
 		realchange = irccasecmp(si->su->nick, parv[0]);
 
-		if (user_changenick(si->su, parv[0], atoi(parv[1])))
+		if (user_changenick(si->su, parv[0], atoll(parv[1])))
 			return;
 
 		// fix up +r if necessary -- jilles

--- a/modules/protocol/inspircd.c
+++ b/modules/protocol/inspircd.c
@@ -801,7 +801,7 @@ static void
 m_ftopic(struct sourceinfo *si, int parc, char *parv[])
 {
 	struct channel *c = channel_find(parv[0]);
-	time_t ts = atol(parv[2]);
+	time_t ts = atoll(parv[2]);
 	const char *setter;
 
 	if (!c)
@@ -935,7 +935,7 @@ m_fjoin(struct sourceinfo *si, int parc, char *parv[])
 	time_t ts;
 
 	c = channel_find(parv[0]);
-	ts = atol(parv[1]);
+	ts = atoll(parv[1]);
 
 	if (!c)
 	{
@@ -1102,7 +1102,7 @@ m_uid(struct sourceinfo *si, int parc, char *parv[])
 	slog(LG_DEBUG, "m_uid(): new user on `%s': %s", si->s->name, parv[2]);
 
 	//            nick,    user,    host,    vhost,    ip,      uid,        gecos,    server,       ts
-	u = user_add(parv[2], parv[5], parv[3], parv[4], parv[6], parv[0], parv[parc - 1], si->s, atol(parv[1]));
+	u = user_add(parv[2], parv[5], parv[3], parv[4], parv[6], parv[0], parv[parc - 1], si->s, atoll(parv[1]));
 
 	if (u == NULL)
 		return;
@@ -1119,7 +1119,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 {
 	slog(LG_DEBUG, "m_nick(): nickname change from `%s': %s", si->su->nick, parv[0]);
 
-	if (user_changenick(si->su, parv[0], atoi(parv[1])))
+	if (user_changenick(si->su, parv[0], atoll(parv[1])))
 		return;
 
 	/* It could happen that our PING arrived late and the
@@ -1202,7 +1202,7 @@ m_fmode(struct sourceinfo *si, int parc, char *parv[])
 			slog(LG_DEBUG, "m_fmode(): nonexistent channel: %s", parv[0]);
 			return;
 		}
-		ts = atoi(parv[1]);
+		ts = atoll(parv[1]);
 		if (ts > c->ts)
 		{
 			return;
@@ -1500,7 +1500,7 @@ m_metadata(struct sourceinfo *si, int parc, char *parv[])
 	if (parc > 3)
 	{
 		c = channel_find(parv[0]);
-		ts = atoi(parv[1]);
+		ts = atoll(parv[1]);
 
 		if (!irccasecmp(parv[2], "mlock"))
 			verify_mlock(c, ts, parv[3]);

--- a/modules/protocol/nefarious.c
+++ b/modules/protocol/nefarious.c
@@ -252,7 +252,7 @@ m_topic(struct sourceinfo *si, int parc, char *parv[])
 		source = si->su->nick;
 
 	if (parc > 2)
-		ts = atoi(parv[parc - 2]);
+		ts = atoll(parv[parc - 2]);
 	if (ts == 0)
 		ts = CURRTIME;
 	else if (c->topic != NULL && ts < c->topicts)
@@ -282,7 +282,7 @@ m_burst(struct sourceinfo *si, int parc, char *parv[])
 	 * %<bans separated with spaces>
 	 * <nicks>
 	 */
-	ts = atoi(parv[1]);
+	ts = atoll(parv[1]);
 
 	c = channel_find(parv[0]);
 
@@ -400,7 +400,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 		slog(LG_DEBUG, "m_nick(): new user on `%s': %s@%s (%s)", si->s->name, parv[0],parv[4],parv[7]);
 
 		decode_p10_ip(parv[parc - 3], ipstring);
-		u = user_add(parv[0], parv[3], parv[4], parv[7], ipstring, parv[parc - 2], parv[parc - 1], si->s, atoi(parv[2]));
+		u = user_add(parv[0], parv[3], parv[4], parv[7], ipstring, parv[parc - 2], parv[parc - 1], si->s, atoll(parv[2]));
 		if (u == NULL)
 			return;
 
@@ -476,7 +476,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 
 		slog(LG_DEBUG, "m_nick(): nickname change from `%s': %s", si->su->nick, parv[0]);
 
-		if (user_changenick(si->su, parv[0], atoi(parv[1])))
+		if (user_changenick(si->su, parv[0], atoll(parv[1])))
 			return;
 
 		handle_nickchange(si->su);

--- a/modules/protocol/p10-generic.c
+++ b/modules/protocol/p10-generic.c
@@ -355,7 +355,7 @@ m_topic(struct sourceinfo *si, int parc, char *parv[])
 		source = si->su->nick;
 
 	if (parc > 2)
-		ts = atoi(parv[parc - 2]);
+		ts = atoll(parv[parc - 2]);
 	if (ts == 0)
 		ts = CURRTIME;
 	else if (c->topic != NULL && ts < c->topicts)
@@ -430,7 +430,7 @@ m_create(struct sourceinfo *si, int parc, char *parv[])
 
 	for (i = 0; i < chanc; i++)
 	{
-		struct channel *c = channel_add(chanv[i], ts = atoi(parv[1]), si->su->server);
+		struct channel *c = channel_add(chanv[i], ts = atoll(parv[1]), si->su->server);
 
 		/* Tell the core to check mode locks now,
 		 * otherwise it may only happen after the next
@@ -483,7 +483,7 @@ m_join(struct sourceinfo *si, int parc, char *parv[])
 
 		if (!c)
 		{
-			c = channel_add(chanv[i], atoi(parv[1]), si->su->server);
+			c = channel_add(chanv[i], atoll(parv[1]), si->su->server);
 			channel_mode_va(NULL, c, 1, "+");
 		}
 
@@ -513,7 +513,7 @@ m_burst(struct sourceinfo *si, int parc, char *parv[])
 	 * %<bans separated with spaces>
 	 * <nicks>
 	 */
-	ts = atoi(parv[1]);
+	ts = atoll(parv[1]);
 
 	c = channel_find(parv[0]);
 
@@ -645,7 +645,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 		slog(LG_DEBUG, "m_nick(): new user on `%s': %s", si->s->name, parv[0]);
 
 		decode_p10_ip(parv[parc - 3], ipstring);
-		u = user_add(parv[0], parv[3], parv[4], NULL, ipstring, parv[parc - 2], parv[parc - 1], si->s, atoi(parv[2]));
+		u = user_add(parv[0], parv[3], parv[4], NULL, ipstring, parv[parc - 2], parv[parc - 1], si->s, atoll(parv[2]));
 		if (u == NULL)
 			return;
 
@@ -685,7 +685,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 
 		slog(LG_DEBUG, "m_nick(): nickname change from `%s': %s", si->su->nick, parv[0]);
 
-		if (user_changenick(si->su, parv[0], atoi(parv[1])))
+		if (user_changenick(si->su, parv[0], atoll(parv[1])))
 			return;
 
 		handle_nickchange(si->su);
@@ -752,7 +752,7 @@ m_mode(struct sourceinfo *si, int parc, char *parv[])
 					  i++;
 			}
 		}
-		if (i < parc && (ts = atoi(parv[i])) != 0)
+		if (i < parc && (ts = atoll(parv[i])) != 0)
 		{
 			if (ts > c->ts)
 			{

--- a/modules/protocol/solanum.c
+++ b/modules/protocol/solanum.c
@@ -136,7 +136,7 @@ m_euid(struct sourceinfo *si, int parc, char *parv[])
 			parv[7],				// uid
 			parv[parc - 1],				// gecos
 			s,					// object parent (server)
-			atoi(parv[2]));				// hopcount
+			atoll(parv[2]));			// hopcount
 		if (u == NULL)
 			return;
 
@@ -191,7 +191,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 
 		slog(LG_DEBUG, "m_nick(): new user on `%s': %s", s->name, parv[0]);
 
-		u = user_add(parv[0], parv[4], parv[5], NULL, NULL, NULL, parv[7], s, atoi(parv[2]));
+		u = user_add(parv[0], parv[4], parv[5], NULL, NULL, NULL, parv[7], s, atoll(parv[2]));
 		if (u == NULL)
 			return;
 
@@ -218,7 +218,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 
 		realchange = irccasecmp(si->su->nick, parv[0]);
 
-		if (user_changenick(si->su, parv[0], atoi(parv[1])))
+		if (user_changenick(si->su, parv[0], atoll(parv[1])))
 			return;
 
 		// fix up +e if necessary -- jilles

--- a/modules/protocol/ts6-generic.c
+++ b/modules/protocol/ts6-generic.c
@@ -591,7 +591,7 @@ m_mlock(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	time_t ts = atol(parv[0]);
+	time_t ts = atoll(parv[0]);
 	if (ts > c->ts)
 		return;
 
@@ -619,7 +619,7 @@ static void
 m_tb(struct sourceinfo *si, int parc, char *parv[])
 {
 	struct channel *c = channel_find(parv[0]);
-	time_t ts = atol(parv[1]);
+	time_t ts = atoll(parv[1]);
 
 	if (c == NULL)
 		return;
@@ -650,8 +650,8 @@ m_etb(struct sourceinfo *si, int parc, char *parv[])
 			!(si->s->flags & SF_EOB) && c->topic != NULL)
 		return;
 
-	channelts = atol(parv[0]);
-	topicts = atol(parv[2]);
+	channelts = atoll(parv[0]);
+	topicts = atoll(parv[2]);
 	if (c->topic == NULL || channelts < c->ts || (channelts == c->ts && topicts > c->topicts))
 		handle_topic_from(si, c, parv[3], topicts, parv[parc - 1]);
 }
@@ -732,7 +732,7 @@ m_sjoin(struct sourceinfo *si, int parc, char *parv[])
 
 	// :origin SJOIN ts chan modestr [key or limits] :users
 	c = channel_find(parv[1]);
-	ts = atol(parv[0]);
+	ts = atoll(parv[0]);
 
 	if (!c)
 	{
@@ -835,7 +835,7 @@ m_join(struct sourceinfo *si, int parc, char *parv[])
 
 	// :user JOIN ts chan modestr [key or limits]
 	c = channel_find(parv[1]);
-	ts = atol(parv[0]);
+	ts = atoll(parv[0]);
 
 	if (!c)
 	{
@@ -950,7 +950,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 
 		slog(LG_DEBUG, "m_nick(): new user on `%s': %s", s->name, parv[0]);
 
-		u = user_add(parv[0], parv[4], parv[5], NULL, NULL, NULL, parv[7], s, atoi(parv[2]));
+		u = user_add(parv[0], parv[4], parv[5], NULL, NULL, NULL, parv[7], s, atoll(parv[2]));
 		if (u == NULL)
 			return;
 
@@ -975,7 +975,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 
 		slog(LG_DEBUG, "m_nick(): nickname change from `%s': %s", si->su->nick, parv[0]);
 
-		if (user_changenick(si->su, parv[0], atoi(parv[1])))
+		if (user_changenick(si->su, parv[0], atoll(parv[1])))
 			return;
 
 		/* It could happen that our PING arrived late and the
@@ -1006,7 +1006,7 @@ m_uid(struct sourceinfo *si, int parc, char *parv[])
 		s = si->s;
 		slog(LG_DEBUG, "m_uid(): new user on `%s': %s", s->name, parv[0]);
 
-		u = user_add(parv[0], parv[4], parv[5], NULL, parv[6], parv[7], parv[8], s, atoi(parv[2]));
+		u = user_add(parv[0], parv[4], parv[5], NULL, parv[6], parv[7], parv[8], s, atoll(parv[2]));
 		if (u == NULL)
 			return;
 
@@ -1050,7 +1050,7 @@ m_euid(struct sourceinfo *si, int parc, char *parv[])
 			parv[7],				// uid
 			parv[parc - 1],				// gecos
 			s,					// object parent (server)
-			atoi(parv[2]));				// hopcount
+			atoll(parv[2]));			// hopcount
 		if (u == NULL)
 			return;
 
@@ -1410,7 +1410,7 @@ m_signon(struct sourceinfo *si, int parc, char *parv[])
 		return;
 
 	// NICK
-	if (user_changenick(u, parv[0], atoi(parv[3])))
+	if (user_changenick(u, parv[0], atoll(parv[3])))
 		return;
 
 	handle_nickchange(u); // If they're logging out, this will bug them about identifying. Or something.

--- a/modules/protocol/unreal.c
+++ b/modules/protocol/unreal.c
@@ -764,7 +764,7 @@ m_mlock(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	time_t ts = atol(parv[0]);
+	time_t ts = atoll(parv[0]);
 	if (ts > c->ts)
 		return;
 
@@ -922,7 +922,7 @@ m_sjoin(struct sourceinfo *si, int parc, char *parv[])
 	{
 		// :origin SJOIN ts chan modestr [key or limits] :users
 		c = channel_find(parv[1]);
-		ts = atol(parv[0]);
+		ts = atoll(parv[0]);
 
 		if (!c)
 		{
@@ -955,7 +955,7 @@ m_sjoin(struct sourceinfo *si, int parc, char *parv[])
 	{
 		// :origin SJOIN ts chan :users
 		c = channel_find(parv[1]);
-		ts = atol(parv[0]);
+		ts = atoll(parv[0]);
 
 		if (!c)
 		{
@@ -988,7 +988,7 @@ m_sjoin(struct sourceinfo *si, int parc, char *parv[])
 	else if (parc == 2)
 	{
 		c = channel_find(parv[1]);
-		ts = atol(parv[0]);
+		ts = atoll(parv[0]);
 		if (!c)
 		{
 			slog(LG_DEBUG, "m_sjoin(): new channel: %s (modes lost)", parv[1]);
@@ -1080,7 +1080,7 @@ m_uid(struct sourceinfo *si, int parc, char *parv[])
 				if (!inet_ntop(af, ipdata, ipstring, sizeof ipstring))
 					iplen = 0;
 		}
-		u = user_add(parv[0], parv[3], parv[4], vhost, iplen != 0 ? ipstring : NULL, parv[5], parv[parc - 1], s, atoi(parv[2]));
+		u = user_add(parv[0], parv[3], parv[4], vhost, iplen != 0 ? ipstring : NULL, parv[5], parv[parc - 1], s, atoll(parv[2]));
 		if (u == NULL)
 			return;
 
@@ -1165,7 +1165,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 				if (!inet_ntop(af, ipdata, ipstring, sizeof ipstring))
 					iplen = 0;
 		}
-		u = user_add(parv[0], parv[3], parv[4], vhost, iplen != 0 ? ipstring : NULL, NULL, parv[parc - 1], s, atoi(parv[2]));
+		u = user_add(parv[0], parv[3], parv[4], vhost, iplen != 0 ? ipstring : NULL, NULL, parv[parc - 1], s, atoll(parv[2]));
 		if (u == NULL)
 			return;
 
@@ -1187,7 +1187,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 			if (authservice_loaded && should_reg_umode(u))
 				sts(":%s SVS2MODE %s +r", nicksvs.nick, u->nick);
 		}
-		else if (u->ts > 100 && (time_t)atoi(parv[6]) == u->ts)
+		else if (u->ts > 100 && (time_t)atoll(parv[6]) == u->ts)
 			handle_burstlogin(u, NULL, 0);
 
 		handle_nickchange(u);
@@ -1205,7 +1205,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 
 		realchange = irccasecmp(si->su->nick, parv[0]);
 
-		if (user_changenick(si->su, parv[0], atoi(parv[1])))
+		if (user_changenick(si->su, parv[0], atoll(parv[1])))
 			return;
 
 		// fix up +r if necessary -- jilles

--- a/modules/protocol/unreal4.c
+++ b/modules/protocol/unreal4.c
@@ -746,7 +746,7 @@ m_mlock(struct sourceinfo *si, int parc, char *parv[])
 		return;
 	}
 
-	time_t ts = atol(parv[0]);
+	time_t ts = atoll(parv[0]);
 	if (ts > c->ts)
 		return;
 
@@ -904,7 +904,7 @@ m_sjoin(struct sourceinfo *si, int parc, char *parv[])
 	{
 		// :origin SJOIN ts chan modestr [key or limits] :users
 		c = channel_find(parv[1]);
-		ts = atol(parv[0]);
+		ts = atoll(parv[0]);
 
 		if (!c)
 		{
@@ -937,7 +937,7 @@ m_sjoin(struct sourceinfo *si, int parc, char *parv[])
 	{
 		// :origin SJOIN ts chan :users
 		c = channel_find(parv[1]);
-		ts = atol(parv[0]);
+		ts = atoll(parv[0]);
 
 		if (!c)
 		{
@@ -970,7 +970,7 @@ m_sjoin(struct sourceinfo *si, int parc, char *parv[])
 	else if (parc == 2)
 	{
 		c = channel_find(parv[1]);
-		ts = atol(parv[0]);
+		ts = atoll(parv[0]);
 		if (!c)
 		{
 			slog(LG_DEBUG, "m_sjoin(): new channel: %s (modes lost)", parv[1]);
@@ -1062,7 +1062,7 @@ m_uid(struct sourceinfo *si, int parc, char *parv[])
 				if (!inet_ntop(af, ipdata, ipstring, sizeof ipstring))
 					iplen = 0;
 		}
-		u = user_add(parv[0], parv[3], parv[4], vhost, iplen != 0 ? ipstring : NULL, parv[5], parv[parc - 1], s, atoi(parv[2]));
+		u = user_add(parv[0], parv[3], parv[4], vhost, iplen != 0 ? ipstring : NULL, parv[5], parv[parc - 1], s, atoll(parv[2]));
 		if (u == NULL)
 			return;
 
@@ -1147,7 +1147,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 				if (!inet_ntop(af, ipdata, ipstring, sizeof ipstring))
 					iplen = 0;
 		}
-		u = user_add(parv[0], parv[3], parv[4], vhost, iplen != 0 ? ipstring : NULL, NULL, parv[parc - 1], s, atoi(parv[2]));
+		u = user_add(parv[0], parv[3], parv[4], vhost, iplen != 0 ? ipstring : NULL, NULL, parv[parc - 1], s, atoll(parv[2]));
 		if (u == NULL)
 			return;
 
@@ -1187,7 +1187,7 @@ m_nick(struct sourceinfo *si, int parc, char *parv[])
 
 		realchange = irccasecmp(si->su->nick, parv[0]);
 
-		if (user_changenick(si->su, parv[0], atoi(parv[1])))
+		if (user_changenick(si->su, parv[0], atoll(parv[1])))
 			return;
 
 		// fix up +r if necessary -- jilles


### PR DESCRIPTION
This patch was done while reviewing potential year-2038 issues in openSUSE.

Note: I had originally created the patch based on our v7.2.12 package to reduce experimental `gcc -Wtime_t-conversion` warnings
then cherry-picked it ontop of master and resolved a dozen conflicts, so it might not even compile. Please test/review carefully