### PR TITLE
serv: add Serv compatibility router module

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -220,6 +220,13 @@ NickServ
   (unless the flag is unset by default)
 - NickServ `VHOST` no longer supports legacy pre-v5.0 command syntax
 
+Serv
+----
+- New `serv/main` module: a single entry point pseudoclient that routes
+  NICK, CHAN, MEMO, GROUP, OPER, INFO, and GLOBAL commands to the backing
+  service. Commands can also be reached as `Serv <namespace> <command>`, e.g.
+  `/msg Serv CHAN INFO #channel`. Includes `serv/` help files.
+
 IRCds
 -----
 - Support `chm_nonotice.so` (Block channel notices) extension in charybdis IRCd

--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -717,6 +717,17 @@ loadmodule "infoserv/main";
 
 
 
+/* Serv module.
+ *
+ * Serv is a compatibility router: it provides a single entry point that
+ * forwards commands to the other services using namespace prefixes, e.g.
+ * `/msg Serv NICK IDENTIFY <nick> <password>`. Its display nick is set in
+ * the `serv {}` block below.
+ */
+loadmodule "serv/main";
+
+
+
 /* SASL agent module.
  *
  * Allows clients to authenticate to services via SASL with an appropriate
@@ -1660,6 +1671,13 @@ uplink "irc6.example.net" {
  * Services to operate correctly. You should make sure these settings
  * are properly configured for your network.
  */
