### PR TITLE
Add labeled-response support for solanum

### DIFF
--- a/configure
+++ b/configure
@@ -6310,6 +6310,13 @@ else $as_nop
 fi
 
 done
+    ac_fn_c_check_func "$LINENO" "timespec_get" "ac_cv_func_timespec_get"
+if test "x$ac_cv_func_timespec_get" = xyes
+then :
+  printf "%s\n" "#define HAVE_TIMESPEC_GET 1" >>confdefs.h
+
+fi
+
     ac_fn_c_check_func "$LINENO" "timingsafe_bcmp" "ac_cv_func_timingsafe_bcmp"
 if test "x$ac_cv_func_timingsafe_bcmp" = xyes
 then :

--- a/include/atheme/phandler.h
+++ b/include/atheme/phandler.h
@@ -75,6 +75,7 @@ struct ircd
 #define IRCD_HOLDNICK			2 /* supports holdnick_sts() */
 #define IRCD_TOPIC_NOCOLOUR		4
 #define IRCD_SASL_USE_PUID		8
+#define IRCD_MESSAGE_TAGS		16 /* conditionally added in protocol module if tag support isn't guaranteed */
 
 /* forced nick change types */
 #define FNC_REGAIN 0 /* give a registered user their nick back */
@@ -259,6 +260,9 @@ extern bool (*is_ircop)(struct user *u);
 extern bool (*is_admin)(struct user *u);
 /* as above; used to respect external services clients */
 extern bool (*is_service)(struct user *u);
+/* low-level function used for sending all server-to-server messages */
+extern int (*sts)(const char *fmt, ...) ATHEME_FATTR_PRINTF(1, 2);
+extern void (*handle_command)(struct proto_cmd *pcmd, struct sourceinfo *si, int parc, char *parv[]);
 
 unsigned int generic_server_login(void);
 void generic_introduce_nick(struct user *u);
@@ -310,6 +314,8 @@ void generic_undline_sts(const char *server, const char *host);
 bool generic_is_ircop(struct user *u);
 bool generic_is_admin(struct user *u);
 bool generic_is_service(struct user *u);
+int generic_sts(const char *fmt, ...) ATHEME_FATTR_PRINTF(1, 2);
+void generic_handle_command(struct proto_cmd *pcmd, struct sourceinfo *si, int parc, char *parv[]);
 
 extern const struct cmode *mode_list;
 extern struct extmode *ignore_mode_list;

--- a/include/atheme/sourceinfo.h
+++ b/include/atheme/sourceinfo.h
@@ -63,6 +63,8 @@ struct sourceinfo
 	unsigned int                    output_count;   // lines of output upto now
 	struct language *               force_language; // locale to force replies to be in, could be NULL
 	struct command *                command;        // The command being executed
+
+	mowgli_patricia_t *             tags;           // IRCv3 message tags (NULL if no tags)
 };
 
 #endif /* !ATHEME_INC_SOURCEINFO_H */

--- a/include/atheme/sysconf.h.in
+++ b/include/atheme/sysconf.h.in
@@ -404,6 +404,9 @@
 /* Define to 1 if you have the <sys/wait.h> header file. */
 #undef HAVE_SYS_WAIT_H
 
+/* Define to 1 if you have the `timespec_get' function. */
+#undef HAVE_TIMESPEC_GET
+
 /* Define to 1 if you have the <time.h> header file. */
 #undef HAVE_TIME_H
 

--- a/include/atheme/uplink.h
+++ b/include/atheme/uplink.h
@@ -50,7 +50,7 @@ extern void (*parse)(char *line);
 void irc_handle_connect(struct connection *cptr);
 
 /* send.c */
-int sts(const char *fmt, ...) ATHEME_FATTR_PRINTF(1, 2);
+int send_line(const char *line);
 void io_loop(void);
 
 #endif /* !ATHEME_INC_UPLINK_H */

--- a/libathemecore/phandler.c
+++ b/libathemecore/phandler.c
@@ -66,6 +66,8 @@ void (*undline_sts)(const char *server, const char *host) = generic_undline_sts;
 bool (*is_ircop)(struct user *u) = generic_is_ircop;
 bool (*is_admin)(struct user *u) = generic_is_admin;
 bool (*is_service)(struct user *u) = generic_is_service;
