### PR TITLE
nickserv: add NOTICEFRONT to route on-connect notices via a front service

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -219,6 +219,10 @@ NickServ
 - NickServ `RETURN` now enables the `HIDEMAIL` flag if the email was changed
   (unless the flag is unset by default)
 - NickServ `VHOST` no longer supports legacy pre-v5.0 command syntax
+- New `NOTICEFRONT` setting in the `nickserv {}` block: when a front service
+  such as `Serv` is in use, NickServ's on-connect notices (welcome, identify
+  reminder, registered-nick notice) are sent by that service and their hints
+  use the router's namespace syntax, e.g. `/msg Serv NICK IDENTIFY ...`.
 
 IRCds
 -----

--- a/dist/atheme.conf.example
+++ b/dist/atheme.conf.example
@@ -1681,6 +1681,15 @@ nickserv {
 	 */
 	spam;
 
+	/* noticefront
+	 *
+	 * When a front service such as serv/main is in use, send NickServ's
+	 * on-connect notices (welcome, identify reminder, registered-nick
+	 * notice) from that service instead, using its namespace syntax, e.g.
+	 * `/msg Serv NICK IDENTIFY <nick> <password>`.
+	 */
+	#noticefront = "Serv";
+
 	/* no_nick_ownership
 	 *
 	 * Enable this to disable nickname ownership (old userserv{}). This

--- a/include/atheme/services.h
+++ b/include/atheme/services.h
@@ -3,6 +3,7 @@
  * SPDX-URL: https://spdx.org/licenses/ISC.html
  *
  * Copyright (C) 2005 William Pitcock, et al.
+ * Copyright (C) 2026 syk <syk@localhost>
  *
  * Data structures related to services psuedo-clients.
  */
@@ -60,6 +61,7 @@ struct nicksvs
 	unsigned int    enforce_expiry; // expiry time
 	unsigned int    enforce_delay;  // delay for nickname enforce
 	char *          enforce_prefix; // prefix for enforcement
+	char *          noticefront;    // service to send on-connect notices (router front)
 	mowgli_list_t   emailexempts;   // emails exempt from maxusers checks
 };
 