+serv {
+	nick = "Serv";
+	user = "Serv";
+	host = "services.int";
+	real = "Services Entry Point";
+};
+
 nickserv {
 
 	nick = "NickServ";

--- a/help/default/serv/chan
+++ b/help/default/serv/chan
@@ -1,0 +1,12 @@
+The CHAN and CHANNEL namespaces provide channel commands.
+
+Syntax:
+
+    /msg &nick& CHAN <command> [arguments...]
+    /msg &nick& CHANNEL <command> [arguments...]
+
+Common commands: REGISTER, DROP, INFO, SET, TOPIC, FLAGS, AKICK
+
+For help on a command, type:
+
+    /msg &nick& HELP CHAN <command>

--- a/help/default/serv/global
+++ b/help/default/serv/global
@@ -1,0 +1,9 @@
+The GLOBAL namespace provides global announcement commands.
+
+Syntax:
+
+    /msg &nick& GLOBAL <command> [arguments...]
+
+For help on a command, type:
+
+    /msg &nick& HELP GLOBAL <command>

--- a/help/default/serv/group
+++ b/help/default/serv/group
@@ -1,0 +1,11 @@
+The GROUP namespace provides group commands.
+
+Syntax:
+
+    /msg &nick& GROUP <command> [arguments...]
+
+Common commands: REGISTER, JOIN, INFO, LISTCHANS, FLAGS
+
+For help on a command, type:
+
+    /msg &nick& HELP GROUP <command>

--- a/help/default/serv/help
+++ b/help/default/serv/help
@@ -1,0 +1,31 @@
+Serv is a unified entry point for the network services.
+
+The following namespaces are available:
+
+    NICK    nickname and account commands
+    CHAN    channel commands
+    MEMO    memo commands
+    GROUP   group commands
+    OPER    operator commands (requires operator privileges)
+    INFO    information commands
+    GLOBAL  global announcement commands
+
+To get help on a namespace, type:
+
+    /msg &nick& HELP NICK
+    /msg &nick& HELP CHAN
+    /msg &nick& HELP MEMO
+    /msg &nick& HELP GROUP
+    /msg &nick& HELP OPER
+    /msg &nick& HELP INFO
+    /msg &nick& HELP GLOBAL
+
+To use a command, type:
+
+    /msg &nick& NICK <command> [arguments...]
+    /msg &nick& CHAN <command> [arguments...]
+    /msg &nick& MEMO <command> [arguments...]
+    /msg &nick& GROUP <command> [arguments...]
+    /msg &nick& OPER <command> [arguments...]
+    /msg &nick& INFO <command> [arguments...]
+    /msg &nick& GLOBAL <command> [arguments...]

--- a/help/default/serv/info
+++ b/help/default/serv/info
@@ -1,0 +1,9 @@
+The INFO namespace provides information commands.
+
+Syntax:
+
+    /msg &nick& INFO <command> [arguments...]
+
+For help on a command, type:
+
+    /msg &nick& HELP INFO <command>

--- a/help/default/serv/memo
+++ b/help/default/serv/memo
@@ -1,0 +1,11 @@
+The MEMO namespace provides memo commands.
+
+Syntax:
+
+    /msg &nick& MEMO <command> [arguments...]
+
+Common commands: SEND, LIST, READ, FORWARD, DELETE
+
+For help on a command, type:
+
+    /msg &nick& HELP MEMO <command>

--- a/help/default/serv/nick
+++ b/help/default/serv/nick
@@ -1,0 +1,12 @@
+The NICK and ACCOUNT namespaces provide nickname and account commands.
+
+Syntax:
+
+    /msg &nick& NICK <command> [arguments...]
+    /msg &nick& ACCOUNT <command> [arguments...]
+
+Common commands: REGISTER, IDENTIFY, LOGOUT, INFO, SET, LISTCHANS
+
+For help on a command, type:
+
+    /msg &nick& HELP NICK <command>

--- a/help/default/serv/oper
+++ b/help/default/serv/oper
@@ -1,0 +1,12 @@
+The OPER namespace provides operator commands.
+
+Syntax:
+
+    /msg &nick& OPER <command> [arguments...]
+
+This namespace requires operator privileges; unprivileged users are
+denied exactly as they would be by OperServ directly.
+
+For help on a command, type:
+
+    /msg &nick& HELP OPER <command>

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -34,6 +34,7 @@ SUBDIRS =                   \
     protocol                \
     proxyscan               \
     rpgserv                 \
+    serv                    \
     saslserv                \
     scripting               \
     security                \

--- a/modules/serv/Makefile
+++ b/modules/serv/Makefile
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: ISC
+# SPDX-URL: https://spdx.org/licenses/ISC.html
+#
+# Copyright (C) 2026 Atheme Development Group (https://atheme.github.io/)
+# Copyright (C) 2026 syk <syk@localhost>
+
+include ../../extra.mk
+
+MODULE = serv
+SRCS   = \
+    main.c
+
+include ../../buildsys.mk
+include ../../buildsys.module.mk
+
+CPPFLAGS += -I../../include
+LDFLAGS  += -L../../libathemecore
+LIBS     += -lathemecore

--- a/modules/serv/main.c
+++ b/modules/serv/main.c
@@ -1,0 +1,334 @@
+/*
+ * SPDX-License-Identifier: ISC
+ * SPDX-URL: https://spdx.org/licenses/ISC.html
+ *
+ * Copyright (C) 2026 Atheme Development Group (https://atheme.github.io/)
+ * Copyright (C) 2026 syk <syk@localhost>
+ *
+ * This file contains the main() routine for the Serv compatibility router.
+ */
+
+#include <atheme.h>
+
+struct serv_namespace {
+	const char *public_name;
+	const char *target_service;
+};
+
+static const struct serv_namespace serv_namespaces[] = {
+	{ "NICK",    "nickserv" },
+	{ "ACCOUNT", "nickserv" },
+	{ "CHAN",    "chanserv" },
+	{ "CHANNEL", "chanserv" },
+	{ "MEMO",    "memoserv" },
+	{ "GROUP",   "groupserv" },
+	{ "OPER",    "operserv" },
+	{ "INFO",    "infoserv" },
+	{ "GLOBAL",  "global"   },
+	{ NULL,      NULL       },
+};
+
+static struct service *servsvs = NULL;
+
+static const char *
+serv_namespace_service(const char *name)
+{
+	const struct serv_namespace *ns;
+
+	if (name == NULL)
+		return NULL;
+
+	for (ns = serv_namespaces; ns->public_name != NULL; ns++)
+		if (irccasecmp(ns->public_name, name) == 0)
+			return ns->target_service;
+
+	return NULL;
+}
+
+static void
+serv_show_root_help(struct sourceinfo *si)
+{
+	(void) help_display_prefix(si, si->service);
+
+	(void) command_success_nodata(si, _("%s provides one entry point for network services."), si->service->disp);
+	(void) help_display_newline(si);
+	(void) command_success_nodata(si, _("Account commands:  /msg %s NICK <command>"), si->service->disp);
+	(void) command_success_nodata(si, _("Channel commands:  /msg %s CHAN <command>"), si->service->disp);
+	(void) command_success_nodata(si, _("Memo commands:     /msg %s MEMO <command>"), si->service->disp);
+	(void) command_success_nodata(si, _("Group commands:    /msg %s GROUP <command>"), si->service->disp);
+	(void) command_success_nodata(si, _("Oper commands:     /msg %s OPER <command>"), si->service->disp);
+	(void) command_success_nodata(si, _("Info commands:     /msg %s INFO <command>"), si->service->disp);
+	(void) command_success_nodata(si, _("Global commands:   /msg %s GLOBAL <command>"), si->service->disp);
+	(void) help_display_newline(si);
+	(void) command_success_nodata(si, _("For details: /msg %s HELP NICK"), si->service->disp);
+	(void) command_success_nodata(si, _("             /msg %s HELP CHAN"), si->service->disp);
+	(void) command_success_nodata(si, _("             /msg %s HELP MEMO"), si->service->disp);
+	(void) command_success_nodata(si, _("             /msg %s HELP GROUP"), si->service->disp);
+	(void) command_success_nodata(si, _("             /msg %s HELP OPER"), si->service->disp);
+	(void) command_success_nodata(si, _("             /msg %s HELP INFO"), si->service->disp);
+	(void) command_success_nodata(si, _("             /msg %s HELP GLOBAL"), si->service->disp);
+
+	(void) help_display_suffix(si);
+}
+
+static void
+serv_show_ns_help(struct sourceinfo *si, const char *ns, const char *service)
+{
+	(void) command_success_nodata(si, _("The \2%s\2 namespace provides \2%s\2 commands."), ns, service);
+	(void) command_success_nodata(si, _("Syntax: /msg %s %s <command> [arguments...]"), si->service->disp, ns);
+}
+
+static void
+serv_cmd_help(struct sourceinfo *const restrict si, const int ATHEME_VATTR_UNUSED parc, char **const restrict parv)
+{
+	struct service *const saved = si->service;
+	char *ns, *subcommand;
+	const char *service;
+	struct service *dest;
+
+	if (parv[0] == NULL)
+	{
+		serv_show_root_help(si);
+		return;
+	}
+
+	ns = strtok(parv[0], " ");
+	subcommand = strtok(NULL, "");
+
+	if (ns == NULL)
+	{
+		serv_show_root_help(si);
+		return;
+	}
+
+	if (strcasecmp(ns, "COMMANDS") == 0)
+	{
+		(void) command_help(si, si->service->commands);
+		return;
+	}
+
+	service = serv_namespace_service(ns);
+	if (service != NULL)
+	{
+		if (subcommand == NULL)
+		{
+			(void) help_display(si, si->service, ns, si->service->commands);
+			return;
+		}
+
+		dest = service_find(service);
+		if (dest == NULL)
+		{
+			(void) command_fail(si, fault_nosuch_target, _("The \2%s\2 service is currently unavailable."), service);
+			return;
+		}
+
+		si->service = dest;
+		(void) command_exec_split(dest, si, "HELP", subcommand, dest->commands);
+		si->service = saved;
+		return;
+	}
+
+	(void) help_display_invalid(si, si->service, ns);
+}
+
+static void
+serv_cmd_ns(struct sourceinfo *const restrict si, const int ATHEME_VATTR_UNUSED parc, char **const restrict parv)
+{
+	const char *const ns = si->command->name;
+	const char *const service = serv_namespace_service(ns);
+	struct service *const dest = service_find(service);
+	struct service *const saved = si->service;
+	char *cmd, *text;
+
+	if (parv[0] == NULL)
+	{
+		(void) command_fail(si, fault_needmoreparams, STR_INSUFFICIENT_PARAMS, ns);
+		(void) command_fail(si, fault_needmoreparams, _("Syntax: %s <command> [arguments...]"), ns);
+		serv_show_ns_help(si, ns, service);
+		return;
+	}
+
+	if (dest == NULL)
+	{
+		(void) command_fail(si, fault_nosuch_target, _("The \2%s\2 service is currently unavailable."), service);
+		return;
+	}
+
+	cmd = strtok(parv[0], " ");
+	text = strtok(NULL, "");
+
+	if (cmd == NULL)
+	{
+		(void) command_fail(si, fault_needmoreparams, STR_INSUFFICIENT_PARAMS, ns);
+		(void) command_fail(si, fault_needmoreparams, _("Syntax: %s <command> [arguments...]"), ns);
+		serv_show_ns_help(si, ns, service);
+		return;
+	}
+
+	si->service = dest;
+	(void) command_exec_split(dest, si, cmd, text, dest->commands);
+	si->service = saved;
+}
+
+static void
+serv_handler(struct sourceinfo *si, int parc, char *parv[])
+{
+	char *cmd, *text;
+
+	if (parv[parc - 1] == NULL || parv[parc - 1][0] == '\0')
+	{
+		serv_show_root_help(si);
+		return;
+	}
+
+	cmd = strtok(parv[parc - 1], " ");
+	text = strtok(NULL, "");
+
+	if (!cmd)
+	{
+		serv_show_root_help(si);
+		return;
+	}
+
+	if (*parv[parc - 1] == '\001')
+	{
+		(void) handle_ctcp_common(si, cmd, text);
+		return;
+	}
+
+	(void) command_exec_split(si->service, si, cmd, text, si->service->commands);
+}
+
+static struct command serv_help = {
+	.name           = "HELP",
+	.desc           = STR_HELP_DESCRIPTION,
+	.access         = AC_NONE,
+	.maxparc        = 1,
+	.cmd            = &serv_cmd_help,
+	.help           = { .path = "serv/help" },
+};
+
+static struct command serv_nick = {
+	.name           = "NICK",
+	.desc           = N_("Provides account and nickname commands."),
+	.access         = AC_NONE,
+	.maxparc        = 1,
+	.cmd            = &serv_cmd_ns,
+	.help           = { .path = "serv/nick" },
+};
+
+static struct command serv_account = {
+	.name           = "ACCOUNT",
+	.desc           = N_("Provides account commands."),
+	.access         = AC_NONE,
+	.maxparc        = 1,
+	.cmd            = &serv_cmd_ns,
+	.help           = { .path = "serv/nick" },
+};
+
+static struct command serv_chan = {
+	.name           = "CHAN",
+	.desc           = N_("Provides channel commands."),
+	.access         = AC_NONE,
+	.maxparc        = 1,
+	.cmd            = &serv_cmd_ns,
+	.help           = { .path = "serv/chan" },
+};
+
+static struct command serv_channel = {
+	.name           = "CHANNEL",
+	.desc           = N_("Provides channel commands."),
+	.access         = AC_NONE,
+	.maxparc        = 1,
+	.cmd            = &serv_cmd_ns,
+	.help           = { .path = "serv/chan" },
+};
+
+static struct command serv_memo = {
+	.name           = "MEMO",
+	.desc           = N_("Provides memo commands."),
+	.access         = AC_NONE,
+	.maxparc        = 1,
+	.cmd            = &serv_cmd_ns,
+	.help           = { .path = "serv/memo" },
+};
+
+static struct command serv_group = {
+	.name           = "GROUP",
+	.desc           = N_("Provides group commands."),
+	.access         = AC_NONE,
+	.maxparc        = 1,
+	.cmd            = &serv_cmd_ns,
+	.help           = { .path = "serv/group" },
+};
+
+static struct command serv_oper = {
+	.name           = "OPER",
+	.desc           = N_("Provides operator commands."),
+	.access         = AC_NONE,
+	.maxparc        = 1,
+	.cmd            = &serv_cmd_ns,
+	.help           = { .path = "serv/oper" },
+};
+
+static struct command serv_info = {
+	.name           = "INFO",
+	.desc           = N_("Provides information commands."),
+	.access         = AC_NONE,
+	.maxparc        = 1,
+	.cmd            = &serv_cmd_ns,
+	.help           = { .path = "serv/info" },
+};
+
+static struct command serv_global = {
+	.name           = "GLOBAL",
+	.desc           = N_("Provides global announcement commands."),
+	.access         = AC_NONE,
+	.maxparc        = 1,
+	.cmd            = &serv_cmd_ns,
+	.help           = { .path = "serv/global" },
+};
+
+static void
+mod_init(struct module *const restrict m)
+{
+	if (! (servsvs = service_add("serv", serv_handler)))
+	{
+		(void) slog(LG_ERROR, "%s: service_add() failed", m->name);
+
+		m->mflags |= MODFLAG_FAIL;
+		return;
+	}
+
+	(void) service_bind_command(servsvs, &serv_help);
+	(void) service_bind_command(servsvs, &serv_nick);
+	(void) service_bind_command(servsvs, &serv_account);
+	(void) service_bind_command(servsvs, &serv_chan);
+	(void) service_bind_command(servsvs, &serv_channel);
+	(void) service_bind_command(servsvs, &serv_memo);
+	(void) service_bind_command(servsvs, &serv_group);
+	(void) service_bind_command(servsvs, &serv_oper);
+	(void) service_bind_command(servsvs, &serv_info);
+	(void) service_bind_command(servsvs, &serv_global);
+}
+
+static void
+mod_deinit(const enum module_unload_intent ATHEME_VATTR_UNUSED intent)
+{
+	(void) service_unbind_command(servsvs, &serv_channel);
+	(void) service_unbind_command(servsvs, &serv_chan);
+	(void) service_unbind_command(servsvs, &serv_account);
+	(void) service_unbind_command(servsvs, &serv_nick);
+	(void) service_unbind_command(servsvs, &serv_help);
+	(void) service_unbind_command(servsvs, &serv_group);
+	(void) service_unbind_command(servsvs, &serv_oper);
+	(void) service_unbind_command(servsvs, &serv_info);
+	(void) service_unbind_command(servsvs, &serv_global);
+	(void) service_unbind_command(servsvs, &serv_memo);
+
+	(void) service_delete(servsvs);
+	servsvs = NULL;
+}
+
+SIMPLE_DECLARE_MODULE_V1("serv/main", MODULE_UNLOAD_CAPABILITY_OK)


### PR DESCRIPTION
Adds a new `serv/main` module: a single entry point pseudoclient that routes commands to the backing services using namespace prefixes:

```
/msg Serv NICK IDENTIFY <nick> <password>
/msg Serv CHAN INFO #channel
/msg Serv MEMO LIST
/msg Serv GLOBAL GLOBAL <text>
```

Namespaces: `NICK`/`ACCOUNT` -> NickServ, `CHAN`/`CHANNEL` -> ChanServ, `MEMO` -> MemoServ, `GROUP` -> GroupServ, `OPER` -> OperServ, `INFO` -> InfoServ, `GLOBAL` -> Global.

Design notes:

- Delegation preserves the caller's authentication state. `command_exec()` authorizes via the source's `su`/`smu`, so restrictions such as OPER and GLOBAL are enforced by the destination service with its own messages.
- The destination service replies under its own nick (transparent pass-through), keeping reply conventions, help text, and logging identical to a direct message to that service.
- The display nick is set with the standard `serv { NICK "..." }` block; the example configuration ships it as `Serv`.
- Router-owned help files live in `help/default/serv/`; `HELP <ns> <subcommand>` passes through to the destination service.

Verified live against UnrealIRCd: all seven namespaces delegate correctly with auth preserved, the memo send/list/read/delete cycle works through Serv, unprivileged OPER/GLOBAL are denied, and help renders in all paths.