### PR TITLE
fix compilation with recent ExtUtils::ParseXS

### DIFF
--- a/modules/scripting/perl/api/config.xs
+++ b/modules/scripting/perl/api/config.xs
@@ -8,6 +8,7 @@ OUTPUT:
     RETVAL
 
 MODULE = Atheme			PACKAGE = Atheme::ChanServ::Config
+
 #include "../../../chanserv/chanserv.h"
 
 char *


### PR DESCRIPTION
Recent versions of ExtUtils::ParseXS (since 3.58 or so?) have started being pickier about the XS syntax they accept. Anyone who is using Perl 5.44 (or has upgraded ExtUtils::ParseXS) may see this error:

    Error: unrecognised line: '#include "../../../chanserv/chanserv.h"' in config.xs, line 11
      (possible start of a truncated XSUB definition?)

Fix: Leave an empty line between MODULE and a following preprocessor directive.

(See also <https://bugs.gentoo.org/978484>.)