+int (*sts)(const char *fmt, ...) = generic_sts;
+void (*handle_command)(struct proto_cmd *pcmd, struct sourceinfo *si, int parc, char *parv[]) = generic_handle_command;
 
 unsigned int
 generic_server_login(void)
@@ -484,6 +486,28 @@ generic_is_service(struct user *u)
 		return true;
 
 	return false;
+}
+
+int ATHEME_FATTR_PRINTF(1, 2)
+generic_sts(const char *fmt, ...)
+{
+	va_list ap;
+	char buf[BUFSIZE+1];
+
+	return_val_if_fail(fmt != NULL, 0);
+
+	va_start(ap, fmt);
+	vsnprintf(buf, sizeof(buf), fmt, ap);
+	va_end(ap);
+
+	return send_line(buf);
+}
+
+void
+generic_handle_command(struct proto_cmd *pcmd, struct sourceinfo *si, int parc, char *parv[])
+{
+	if (pcmd->handler)
+		pcmd->handler(si, parc, parv);
 }
 
 /* vim:cinoptions=>s,e0,n0,f0,{0,}0,^0,=s,ps,t0,c3,+s,(2s,us,)20,*30,gs,hs

--- a/libathemecore/send.c
+++ b/libathemecore/send.c
@@ -16,11 +16,11 @@
 #include "internal.h"
 
 /* send a line to the server, append the \r\n */