--- a/modules/nickserv/main.c
+++ b/modules/nickserv/main.c
@@ -3,11 +3,14 @@
  * SPDX-URL: https://spdx.org/licenses/ISC.html
  *
  * Copyright (C) 2005 Atheme Project (http://atheme.org/)
+ * Copyright (C) 2026 syk <syk@localhost>
  *
  * This file contains the main() routine.
  */
 
 #include <atheme.h>
+
+static struct service *notice_front;
 
 static struct {
 	const char *nickstring, *accountstring;
@@ -52,10 +55,16 @@ nickserv_handle_nickchange(struct user *u)
 
 		if (!(u->flags & UF_SEENINFO) && chansvs.me != NULL)
 		{
-			notice(nicksvs.nick, u->nick, "Welcome to \2%s\2, \2%s\2! Here on \2%s\2, we provide "
-			       "services to enable the registration of nicknames and channels! For details, type "
-			       "\2/msg %s HELP\2 and \2/msg %s HELP\2", me.netname, u->nick, me.netname,
-			       nicksvs.me->disp, chansvs.me->disp);
+			if (notice_front != NULL)
+				notice(notice_front->nick, u->nick, "Welcome to \2%s\2, \2%s\2! Here on \2%s\2, we provide "
+				       "services to enable the registration of nicknames and channels! For details, type "
+				       "\2/msg %s NICK HELP\2 and \2/msg %s CHAN HELP\2", me.netname, u->nick, me.netname,
+				       notice_front->disp, notice_front->disp);
+			else
+				notice(nicksvs.nick, u->nick, "Welcome to \2%s\2, \2%s\2! Here on \2%s\2, we provide "
+				       "services to enable the registration of nicknames and channels! For details, type "
+				       "\2/msg %s HELP\2 and \2/msg %s HELP\2", me.netname, u->nick, me.netname,
+				       nicksvs.me->disp, chansvs.me->disp);
 
 			u->flags |= UF_SEENINFO;
 		}
@@ -72,13 +81,22 @@ nickserv_handle_nickchange(struct user *u)
 	// OpenServices: is user on access list? -nenolod
 	if (myuser_access_verify(u, mn->owner))
 	{
-		notice(nicksvs.nick, u->nick, "Please identify via \2/msg %s IDENTIFY %s <password>\2",
-		                              nicksvs.me->disp, entity(mn->owner)->name);
+		if (notice_front != NULL)
+			notice(notice_front->nick, u->nick, "Please identify via \2/msg %s NICK IDENTIFY %s <password>\2",
+			                              notice_front->disp, entity(mn->owner)->name);
+		else
+			notice(nicksvs.nick, u->nick, "Please identify via \2/msg %s IDENTIFY %s <password>\2",
+			                              nicksvs.me->disp, entity(mn->owner)->name);
 		return;
 	}
 
 	if (metadata_find(mn->owner, "private:freeze:freezer"))
-		notice(nicksvs.nick, u->nick, "This nickname is registered. Please choose a different nickname.");
+		notice(notice_front != NULL ? notice_front->nick : nicksvs.nick, u->nick,
+		       "This nickname is registered. Please choose a different nickname.");
+	else if (notice_front != NULL)
+		notice(notice_front->nick, u->nick, "This nickname is registered. Please choose a different nickname, or "
+		                              "identify via \2/msg %s NICK IDENTIFY %s <password>\2",
+		                              notice_front->disp, entity(mn->owner)->name);
 	else
 		notice(nicksvs.nick, u->nick, "This nickname is registered. Please choose a different nickname, or "
 		                              "identify via \2/msg %s IDENTIFY %s <password>\2",
@@ -98,6 +116,18 @@ nickserv_config_ready(void *unused)
 	nicksvs.user = nicksvs.me->user;
 	nicksvs.host = nicksvs.me->host;
 	nicksvs.real = nicksvs.me->real;
+
+	notice_front = NULL;
+	if (nicksvs.noticefront != NULL)
+	{
+		struct service *svs = service_find(nicksvs.noticefront);
+
+		if (svs == NULL)
+			(void) slog(LG_ERROR, "%s: noticefront service \2%s\2 not found",
+			            MOWGLI_FUNC_NAME, nicksvs.noticefront);
+		else
+			notice_front = svs;
+	}
 
 	if (nicksvs.no_nick_ownership)
 		for (i = 0; nick_account_trans[i].nickstring != NULL; i++)
@@ -154,6 +184,7 @@ mod_init(struct module ATHEME_VATTR_UNUSED *const restrict m)
 	add_duration_conf_item("ENFORCE_EXPIRE", &nicksvs.me->conf_table, 0, &nicksvs.enforce_expiry, "d", 0);
 	add_duration_conf_item("ENFORCE_DELAY", &nicksvs.me->conf_table, 0, &nicksvs.enforce_delay, "s", 30);
 	add_dupstr_conf_item("ENFORCE_PREFIX", &nicksvs.me->conf_table, 0, &nicksvs.enforce_prefix, "Guest");
+	add_dupstr_conf_item("NOTICEFRONT", &nicksvs.me->conf_table, 0, &nicksvs.noticefront, NULL);
 	add_conf_item("EMAILEXEMPTS", &nicksvs.me->conf_table, c_ni_emailexempts);
 	add_uint_conf_item("MAXNICKS", &nicksvs.me->conf_table, 9, &nicksvs.maxnicks, 1, INT_MAX, 5);
 }
@@ -171,6 +202,8 @@ mod_deinit(const enum module_unload_intent ATHEME_VATTR_UNUSED intent)
 		nicksvs.me = NULL;
 	}
 	authservice_loaded--;
+
+	notice_front = NULL;
 
         hook_del_config_ready(nickserv_config_ready);
         hook_del_nick_check(nickserv_handle_nickchange);

--- a/modules/nickserv/main.c
+++ b/modules/nickserv/main.c
@@ -10,8 +10,6 @@
 
 #include <atheme.h>
 
-static struct service *notice_front;
-
 static struct {
 	const char *nickstring, *accountstring;
 } nick_account_trans[] = {
@@ -36,6 +34,7 @@ nickserv_handle_nickchange(struct user *u)
 {
 	struct mynick *mn;
 	struct hook_nick_enforce hdata;
+	struct service *const notice_front = (nicksvs.noticefront != NULL) ? service_find(nicksvs.noticefront) : NULL;
 
 	if (nicksvs.me == NULL || nicksvs.no_nick_ownership)
 		return;
@@ -117,17 +116,9 @@ nickserv_config_ready(void *unused)
 	nicksvs.host = nicksvs.me->host;
 	nicksvs.real = nicksvs.me->real;
 
-	notice_front = NULL;
-	if (nicksvs.noticefront != NULL)
-	{
-		struct service *svs = service_find(nicksvs.noticefront);
-
-		if (svs == NULL)
-			(void) slog(LG_ERROR, "%s: noticefront service \2%s\2 not found",
-			            MOWGLI_FUNC_NAME, nicksvs.noticefront);
-		else
-			notice_front = svs;
-	}
+	if (nicksvs.noticefront != NULL && service_find(nicksvs.noticefront) == NULL)
+		(void) slog(LG_ERROR, "%s: noticefront service \2%s\2 not found",
+		            MOWGLI_FUNC_NAME, nicksvs.noticefront);
 
 	if (nicksvs.no_nick_ownership)
 		for (i = 0; nick_account_trans[i].nickstring != NULL; i++)
@@ -202,8 +193,6 @@ mod_deinit(const enum module_unload_intent ATHEME_VATTR_UNUSED intent)
 		nicksvs.me = NULL;
 	}
 	authservice_loaded--;
-
-	notice_front = NULL;
 
         hook_del_config_ready(nickserv_config_ready);
         hook_del_nick_check(nickserv_handle_nickchange);


### PR DESCRIPTION
Adds a `NOTICEFRONT` setting to the `nickserv {}` block. When set, NickServ's on-connect notices are sent from the named service instead of NickServ itself:

- the registration welcome notice,
- the access-list identify reminder,
- the registered-nick notice.

The hints in those notices use the front service's namespace syntax, e.g. `/msg Serv NICK IDENTIFY <nick> <password>`.

The front service is resolved at send time via `service_find()`; a misconfigured value is logged once at config-read time. It falls back to NickServ itself if the value is unset or the service does not exist, and resolving per notice also tolerates the front module being unloaded or reloaded at runtime. It works independently of the `serv/main` module and is compatible with any pseudoclient.