### PR TITLE
Fix implicit function declaration on Perl 5.44

### DIFF
--- a/modules/scripting/perl/api/channel.xs
+++ b/modules/scripting/perl/api/channel.xs
@@ -1,5 +1,7 @@
 MODULE = Atheme			PACKAGE = Atheme::Channel
 
+#include "../../../chanserv/chanserv.h"
+
 Atheme_Channel
 find(SV * package, const char * name)
 CODE:


### PR DESCRIPTION
--------

See also https://bugs.gentoo.org/show_bug.cgi?id=980329

Without this commit, Atheme fails to compile with Perl enabled on Perl 5.44 (any remaining whitespace errors are my own):

```
./channel.xs: In function 'XS_Atheme__Channel_register':
./channel.xs:51:40: error: implicit declaration of function 'custom_founder_check' [-Wimplicit-function-declaration]
   51 |     if ( chanacs_add(mc, entity(user), custom_founder_check(), CURRTIME, entity(si->smu)) == NULL) {
      |                                        ^~~~~~~~~~~~~~~~~~~~
In file included from Atheme.c:3739:
../../../chanserv/chanserv.h: At top level:
../../../chanserv/chanserv.h:15:28: error: conflicting types for 'custom_founder_check'; have 'unsigned int(void)'
   15 | static inline unsigned int custom_founder_check(void)
      |                            ^~~~~~~~~~~~~~~~~~~~
./channel.xs:51:40: note: previous implicit declaration of 'custom_founder_check' with type 'int()'
   51 |     if ( chanacs_add(mc, entity(user), custom_founder_check(), CURRTIME, entity(si->smu)) == NULL) {
      |                                        ^~~~~~~~~~~~~~~~~~~~
make[4]: *** [../../../../buildsys.mk:331: Atheme.plugin.o] Error 1
```

Steps to reproduce:
```bash
$ # On system with Perl 5.44
$ ./autogen.sh
$ ./configure --with-perl
$ make
```