-int ATHEME_FATTR_PRINTF(1, 2)
-sts(const char *fmt, ...)
+int
+send_line(const char *line)
 {
-	va_list ap;
-	char buf[513];
+	char buf[BUFSIZE+1];
+	size_t off = 0;
 	int len;
 
 	if (!me.connected)
@@ -28,11 +28,29 @@ sts(const char *fmt, ...)
 
 	return_val_if_fail(curr_uplink != NULL, 0);
 	return_val_if_fail(curr_uplink->conn != NULL, 0);
-	return_val_if_fail(fmt != NULL, 0);
+	return_val_if_fail(line != NULL, 0);
 
-	va_start(ap, fmt);
-	vsnprintf(buf, 511, fmt, ap); /* leave two bytes for \r\n */
-	va_end(ap);
+	if (*line == '@')
+	{
+		const char *sp = strchr(line, ' ');
+		if (sp == NULL)
+			return 0;
+
+		// right now BUFSIZE == 1024, so we only support up to 512 bytes of tags including framing
+		// this should be adjusted to 8191 once the rest of atheme grows support for the longer sizes
+		// if tag data is longer, skip the tags rather than truncating them to avoid corrupted tag data
+		// also skip tags if the IRCd lacks support for receiving message tags
+		if (ircd->flags & IRCD_MESSAGE_TAGS && sp - line < 512)
+		{
+			mowgli_strlcpy(buf, line, sp - line + 2);
+			off = sp - line + 1;
+		}
+
+		line = sp + 1;
+	}
+
+	return_val_if_fail(sizeof(buf) - off >= 513, 0);
+	mowgli_strlcpy(buf + off, line, 511);
 
 	len = strlen(buf);
 	buf[len++] = '\r';

--- a/m4/atheme-check-build-requirements.m4
+++ b/m4/atheme-check-build-requirements.m4
@@ -94,6 +94,7 @@ AC_DEFUN([ATHEME_CHECK_BUILD_REQUIREMENTS], [
     AC_CHECK_FUNCS([strtold], [], [ATHEME_REQUIRED_FUNC_MISSING])
     AC_CHECK_FUNCS([strtoul], [], [ATHEME_REQUIRED_FUNC_MISSING])
     AC_CHECK_FUNCS([strtoull], [], [ATHEME_REQUIRED_FUNC_MISSING])
+    AC_CHECK_FUNCS([timespec_get], [], [])
     AC_CHECK_FUNCS([timingsafe_bcmp], [], [])
     AC_CHECK_FUNCS([timingsafe_memcmp], [], [])
     AC_CHECK_FUNCS([vsnprintf], [], [ATHEME_REQUIRED_FUNC_MISSING])

--- a/modules/protocol/solanum.c
+++ b/modules/protocol/solanum.c
@@ -116,7 +116,7 @@ current_time(void)
 	struct tm *tm = NULL;
 	unsigned int ms = 0;
 
-#if defined(TIME_UTC)
+#if defined(HAVE_TIMESPEC_GET)
 	struct timespec ts;
 	timespec_get(&ts, TIME_UTC);
 	tm = gmtime(&ts.tv_sec);
@@ -190,12 +190,12 @@ solanum_sts(const char *fmt, ...)
 void
 solanum_handle_command(struct proto_cmd *pcmd, struct sourceinfo *si, int parc, char *parv[])
 {
-	current_si = si;
-
 	if (pcmd->handler)
+	{
+		current_si = si;
 		pcmd->handler(si, parc, parv);
-
-	current_si = NULL;
+		current_si = NULL;
+	}
 
 	if (si->tags != NULL && ircd->flags & IRCD_MESSAGE_TAGS)
 	{

--- a/modules/protocol/solanum.c
+++ b/modules/protocol/solanum.c
@@ -82,6 +82,8 @@ static const struct cmode solanum_user_mode_list[] = {
   { '\0', 0 }
 };
 
+static struct sourceinfo *current_si = NULL;
+
 static bool
 solanum_is_valid_hostslash(const char *host)
 {
@@ -105,6 +107,124 @@ solanum_is_valid_hostslash(const char *host)
 		return false;
 
 	return dot;
+}
+
+static const char *
+current_time(void)
+{
+	static char buf[32];
+	struct tm *tm = NULL;
+	unsigned int ms = 0;
+
+#if defined(TIME_UTC)
+	struct timespec ts;
+	timespec_get(&ts, TIME_UTC);
+	tm = gmtime(&ts.tv_sec);
+	ms = ts.tv_nsec / 1000000;
+#elif defined(CLOCK_REALTIME)
+	struct timespec ts;
+	clock_gettime(CLOCK_REALTIME, &ts);
+	tm = gmtime(&ts.tv_sec);
+	ms = ts.tv_nsec / 1000000;
+#elif defined(HAVE_GETTIMEOFDAY)
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
+	tm = gmtime(&tv.tv_sec);
+	ms = tv.tv_usec / 1000;
+#else
+	time_t t = time(NULL);
+	tm = gmtime(&t);
+#endif
+
+	snprintf(buf, sizeof(buf), "%04d-%02d-%02dT%02d:%02d:%02d.%03uZ",
+		tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
+		tm->tm_hour, tm->tm_min, tm->tm_sec, ms);
+
+	return buf;
+}
+
+static const char *
+response_tag(void)
+{
+	static char buf[128];
+
+	if (current_si == NULL || current_si->tags == NULL)
+		return "";
+
+	const char *response = mowgli_patricia_retrieve(current_si->tags, "solanum.chat/response");
+	if (response == NULL)
+		return "";
+
+	snprintf(buf, sizeof(buf), ";solanum.chat/response=%s", response);
+	return buf;
+}
+
+static int ATHEME_FATTR_PRINTF(1, 2)
+solanum_sts(const char *fmt, ...)
+{
+	va_list ap;
+	char buf[BUFSIZE+1];
+	char buf2[BUFSIZE+1];
+	size_t off = 0;
+
+	return_val_if_fail(fmt != NULL, 0);
+
+	va_start(ap, fmt);
+	vsnprintf(buf2, sizeof(buf2), fmt, ap);
+	va_end(ap);
+
+	if (ircd->flags & IRCD_MESSAGE_TAGS)
+	{
+		off = snprintf(buf, sizeof(buf), "@time=%s%s", current_time(), response_tag());
+		// merge any tags passed into sts()
+		if (*buf2 == '@')
+			*buf2 = ';';
+		else
+			buf[off++] = ' ';
+	}
+
+	mowgli_strlcpy(buf + off, buf2, sizeof(buf) - off);
+	return send_line(buf);
+}
+
+void
+solanum_handle_command(struct proto_cmd *pcmd, struct sourceinfo *si, int parc, char *parv[])
+{
+	current_si = si;
+
+	if (pcmd->handler)
+		pcmd->handler(si, parc, parv);
+
+	current_si = NULL;
+
+	if (si->tags != NULL && ircd->flags & IRCD_MESSAGE_TAGS)
+	{
+		const char *response = mowgli_patricia_retrieve(si->tags, "solanum.chat/response");
+		const char *mask;
+		if (response == NULL)
+			return;
+
+		char buf[128];
+		char *p;
+		mowgli_strlcpy(buf, response, sizeof(buf));
+
+		// skip past the first two tokens; we only care about the third (the mask)
+		if (strtok_r(buf, ",", &p) == NULL)
+			return;
+		if (strtok_r(NULL, ",", &p) == NULL)
+			return;
+		if ((mask = strtok_r(NULL, ",", &p)) == NULL)
+			return;
+
+		// no ACK if the mask doesn't match us
+		if (match(mask, me.name))
+			return;
+
+		if (si->s != NULL)
+			sts("@solanum.chat/response=%s :%s ENCAP %s ACK", response, me.name, si->s->name);
+		else if (si->su != NULL)
+			sts("@solanum.chat/response=%s :%s ENCAP %s ACK", response, me.name, si->su->server->name);
+	}
 }
 
 static void
@@ -307,6 +427,8 @@ mod_init(struct module *const restrict m)
 	mode_list = solanum_mode_list;
 	user_mode_list = solanum_user_mode_list;
 
+	sts = &solanum_sts;
+	handle_command = &solanum_handle_command;
 	wallops_sts = &solanum_wallops_sts;
 	ircd_on_login = &solanum_on_login;
 	ircd_on_logout = &solanum_on_logout;

--- a/modules/protocol/ts6-generic.c
+++ b/modules/protocol/ts6-generic.c
@@ -90,7 +90,7 @@ ts6_server_login(void)
 
 	me.bursting = true;
 
-	sts("CAPAB :QS EX IE KLN UNKLN ENCAP TB SERVICES EUID EOPMOD MLOCK");
+	sts("CAPAB :QS EX IE KLN UNKLN ENCAP TB SERVICES EUID EOPMOD MLOCK STAG");
 	sts("SERVER %s 1 :%s%s", me.name, me.hidden ? "(H) " : "", me.desc);
 	sts("SVINFO %d 3 0 :%lu", ircd->uses_uid ? 6 : 5,
 			(unsigned long)CURRTIME);
@@ -715,6 +715,12 @@ m_notice(struct sourceinfo *si, int parc, char *parv[])
 		return;
 
 	handle_message(si, parv[0], true, parv[1]);
+}
+
+static void
+m_tagmsg(struct sourceinfo *si, int parc, char *parv[])
+{
+	// no-op; nothing in atheme currently cares about incoming TAGMSG
 }
 
 static void
@@ -1442,6 +1448,7 @@ m_capab(struct sourceinfo *si, int parc, char *parv[])
 	use_tb = false;
 	use_eopmod = false;
 	use_mlock = false;
+	ircd->flags &= ~IRCD_MESSAGE_TAGS;
 	for (p = strtok(parv[0], " "); p != NULL; p = strtok(NULL, " "))
 	{
 		if (!irccasecmp(p, "EUID"))
@@ -1468,6 +1475,11 @@ m_capab(struct sourceinfo *si, int parc, char *parv[])
 		{
 			slog(LG_DEBUG, "m_capab(): uplink supports MLOCK, enabling support.");
 			use_mlock = true;
+		}
+		if (!irccasecmp(p, "STAG"))
+		{
+			slog(LG_DEBUG, "m_capab(): uplink supports message tags, enabling support.");
+			ircd->flags |= IRCD_MESSAGE_TAGS;
 		}
 	}
 
@@ -1570,6 +1582,7 @@ mod_init(struct module *const restrict m)
 	pcommand_add("PONG", m_pong, 1, MSRC_SERVER);
 	pcommand_add("PRIVMSG", m_privmsg, 2, MSRC_USER);
 	pcommand_add("NOTICE", m_notice, 2, MSRC_UNREG | MSRC_USER | MSRC_SERVER);
+	pcommand_add("TAGMSG", m_tagmsg, 1, MSRC_USER);
 	pcommand_add("SJOIN", m_sjoin, 4, MSRC_SERVER);
 	pcommand_add("PART", m_part, 1, MSRC_USER);
 	pcommand_add("NICK", m_nick, 2, MSRC_USER | MSRC_SERVER);

--- a/modules/transport/rfc1459/parse.c
+++ b/modules/transport/rfc1459/parse.c
@@ -15,6 +15,58 @@
 #include <atheme.h>
 #include "rfc1459.h"
 
+/* Unescapes an IRCv3 message-tags value in-place
+ * \: -> ';', \s -> ' ', \\ -> '\', \r -> CR, \n -> LF
+ */
+static void
+message_tag_unescape(char *value)
+{
+	char *dst = value;
+
+	for (char *src = value; *src != '\0'; src++)
+	{
+		if (*src != '\\')
+		{
+			*dst++ = *src;
+			continue;
+		}
+
+		switch (*++src)
+		{
+		case ':':
+			*dst++ = ';';
+			break;
+		case 's':
+			*dst++ = ' ';
+			break;
+		case '\\':
+			*dst++ = '\\';
+			break;
+		case 'r':
+			*dst++ = '\r';
+			break;
+		case 'n':
+			*dst++ = '\n';
+			break;
+		case '\0':
+			// trailing lone backslash; drop it
+			*dst = '\0';
+			return;
+		default:
+			*dst++ = *src;
+			break;
+		}
+	}
+
+	*dst = '\0';
+}
+
+static void
+message_tag_free_cb(const char *key, void *data, void *privdata)
+{
+	sfree(data);
+}
+
 // parses a standard 2.8.21 style IRC stream
 void
 irc_parse(char *line)
@@ -54,16 +106,44 @@ irc_parse(char *line)
 
 		slog(LG_RAWDATA, "-> %s", line);
 
-		/* If it starts with a @ we have IRCv3 message tags.
-		 * We don't handle these so just skip them.
-		 */
+		// If it starts with @ we have IRCv3 message tags.
 		if (*line == '@')
 		{
-			line = strchr(line, ' ');
-			if (!line)
+			line++;
+			if (*line == ' ')
+				goto cleanup; /* no tags, starts with "@ " */
+
+			char *sp = strchr(line, ' ');
+			if (!sp)
 				goto cleanup; /* just "@tags" */
 
-			line++;
+			*sp = '\0';
+			si->tags = mowgli_patricia_create(NULL);
+			for (char *tag = strtok_r(line + 1, ";", &pos); tag != NULL; tag = strtok_r(NULL, ";", &pos))
+			{
+				char *key = tag;
+				char *value = strchr(tag, '=');
+				void *old;
+
+				if (value != NULL)
+				{
+					*value++ = '\0';
+					message_tag_unescape(value);
+				}
+				else
+					value = "";
+
+				if (*key == '\0')
+					continue;
+
+				// if we get duplicate keys, keep only the latest one
+				if ((old = mowgli_patricia_delete(si->tags, key)) != NULL)
+					sfree(old);
+
+				mowgli_patricia_add(si->tags, key, sstrdup(value));
+			}
+
+			line = sp + 1;
 			if (*line == '\n' || *line == '\000')
 				goto cleanup; /* just "@tags " */
 		}
@@ -176,13 +256,16 @@ irc_parse(char *line)
 				slog(LG_INFO, "irc_parse(): insufficient parameters for command %s", pcmd->token);
 				goto cleanup;
 			}
-			if (pcmd->handler)
-			{
-				pcmd->handler(si, parc, parv);
-			}
+			handle_command(pcmd, si, parc, parv);
 		}
 	}
 
 cleanup:
+	if (si->tags != NULL)
+	{
+		mowgli_patricia_destroy(si->tags, message_tag_free_cb, NULL);
+		si->tags = NULL;
+	}
+
 	atheme_object_unref(si);
 }


### PR DESCRIPTION
This required a handful of changes in core code as well:

- Actually parse IRCv3 message tags instead of skipping over them; they are stored in a new patricia tree on struct sourceinfo which is NULL if no tags are passed to avoid unnecessary allocation overhead
- New flag for struct ircd to denote that it supports receiving message tags over the server-to-server link; solanum conditionally defines this flag based on the STAG capab, but other protocol modules may unconditionally define it if they know uplinks always support tags
- Move sts to phandler so protocol modules can override it if necessary, allowing a low-level hook point for all outgoing traffic; the existing sts function was renamed to send_line and made non-variadic
- send_line will skip over outgoing tags if the ircd isn't flagged as supporting message tags, allowing modules to safely pass arbitrary tags without needing to worry if they are supported or not (e.g. ChanServ modules could in the future pass +channel-context)
- New handle_command wrapper to dispatch commands, the default impl of which simply calls the handler if it exists
- Advertise the STAG capab in ts6-generic, and set the new message tag flag on the ircd struct if we receive STAG from the uplink
- The solanum module overrides sts to add the server-time tag (required now that we advertise STAG) and the solanum.chat/response tag if one was passed to us
- The solanum module overrides handle_command to send ENCAP ACK at the end of command processing if required by an incoming solanum.chat/response tag